### PR TITLE
Add CMSTP UAC Bypass via COM Object Access

### DIFF
--- a/rules/windows/sysmon/sysmon_cmstp_com_object_access.yml
+++ b/rules/windows/sysmon/sysmon_cmstp_com_object_access.yml
@@ -3,7 +3,9 @@ status: stable
 description: Detects UAC Bypass Attempt Using Microsoft Connection Manager Profile Installer Autoelevate-capable COM Objects
 tags:
     - attack.defense_evasion
+    - attack.privilege_escalation
     - attack.execution
+    - attack.t1088
     - attack.t1191
     - attack.g0069
 author: Nik Seetharaman

--- a/rules/windows/sysmon/sysmon_cmstp_com_object_access.yml
+++ b/rules/windows/sysmon/sysmon_cmstp_com_object_access.yml
@@ -1,0 +1,35 @@
+title: CMSTP UAC Bypass via COM Object Access
+status: stable
+description: Detects UAC Bypass Attempt Using Microsoft Connection Manager Profile Installer Autoelevate-capable COM Objects
+tags:
+    - attack.defense_evasion
+    - attack.execution
+    - attack.t1191
+    - attack.g0069
+author: Nik Seetharaman
+references:
+    - http://www.endurant.io/cmstp/detecting-cmstp-enabled-code-execution-and-uac-bypass-with-sysmon/
+    - https://twitter.com/hFireF0X/status/897640081053364225
+logsource:
+    product: windows
+    service: sysmon
+detection:
+    # CMSTP Spawning Child Process
+    selection1:
+        EventID: 1
+        ParentCommandLine:
+            - '*\DllHost.exe'
+            - '*\{3E5FC7F9-9A51-4367-9063-A120244FBEC7}' #CMSTPLUA
+    selection2:
+        EventID: 1
+        ParentCommandLine:
+            - '*\DllHost.exe'
+            - '*\{3E000D72-A845-4CD9-BD83-80C07C3B881F}' #CMLUAUTIL, see https://twitter.com/hFireF0X/status/897640081053364225
+    condition: 1 of them
+fields:
+    - CommandLine
+    - ParentCommandLine
+    - Hashes
+falsepositives:
+    - Legitimate CMSTP use (unlikely in modern enterprise environments)
+level: high


### PR DESCRIPTION
Detections for UAC Bypass via CMSTP-associated COM Objects. See http://www.endurant.io/cmstp/detecting-cmstp-enabled-code-execution-and-uac-bypass-with-sysmon/ as well as https://twitter.com/hFireF0X/status/897640081053364225

Tested for robustness / false positive rate and status set to 'stable.'