### PR TITLE
ATT&CK tagging of Suspicious Certutil Command rule

### DIFF
--- a/rules/windows/sysmon/sysmon_susp_certutil_command.yml
+++ b/rules/windows/sysmon/sysmon_susp_certutil_command.yml
@@ -25,6 +25,11 @@ detection:
 fields:
     - CommandLine
     - ParentCommandLine
+tags:
+    - attack.defense_evasion
+    - attack.t1140
+    - attack.s0189
+    - attack.g0007
 falsepositives:
     - False positives depend on scripts and administrative tools used in the monitored environment
 level: high


### PR DESCRIPTION
tags:
    - attack.defense_evasion
    - attack.t1140
    - attack.s0189
    - attack.g0007

sources:
https://attack.mitre.org/wiki/Technique/T1140
https://attack.mitre.org/wiki/Software/S0189
https://attack.mitre.org/wiki/Group/G0007