### PR TITLE
Update sysmon_susp_regsvr32_anomalies to detect wscript child process

### DIFF
--- a/rules/windows/sysmon/sysmon_susp_regsvr32_anomalies.yml
+++ b/rules/windows/sysmon/sysmon_susp_regsvr32_anomalies.yml
@@ -24,7 +24,13 @@ detection:
         Commandline: 
             - '*/i:http* scrobj.dll'
             - '*/i:ftp* scrobj.dll'
-    condition: selection1 or selection2 or selection3
+    # Regsvr32.exe spawned wscript.exe process - indicator of COM scriptlet
+    # https://www.hybrid-analysis.com/sample/f34da6d84a9663928606894fbc494cd9bf2f03c98cf0c775462802558d3a50ef?environmentId=100
+    selection4:
+        EventID: 1
+        Image: '*\wscript.exe'
+        ParentImage: '*\regsvr32.exe'
+    condition: selection1 or selection2 or selection3 or selection4
 falsepositives:
     - Unknown
 level: high


### PR DESCRIPTION
Rule to detect COM scriptlet invocation when wscript.exe is spawned from regsvr32.exe. 
example: https://www.hybrid-analysis.com/sample/f34da6d84a9663928606894fbc494cd9bf2f03c98cf0c775462802558d3a50ef?environmentId=100
SCT script code:
var objShell = new ActiveXObject("WScript.shell");