### PR TITLE
SQL Injection error message patterns

### DIFF
--- a/rules/web/web_sqlinjection_errors
+++ b/rules/web/web_sqlinjection_errors
@@ -1,0 +1,22 @@
+title: Suspicious SQL Error Messages
+description: Detects SQL error messages that indicate probing for an injection attack
+author: Bjoern Kimminich
+reference: http://www.sqlinjection.net/errors
+logsource:
+    category: application
+    product: sql
+detection:
+    keywords:
+        # Oracle
+        - quoted string not properly terminated
+        # MySQL
+        - You have an error in your SQL syntax
+        # SQL Server
+        - Unclosed quotation mark
+        # SQLite
+        - near "*": syntax error
+        - SELECTs to the left and right of UNION do not have the same number of result columns
+    condition: keywords
+falsepositives:
+    - Application bugs
+level: high


### PR DESCRIPTION
Rule file that detects error messages from different DB providers that would occur during SQL Injection probing.

The rule file is not trying to be complete, it only contains some examples from http://www.sqlinjection.net/errors/ plus some I experienced occuring in SQLite databases. Maybe tag as `experimental` and explicitly ask for more pattern input from DB and SQLi experts?