### PR TITLE
Condition needs to be a `str` not a `list`

### DIFF
--- a/rules/network/net_susp_network_scan.yml
+++ b/rules/network/net_susp_network_scan.yml
@@ -7,9 +7,7 @@ detection:
     selection:
         action: denied
     timeframe: 24h
-    condition:
-        - selection | count(dst_port) by src_ip > 10
-        - selection | count(dst_ip) by src_ip > 10
+    condition: ( selection | count(dst_port) by src_ip > 10 ) or ( selection | count(dst_ip) by src_ip > 10 )
 fields:
     - src_ip
     - dst_ip


### PR DESCRIPTION
To be consistent with schema and all the other rules:
- `condition` should be a `str`
- if an `or` condition needs to be applied, use parentheses and literal `or` instead of a `list`

This is the only rule sample that has condition as a list ...