### PR TITLE
LogPoint windows mapping

### DIFF
--- a/tools/config/logpoint-windows-all.yml
+++ b/tools/config/logpoint-windows-all.yml
@@ -1,0 +1,20 @@
+logsources:
+  windows-security:
+    product: windows
+    service: security
+    conditions:
+      event_source: 'Microsoft-Windows-Security-Auditing'
+  windows-security:
+    product: windows
+    service: system
+    conditions:
+      event_source: 'Microsoft-Windows-Security-Auditing'
+fieldmappings:
+    EventID: event_id
+    FailureCode: result_code
+    GroupName: group_name
+    ServiceName: service
+    SubjectAccountName: target_user
+    TicketOptions: ticket_options
+    TicketEnctyption: ticket_encryption
+    Type: event_type


### PR DESCRIPTION
Depending on the event, LogPoint might normalise windows 'subject account name' as caller_user, target_user, user or member. How do I handle this in field mapping?