### PR TITLE
improved win_pass_the_hash.yml rule

### DIFF
--- a/rules/windows/builtin/win_pass_the_hash.yml
+++ b/rules/windows/builtin/win_pass_the_hash.yml
@@ -12,16 +12,16 @@ detection:
         - EventID: 4624
           LogonType: '3'
           LogonProcess: 'NtLmSsp'
-          KeyLength: '0'
           WorkstationName: '%Workstations%'
           ComputerName: '%Workstations%'
         - EventID: 4625
           LogonType: '3'
           LogonProcess: 'NtLmSsp'
-          KeyLength: '0'
           WorkstationName: '%Workstations%'
           ComputerName: '%Workstations%'
-    condition: selection
+    filter:
+        AccountName: 'ANONYMOUS LOGON'
+    condition: selection and not filter
 falsepositives:
     - Administrator activity
     - Penetration tests


### PR DESCRIPTION
— deleted useless KeyLength: '0'
— added filter condition to exclude AccountName='ANONYMOUS LOGON', because of false positives

[proof] http://serverfault.com/questions/338644/what-are-anonymous-logons-in-windows-event-log