### PR TITLE
Add rule for Windows registry persistence mechanisms

### DIFF
--- a/rules/windows/other/win_reg_persistence.yaml
+++ b/rules/windows/other/win_reg_persistence.yaml
@@ -1,0 +1,25 @@
+---
+action: global
+title: Registry Persistence Mechanisms
+description: Detects persistence registry keys 
+references:
+    - https://oddvar.moe/2018/04/10/persistence-using-globalflags-in-image-file-execution-options-hidden-from-autoruns-exe/
+date: 2018/04/11
+author: @Karneades
+detection:
+    condition: 1 of them
+falsepositives:
+    - none
+level: critical
+---
+logsource:
+   product: windows
+   service: sysmon
+detection:
+    selection_reg1:
+        EventID: 13 
+        TargetObject: 
+            - 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\*\GlobalFlag'
+            - 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\SilentProcessExit\*\ReportingMode'
+            - 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\SilentProcessExit\*\MonitorProcess'
+        EventType: 'SetValue'

--- a/rules/windows/other/win_reg_persistence.yaml
+++ b/rules/windows/other/win_reg_persistence.yaml
@@ -1,17 +1,9 @@
----
-action: global
 title: Registry Persistence Mechanisms
 description: Detects persistence registry keys 
 references:
     - https://oddvar.moe/2018/04/10/persistence-using-globalflags-in-image-file-execution-options-hidden-from-autoruns-exe/
 date: 2018/04/11
 author: Karneades
-detection:
-    condition: 1 of them
-falsepositives:
-    - none
-level: critical
----
 logsource:
    product: windows
    service: sysmon
@@ -23,3 +15,7 @@ detection:
             - 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\SilentProcessExit\*\ReportingMode'
             - 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\SilentProcessExit\*\MonitorProcess'
         EventType: 'SetValue'
+    condition: 1 of them
+falsepositives:
+    - unknown
+level: critical

--- a/rules/windows/other/win_reg_persistence.yaml
+++ b/rules/windows/other/win_reg_persistence.yaml
@@ -5,7 +5,7 @@ description: Detects persistence registry keys
 references:
     - https://oddvar.moe/2018/04/10/persistence-using-globalflags-in-image-file-execution-options-hidden-from-autoruns-exe/
 date: 2018/04/11
-author: @Karneades
+author: Karneades
 detection:
     condition: 1 of them
 falsepositives:


### PR DESCRIPTION
Add new rule for special persistence mechanisms and add current registry keys from Oddvar Moe's (@api0cradle) blog post: "https://oddvar.moe/2018/04/10/persistence-using-globalflags-in-image-file-execution-options-hidden-from-autoruns-exe/".

