### PR TITLE
Carbon Black Response and CrowdStrike Falcon - Initial Sigma push

### DIFF
--- a/rules/windows/CrowdStrike_Falcon/cs_bcedit_off.yml
+++ b/rules/windows/CrowdStrike_Falcon/cs_bcedit_off.yml
@@ -1,0 +1,21 @@
+title: bcdedit off
+status: experimental
+description: Detects usage of bcdedit off
+references:
+author: Michael Haag
+logsource:
+    product: crowdstrike:falconhost:json
+    service: cs
+detection:
+    selection:
+        FileName:
+            - 'bcdedit.exe'
+          CommandLine:
+            - '*off'
+    condition: selection
+fields:
+    - CommandLine
+    - FileName
+falsepositives:
+    - Some legitimate apps use this, but limited.
+level: medium

--- a/rules/windows/CrowdStrike_Falcon/cs_bitsadmin_download.yml
+++ b/rules/windows/CrowdStrike_Falcon/cs_bitsadmin_download.yml
@@ -1,0 +1,24 @@
+title: Bitsadmin Download
+status: experimental
+description: Detects usage of bitsadmin downloading a file
+references:
+    - https://blog.netspi.com/15-ways-to-download-a-file/#bitsadmin
+    - https://isc.sans.edu/diary/22264
+author: Michael Haag
+logsource:
+    product: crowdstrike:falconhost:json
+    service: cs
+detection:
+    selection:
+        FileName:
+            - 'bitsadmin.exe'
+        CommandLine:
+            - '*/transfer'
+            - '*/download'
+    condition: selection
+fields:
+    - CommandLine
+    - FileName
+falsepositives:
+    - Some legitimate apps use this, but limited.
+level: medium

--- a/rules/windows/CrowdStrike_Falcon/cs_bypass_squiblytwo.yml
+++ b/rules/windows/CrowdStrike_Falcon/cs_bypass_squiblytwo.yml
@@ -1,0 +1,22 @@
+title: SquiblyTwo
+status: experimental
+description: Detects WMI SquiblyTwo Attack with possible renamed WMI by looking for imphash
+references:
+    - https://subt0x11.blogspot.ch/2018/04/wmicexe-whitelisting-bypass-hacking.html
+    - https://twitter.com/mattifestation/status/986280382042595328
+author: Markus Neis / Florian Roth
+falsepositives:
+    - Unknown
+level: medium
+logsource:
+    product: crowdstrike:falconhost:json
+    service: cs
+detection:
+    selection:
+        FileName:
+            - 'wmic.exe'
+        CommandLine:
+            - 'wmic * *format:\"http*'
+            - "wmic * /format:'http"
+            - 'wmic * /format:http*'
+    condition: 1 of them

--- a/rules/windows/CrowdStrike_Falcon/cs_cmdkey_recon.yml
+++ b/rules/windows/CrowdStrike_Falcon/cs_cmdkey_recon.yml
@@ -1,0 +1,22 @@
+title: cmdkey Cached Credentials Recon
+status: experimental
+description: Detects usage of cmdkey to look for cached credentials.
+reference:
+    - https://www.peew.pw/blog/2017/11/26/exploring-cmdkey-an-edge-case-for-privilege-escalation
+    - https://technet.microsoft.com/en-us/library/cc754243(v=ws.11).aspx
+author: jmallette
+logsource:
+    product: crowdstrike:falconhost:json
+    service: cs
+detection:
+    selection:
+        FileName: 'cmdkey.exe'
+        CommandLine: '* /list *'
+    condition: selection
+fields:
+    - CommandLine
+    - FileName
+    - UserName
+falsepositives:
+    - Legitimate administrative tasks.
+level: low

--- a/rules/windows/CrowdStrike_Falcon/cs_mshta_javascript.yml
+++ b/rules/windows/CrowdStrike_Falcon/cs_mshta_javascript.yml
@@ -1,0 +1,21 @@
+title: Net IPC Share
+status: experimental
+description: Detects mshta with javascript in command line
+references:
+author: Michael Haag
+logsource:
+    product: crowdstrike:falconhost:json
+    service: cs
+detection:
+    selection:
+        FileName:
+            - 'mshta.exe'
+        CommandLine:
+            - '*javascript:*'
+    condition: selection
+fields:
+    - CommandLine
+    - FileName
+falsepositives:
+    - Some admins use it, mostly bad things.
+level: medium

--- a/rules/windows/CrowdStrike_Falcon/cs_net_ipc.yml
+++ b/rules/windows/CrowdStrike_Falcon/cs_net_ipc.yml
@@ -1,0 +1,21 @@
+title: Net IPC Share
+status: experimental
+description: Detects net usage accessing IPC$
+references:
+author: Michael Haag
+logsource:
+    product: crowdstrike:falconhost:json
+    service: cs
+detection:
+    selection:
+        FileName:
+            - 'net.exe'
+        CommandLine:
+            - '*ipc$*'
+    condition: selection
+fields:
+    - CommandLine
+    - FileName
+falsepositives:
+    - Some admins use it, mostly bad things.
+level: medium

--- a/rules/windows/CrowdStrike_Falcon/cs_powershell_download.yml
+++ b/rules/windows/CrowdStrike_Falcon/cs_powershell_download.yml
@@ -1,0 +1,23 @@
+title: Powershell Download
+status: experimental
+description: Detects usage of Powershell Download commands
+references:
+author: Michael Haag
+logsource:
+    product: crowdstrike:falconhost:json
+    service: cs
+detection:
+    selection:
+        FileName:
+            - 'powershell.exe'
+        CommandLine:
+            - '*DownloadFile*'
+            - '*invoke-webrequest*'
+            - '*iwr'
+    condition: selection
+fields:
+    - CommandLine
+    - FileName
+falsepositives:
+    - Some legitimate apps use this, but limited.
+level: medium

--- a/rules/windows/CrowdStrike_Falcon/cs_powershell_encoded.yml
+++ b/rules/windows/CrowdStrike_Falcon/cs_powershell_encoded.yml
@@ -1,0 +1,35 @@
+title: Powershell Encoded Command
+status: experimental
+description: Detects usage of Powershell Encoded Commands
+references:
+author: Michael Haag
+logsource:
+    product: crowdstrike:falconhost:json
+    service: cs
+detection:
+    selection:
+        FileName:
+            - 'powershell.exe'
+        CommandLine:
+            - 'base64'
+            - '-enc'
+            - '-enco'
+            - '-encod'
+            - '-encode'
+            - '-encoded'
+            - '-ec'
+            - '-en'
+            - '-encodedC'
+            - '-encodedCo'
+            - '-encodedCom'
+            - '-encodedComm'
+            - '-encodedComma'
+            - '-encodedComman'
+            - '-encodedCommand'
+    condition: selection
+fields:
+    - CommandLine
+    - FileName
+falsepositives:
+    - Some legitimate apps use this, but limited.
+level: medium

--- a/rules/windows/CrowdStrike_Falcon/cs_powersploit_schtasks.yml
+++ b/rules/windows/CrowdStrike_Falcon/cs_powersploit_schtasks.yml
@@ -1,0 +1,23 @@
+title: Default PowerSploit Schtasks Persistence
+status: experimental
+description: Detects the creation of a schtask via PowerSploit Default Configuration
+references:
+    - https://github.com/0xdeadbeefJERKY/PowerSploit/blob/8690399ef70d2cad10213575ac67e8fa90ddf7c3/Persistence/Persistence.psm1
+author: Markus Neis
+date: 2018/03/06
+logsource:
+    product: crowdstrike:falconhost:json
+    service: cs
+detection:
+    selection:
+        FileName:
+            - 'Powershell.exe'
+        CommandLine:
+            - '*\schtasks.exe*/Create*/RU*system*/SC*ONLOGON*'
+            - '*\schtasks.exe*/Create*/RU*system*/SC*DAILY*'
+            - '*\schtasks.exe*/Create*/RU*system*/SC*ONIDLE*'
+            - '*\schtasks.exe*/Create*/RU*system*/SC*HOURLY*'
+    condition: selection
+falsepositives:
+    - False positives are possible, depends on organisation and processes
+level: high

--- a/rules/windows/CrowdStrike_Falcon/cs_regsvr32_control_rundll.yml
+++ b/rules/windows/CrowdStrike_Falcon/cs_regsvr32_control_rundll.yml
@@ -1,0 +1,21 @@
+title: Detect Regsvr32 Control_RunDLL Usage
+status: experimental
+description: Detects regsvr32 with Control_RunDLL
+references:
+author: Michael Haag
+logsource:
+    product: crowdstrike:falconhost:json
+    service: cs
+detection:
+    selection:
+        FileName:
+            - 'regsvr32.exe'
+        CommandLine:
+            - '*,Control_RunDLL'
+    condition: selection
+fields:
+    - CommandLine
+    - FileName
+falsepositives:
+    - Some legitimate apps use this, but limited.
+level: medium

--- a/rules/windows/CrowdStrike_Falcon/cs_regsvr32_dllregisterserver.yml
+++ b/rules/windows/CrowdStrike_Falcon/cs_regsvr32_dllregisterserver.yml
@@ -1,0 +1,21 @@
+title: Detect Regsvr32 Control_RunDLL Usage
+status: experimental
+description: Detects usage of DllRegisterServer with regsvr32
+references:
+author: Michael Haag
+logsource:
+    product: crowdstrike:falconhost:json
+    service: cs
+detection:
+    selection:
+        FileName:
+            - 'regsvr32.exe'
+        CommandLine:
+            - '*DllRegisterServer'
+    condition: selection
+fields:
+    - CommandLine
+    - FileName
+falsepositives:
+    - Some legitimate apps use this, but limited.
+level: medium

--- a/rules/windows/CrowdStrike_Falcon/cs_rundll32_scrobj.yml
+++ b/rules/windows/CrowdStrike_Falcon/cs_rundll32_scrobj.yml
@@ -1,0 +1,22 @@
+title: Detect Squiblydoo
+status: experimental
+description: Detection of squiblydoo technique - scrobj.dll
+references:
+author: Michael Haag
+logsource:
+    product: crowdstrike:falconhost:json
+    service: cs
+detection:
+    selection:
+        FileName:
+            - 'rundll32.exe'
+        CommandLine:
+            - '*scrobj.dll'
+            - '*scrobj'
+    condition: selection
+fields:
+    - CommandLine
+    - FileName
+falsepositives:
+    - Some legitimate apps use this, but limited.
+level: medium

--- a/rules/windows/CrowdStrike_Falcon/cs_schtask_creation.yml
+++ b/rules/windows/CrowdStrike_Falcon/cs_schtask_creation.yml
@@ -1,0 +1,18 @@
+title: Schtask Creation
+status: experimental
+description: Detects usage of schtask
+references:
+author: Michael Haag
+logsource:
+    product: crowdstrike:falconhost:json
+    service: cs
+detection:
+    selection:
+        FileName:
+            - 'schtask.exe'
+    condition: selection
+fields:
+    - FileName
+falsepositives:
+    - Some legitimate apps use this, but limited.
+level: medium

--- a/rules/windows/CrowdStrike_Falcon/cs_schtask_user_profile.yml
+++ b/rules/windows/CrowdStrike_Falcon/cs_schtask_user_profile.yml
@@ -1,0 +1,21 @@
+title: Schtask from User Profile
+status: experimental
+description: Detects usage of Powershell Download commands
+references:
+author: Michael Haag
+logsource:
+    product: crowdstrike:falconhost:json
+    service: cs
+detection:
+    selection:
+        FileName:
+            - 'schtask.exe'
+        CommandLine:
+            - '*\appdata\*'
+    condition: selection
+fields:
+    - CommandLine
+    - FileName
+falsepositives:
+    - Should be limited in legitimate use
+level: medium

--- a/rules/windows/CrowdStrike_Falcon/cs_susp_recon_activity.yml
+++ b/rules/windows/CrowdStrike_Falcon/cs_susp_recon_activity.yml
@@ -1,0 +1,22 @@
+title: Suspicious Reconnaissance Activity
+status: experimental
+description: Detects suspicious command line activity on Windows systems
+author: Florian Roth
+logsource:
+    product: crowdstrike:falconhost:json
+    service: cs
+detection:
+    selection:
+        CommandLine:
+            - 'net group "domain admins" /domain'
+            - 'net localgroup administrators'
+    condition: selection
+fields:
+    - CommandLine
+falsepositives:
+    - Inventory tool runs
+    - Penetration tests
+    - Administrative activity
+analysis:
+    recommendation: Check if the user that executed the commands is suspicious (e.g. service accounts, LOCAL_SYSTEM)
+level: medium

--- a/rules/windows/CrowdStrike_Falcon/cs_susp_script_execution.yml
+++ b/rules/windows/CrowdStrike_Falcon/cs_susp_script_execution.yml
@@ -3,22 +3,22 @@ status: experimental
 description: Detects suspicious file execution by wscript and cscript
 author: Michael Haag
 logsource:
-    product: bit9:carbonblack:json
-    service: cbr
+    product: crowdstrike:falconhost:json
+    service: cs
 detection:
     selection:
-        process:
+        FileName:
             - 'wscript.exe'
             - 'cscript.exe'
-        command_line:
+        CommandLine:
             - '*.jse'
             - '*.vbe'
             - '*.js'
             - '*.vba'
     condition: selection
 fields:
-    - command_line
-    - process
+    - CommandLine
+    - FileName
 falsepositives:
     - Will need to be tuned. I recommend adding the user profile path in CommandLine if it is getting too noisy.
 level: medium

--- a/rules/windows/CrowdStrike_Falcon/cs_vssadmin_delete.yml
+++ b/rules/windows/CrowdStrike_Falcon/cs_vssadmin_delete.yml
@@ -1,0 +1,21 @@
+title: VSSadmin Delete
+status: experimental
+description: Detects vssadmin shadow copy delete method
+references:
+author: Michael Haag
+logsource:
+    product: crowdstrike:falconhost:json
+    service: cs
+detection:
+    selection:
+        FileName:
+            - 'vssadmin.exe'
+        CommandLine:
+            - 'vssadmin.exe Delete Shadows /All /Quiet'
+    condition: selection
+fields:
+    - CommandLine
+    - FileName
+falsepositives:
+    - Not many legitimate use cases, usually a ransomware sort.
+level: medium

--- a/rules/windows/CrowdStrike_Falcon/cs_watchdogproc.yml
+++ b/rules/windows/CrowdStrike_Falcon/cs_watchdogproc.yml
@@ -1,0 +1,18 @@
+title: WatchdogProc usage
+status: experimental
+description: Detects watchdogproc on the command line.
+references: https://www.endgame.com/blog/technical-blog/malware-personal-touch
+author: Michael Haag
+logsource:
+    product: crowdstrike:falconhost:json
+    service: cs
+detection:
+    selection:
+        CommandLine:
+            - 'watchdogproc*'
+    condition: selection
+fields:
+    - CommandLine
+falsepositives:
+    - Not very common, but occurs.
+level: medium

--- a/rules/windows/CrowdStrike_Falcon/cs_win_binary_github_com.yml
+++ b/rules/windows/CrowdStrike_Falcon/cs_win_binary_github_com.yml
@@ -1,0 +1,19 @@
+title: Microsoft Binary Github Communication
+status: experimental
+description: Detects an executable in the Windows folder accessing github.com
+references:
+    - https://twitter.com/M_haggis/status/900741347035889665
+author: Michael Haag (idea), Florian Roth (rule)
+logsource:
+    product: crowdstrike:falconhost:json
+    service: cs
+detection:
+    selection:
+        DomainName: '.githubusercontent.com'
+        DomainName: 'dl.dropboxusercontent.com'
+        ImageFileName: 'C:\Windows\*'
+    condition: selection
+falsepositives:
+    - 'Unknown'
+    - '@subTee in your network'
+level: high

--- a/rules/windows/carbonblack_response/cbr_bcedit_off.yml
+++ b/rules/windows/carbonblack_response/cbr_bcedit_off.yml
@@ -1,0 +1,21 @@
+title: bcdedit off
+status: experimental
+description: Detects usage of bcdedit off
+references:
+author: Michael Haag
+logsource:
+    product: bit9:carbonblack:json
+    service: cbr
+detection:
+    selection:
+        process:
+            - 'bcdedit.exe'
+        command_line:
+            - '*off'
+    condition: selection
+fields:
+    - command_line
+    - process
+falsepositives:
+    - Some legitimate apps use this, but limited.
+level: medium

--- a/rules/windows/carbonblack_response/cbr_bitsadmin_download.yml
+++ b/rules/windows/carbonblack_response/cbr_bitsadmin_download.yml
@@ -1,0 +1,24 @@
+title: Bitsadmin Download
+status: experimental
+description: Detects usage of bitsadmin downloading a file
+references:
+    - https://blog.netspi.com/15-ways-to-download-a-file/#bitsadmin
+    - https://isc.sans.edu/diary/22264
+author: Michael Haag
+logsource:
+    product: bit9:carbonblack:json
+    service: cbr
+detection:
+    selection:
+        process:
+            - 'bitsadmin.exe'
+        command_line:
+            - '*/transfer'
+            - '*/download'
+    condition: selection
+fields:
+    - command_line
+    - process
+falsepositives:
+    - Some legitimate apps use this, but limited.
+level: medium

--- a/rules/windows/carbonblack_response/cbr_bypass_squiblytwo.yml
+++ b/rules/windows/carbonblack_response/cbr_bypass_squiblytwo.yml
@@ -1,0 +1,22 @@
+title: SquiblyTwo
+status: experimental
+description: Detects WMI SquiblyTwo Attack with possible renamed WMI by looking for imphash
+references:
+    - https://subt0x11.blogspot.ch/2018/04/wmicexe-whitelisting-bypass-hacking.html
+    - https://twitter.com/mattifestation/status/986280382042595328
+author: Markus Neis / Florian Roth
+falsepositives:
+    - Unknown
+level: medium
+logsource:
+    product: bit9:carbonblack:json
+    service: cbr
+detection:
+    selection:
+        process:
+            - 'wmic.exe'
+        command_line:
+            - 'wmic * *format:\"http*'
+            - "wmic * /format:'http"
+            - 'wmic * /format:http*'
+    condition: 1 of them

--- a/rules/windows/carbonblack_response/cbr_cmdkey_recon.yml
+++ b/rules/windows/carbonblack_response/cbr_cmdkey_recon.yml
@@ -1,0 +1,22 @@
+title: cmdkey Cached Credentials Recon
+status: experimental
+description: Detects usage of cmdkey to look for cached credentials.
+reference:
+    - https://www.peew.pw/blog/2017/11/26/exploring-cmdkey-an-edge-case-for-privilege-escalation
+    - https://technet.microsoft.com/en-us/library/cc754243(v=ws.11).aspx
+author: jmallette
+logsource:
+    product: bit9:carbonblack:json
+    service: cbr
+detection:
+    selection:
+        process: 'cmdkey.exe'
+        command_line: '* /list *'
+    condition: selection
+fields:
+    - command_line
+    - process
+    - username
+falsepositives:
+    - Legitimate administrative tasks.
+level: low

--- a/rules/windows/carbonblack_response/cbr_lethalHTA.yml
+++ b/rules/windows/carbonblack_response/cbr_lethalHTA.yml
@@ -1,0 +1,18 @@
+title: MSHTA spwaned by SVCHOST as seen in LethalHTA
+status: experimental
+description: Detects MSHTA.EXE spwaned by SVCHOST described in report
+references:
+    - https://codewhitesec.blogspot.com/2018/07/lethalhta.html
+author: Markus Neis
+date: 2018/06/07
+logsource:
+    product: bit9:carbonblack:json
+    service: cbr
+detection:
+    selection:
+        parent_path: '*\svchost.exe'
+        process: 'mshta.exe'
+    condition: selection
+falsepositives:
+    - Unknown
+level: high

--- a/rules/windows/carbonblack_response/cbr_mshta_javascript.yml
+++ b/rules/windows/carbonblack_response/cbr_mshta_javascript.yml
@@ -1,0 +1,21 @@
+title: Net IPC Share
+status: experimental
+description: Detects mshta with javascript in command line
+references:
+author: Michael Haag
+logsource:
+    product: bit9:carbonblack:json
+    service: cbr
+detection:
+    selection:
+        process:
+            - 'mshta.exe'
+        command_line:
+            - '*javascript:*'
+    condition: selection
+fields:
+    - command_line
+    - process
+falsepositives:
+    - Some admins use it, mostly bad things.
+level: medium

--- a/rules/windows/carbonblack_response/cbr_mshta_spawn_shell.yml
+++ b/rules/windows/carbonblack_response/cbr_mshta_spawn_shell.yml
@@ -1,0 +1,33 @@
+title: MSHTA Spawning Windows Shell
+status: experimental
+description: Detects a Windows command line executable started from MSHTA.
+references:
+    - https://www.trustedsec.com/july-2015/malicious-htas/
+author: Michael Haag
+logsource:
+    product: bit9:carbonblack:json
+    service: cbr
+detection:
+    selection:
+        parent_path: '*\mshta.exe'
+        process:
+            - '*\cmd.exe'
+            - '*\powershell.exe'
+            - '*\wscript.exe'
+            - '*\cscript.exe'
+            - '*\sh.exe'
+            - '*\bash.exe'
+            - '*\reg.exe'
+            - '*\regsvr32.exe'
+            - '*\BITSADMIN*'
+    filter:
+        command_line:
+            - '*/HP/HP*'
+            - '*\HP\HP*'
+    condition: selection and not filter
+fields:
+    - parent_path
+    - process
+falsepositives:
+    - Printer software / driver installations
+level: high

--- a/rules/windows/carbonblack_response/cbr_net_ipc.yml
+++ b/rules/windows/carbonblack_response/cbr_net_ipc.yml
@@ -1,0 +1,21 @@
+title: Net IPC Share
+status: experimental
+description: Detects net usage accessing IPC$
+references:
+author: Michael Haag
+logsource:
+    product: bit9:carbonblack:json
+    service: cbr
+detection:
+    selection:
+        process:
+            - 'net.exe'
+        command_line:
+            - '*ipc$*'
+    condition: selection
+fields:
+    - command_line
+    - process
+falsepositives:
+    - Some admins use it, mostly bad things. 
+level: medium

--- a/rules/windows/carbonblack_response/cbr_office_shell.yml
+++ b/rules/windows/carbonblack_response/cbr_office_shell.yml
@@ -1,0 +1,42 @@
+title: Microsoft Office Product Spawning Windows Shell
+status: experimental
+description: Detects a Windows command line executable started from Microsoft Word, Excel, Powerpoint, Publisher and Visio.
+references:
+    - https://www.hybrid-analysis.com/sample/465aabe132ccb949e75b8ab9c5bda36d80cf2fd503d52b8bad54e295f28bbc21?environmentId=100
+    - https://mgreen27.github.io/posts/2018/04/02/DownloadCradle.html
+author: Michael Haag, Florian Roth
+date: 2018/04/06
+logsource:
+    product: bit9:carbonblack:json
+    service: cbr
+detection:
+    selection:
+        parent_path:
+            - '*\WINWORD.EXE'
+            - '*\EXCEL.EXE'
+            - '*\POWERPNT.exe'
+            - '*\MSPUB.exe'
+            - '*\VISIO.exe'
+            - '*\OUTLOOK.EXE'
+        process:
+            - 'cmd.exe'
+            - 'powershell.exe'
+            - 'wscript.exe'
+            - 'cscript.exe'
+            - 'sh.exe'
+            - 'bash.exe'
+            - 'scrcons.exe'
+            - 'schtasks.exe'  # see https://www.hybrid-analysis.com/sample/b409538c99f99b94a5035d9fa44a506b41be0feb23e89b7e4d272ba791aa6002?environmentId=100
+            - 'regsvr32.exe'  # see https://twitter.com/subTee/status/899283365647458305
+            - 'hh.exe'  # see https://www.hybrid-analysis.com/sample/6abc2b63f1865a847ff7f5a9d49bb944397b36f5503b9718d6f91f93d60f7cd7?environmentId=100
+            - 'wmic.exe'  # see https://mgreen27.github.io/posts/2018/04/02/DownloadCradle.html
+            - 'mshta.exe'  # see https://mgreen27.github.io/posts/2018/04/02/DownloadCradle.html
+            - 'rundll32.exe'  # see https://mgreen27.github.io/posts/2018/04/02/DownloadCradle.html
+            - 'msiexec.exe'  # see https://twitter.com/DissectMalware/status/984252467474026497
+    condition: selection
+fields:
+    - commandline
+    - parent_path
+falsepositives:
+    - unknown
+level: high

--- a/rules/windows/carbonblack_response/cbr_powershell_download.yml
+++ b/rules/windows/carbonblack_response/cbr_powershell_download.yml
@@ -1,0 +1,23 @@
+title: Powershell Download
+status: experimental
+description: Detects usage of Powershell Download commands
+references:
+author: Michael Haag
+logsource:
+    product: bit9:carbonblack:json
+    service: cbr
+detection:
+    selection:
+        process:
+            - 'powershell.exe'
+        command_line:
+            - '*DownloadFile*'
+            - '*invoke-webrequest*'
+            - '*iwr'
+    condition: selection
+fields:
+    - command_line
+    - process
+falsepositives:
+    - Some legitimate apps use this, but limited.
+level: medium

--- a/rules/windows/carbonblack_response/cbr_powershell_encoded.yml
+++ b/rules/windows/carbonblack_response/cbr_powershell_encoded.yml
@@ -1,0 +1,35 @@
+title: Powershell Encoded Command
+status: experimental
+description: Detects usage of Powershell Encoded Commands
+references:
+author: Michael Haag
+logsource:
+    product: bit9:carbonblack:json
+    service: cbr
+detection:
+    selection:
+        process:
+            - 'powershell.exe'
+        command_line:
+            - 'base64'
+            - '-enc'
+            - '-enco'
+            - '-encod'
+            - '-encode'
+            - '-encoded'
+            - '-ec'
+            - '-en'
+            - '-encodedC'
+            - '-encodedCo'
+            - '-encodedCom'
+            - '-encodedComm'
+            - '-encodedComma'
+            - '-encodedComman'
+            - '-encodedCommand'
+    condition: selection
+fields:
+    - command_line
+    - process
+falsepositives:
+    - Some legitimate apps use this, but limited.
+level: medium

--- a/rules/windows/carbonblack_response/cbr_powersploit_schtasks.yml
+++ b/rules/windows/carbonblack_response/cbr_powersploit_schtasks.yml
@@ -1,0 +1,23 @@
+title: Default PowerSploit Schtasks Persistence
+status: experimental
+description: Detects the creation of a schtask via PowerSploit Default Configuration
+references:
+    - https://github.com/0xdeadbeefJERKY/PowerSploit/blob/8690399ef70d2cad10213575ac67e8fa90ddf7c3/Persistence/Persistence.psm1
+author: Markus Neis
+date: 2018/03/06
+logsource:
+    product: bit9:carbonblack:json
+    service: cbr
+detection:
+    selection:
+        process:
+            - 'Powershell.exe'
+        command_line:
+            - '*\schtasks.exe*/Create*/RU*system*/SC*ONLOGON*'
+            - '*\schtasks.exe*/Create*/RU*system*/SC*DAILY*'
+            - '*\schtasks.exe*/Create*/RU*system*/SC*ONIDLE*'
+            - '*\schtasks.exe*/Create*/RU*system*/SC*HOURLY*'
+    condition: selection
+falsepositives:
+    - False positives are possible, depends on organisation and processes
+level: high

--- a/rules/windows/carbonblack_response/cbr_regsvr32_control_rundll.yml
+++ b/rules/windows/carbonblack_response/cbr_regsvr32_control_rundll.yml
@@ -1,0 +1,21 @@
+title: Detect Regsvr32 Control_RunDLL Usage
+status: experimental
+description: Detects regsvr32 with Control_RunDLL
+references:
+author: Michael Haag
+logsource:
+    product: bit9:carbonblack:json
+    service: cbr
+detection:
+    selection:
+        process:
+            - 'regsvr32.exe'
+        command_line:
+            - '*,Control_RunDLL'
+    condition: selection
+fields:
+    - command_line
+    - process
+falsepositives:
+    - Some legitimate apps use this, but limited.
+level: medium

--- a/rules/windows/carbonblack_response/cbr_regsvr32_dllregisterserver.yml
+++ b/rules/windows/carbonblack_response/cbr_regsvr32_dllregisterserver.yml
@@ -1,0 +1,21 @@
+title: Detect Regsvr32 Control_RunDLL Usage
+status: experimental
+description: Detects usage of DllRegisterServer with regsvr32
+references:
+author: Michael Haag
+logsource:
+    product: bit9:carbonblack:json
+    service: cbr
+detection:
+    selection:
+        process:
+            - 'regsvr32.exe'
+        command_line:
+            - '*DllRegisterServer'
+    condition: selection
+fields:
+    - command_line
+    - process
+falsepositives:
+    - Some legitimate apps use this, but limited.
+level: medium

--- a/rules/windows/carbonblack_response/cbr_rundll32_scrobj.yml
+++ b/rules/windows/carbonblack_response/cbr_rundll32_scrobj.yml
@@ -1,0 +1,22 @@
+title: Detect Squiblydoo
+status: experimental
+description: Detection of squiblydoo technique - scrobj.dll
+references:
+author: Michael Haag
+logsource:
+    product: bit9:carbonblack:json
+    service: cbr
+detection:
+    selection:
+        process:
+            - 'rundll32.exe'
+        command_line:
+            - '*scrobj.dll'
+            - '*scrobj'
+    condition: selection
+fields:
+    - command_line
+    - process
+falsepositives:
+    - Some legitimate apps use this, but limited.
+level: medium

--- a/rules/windows/carbonblack_response/cbr_schtask_creation.yml
+++ b/rules/windows/carbonblack_response/cbr_schtask_creation.yml
@@ -1,0 +1,18 @@
+title: Schtask Creation
+status: experimental
+description: Detects usage of schtask usage
+references:
+author: Michael Haag
+logsource:
+    product: bit9:carbonblack:json
+    service: cbr
+detection:
+    selection:
+        process:
+            - 'schtask.exe'
+    condition: selection
+fields:
+    - process
+falsepositives:
+    - Some legitimate apps use this, but limited.
+level: medium

--- a/rules/windows/carbonblack_response/cbr_schtask_user_profile.yml
+++ b/rules/windows/carbonblack_response/cbr_schtask_user_profile.yml
@@ -1,0 +1,21 @@
+title: Schtask from User Profile
+status: experimental
+description: Detects usage of Powershell Download commands
+references:
+author: Michael Haag
+logsource:
+    product: bit9:carbonblack:json
+    service: cbr
+detection:
+    selection:
+        process:
+            - 'schtask.exe'
+        command_line:
+            - '*\appdata\*'
+    condition: selection
+fields:
+    - command_line
+    - process
+falsepositives:
+    - Should be limited in legitimate use
+level: medium

--- a/rules/windows/carbonblack_response/cbr_susp_recon_activity.yml
+++ b/rules/windows/carbonblack_response/cbr_susp_recon_activity.yml
@@ -1,0 +1,22 @@
+title: Suspicious Reconnaissance Activity
+status: experimental
+description: Detects suspicious command line activity on Windows systems
+author: Florian Roth
+logsource:
+    product: bit9:carbonblack:json
+    service: cbr
+detection:
+    selection:
+        command_line:
+            - 'net group "domain admins" /domain'
+            - 'net localgroup administrators'
+    condition: selection
+fields:
+    - command_line
+falsepositives:
+    - Inventory tool runs
+    - Penetration tests
+    - Administrative activity
+analysis:
+    recommendation: Check if the user that executed the commands is suspicious (e.g. service accounts, LOCAL_SYSTEM)
+level: medium

--- a/rules/windows/carbonblack_response/cbr_susp_script_execution.yml
+++ b/rules/windows/carbonblack_response/cbr_susp_script_execution.yml
@@ -1,0 +1,25 @@
+title: WSF/JSE/JS/VBA/VBE File Execution
+status: experimental
+description: Detects suspicious file execution by wscript and cscript
+author: Michael Haag
+logsource:
+    product: bit9:carbonblack:json
+    service: cbr
+detection:
+    selection:
+        EventID: 1
+        process:
+            - 'wscript.exe'
+            - 'cscript.exe'
+        command_line:
+            - '*.jse'
+            - '*.vbe'
+            - '*.js'
+            - '*.vba'
+    condition: selection
+fields:
+    - command_line
+    - process
+falsepositives:
+    - Will need to be tuned. I recommend adding the user profile path in CommandLine if it is getting too noisy.
+level: medium

--- a/rules/windows/carbonblack_response/cbr_susp_svchost.yml
+++ b/rules/windows/carbonblack_response/cbr_susp_svchost.yml
@@ -1,0 +1,22 @@
+title: Suspicious Svchost Process
+status: experimental
+description: Detects a suspicious svchost process start
+author: Florian Roth
+date: 2017/08/15
+logsource:
+    product: bit9:carbonblack:json
+    service: cbr
+detection:
+    selection:
+        process: 'svchost.exe'
+    filter:
+        parent_path:
+            - '*\services.exe'
+            - '*\MsMpEng.exe'
+    condition: selection and not filter
+fields:
+    - command_line
+    - parent_path
+falsepositives:
+    - Unknown
+level: high

--- a/rules/windows/carbonblack_response/cbr_vssadmin_delete.yml
+++ b/rules/windows/carbonblack_response/cbr_vssadmin_delete.yml
@@ -1,0 +1,21 @@
+title: VSSadmin Delete
+status: experimental
+description: Detects vssadmin shadow copy delete method
+references:
+author: Michael Haag
+logsource:
+    product: bit9:carbonblack:json
+    service: cbr
+detection:
+    selection:
+        process:
+            - 'vssadmin.exe'
+        command_line:
+            - 'vssadmin.exe Delete Shadows /All /Quiet'
+    condition: selection
+fields:
+    - command_line
+    - process
+falsepositives:
+    - Not many legitimate use cases, usually a ransomware sort.
+level: medium

--- a/rules/windows/carbonblack_response/cbr_watchdogproc.yml
+++ b/rules/windows/carbonblack_response/cbr_watchdogproc.yml
@@ -1,0 +1,18 @@
+title: WatchdogProc usage
+status: experimental
+description: Detects watchdogproc on the command line.
+references: https://www.endgame.com/blog/technical-blog/malware-personal-touch
+author: Michael Haag
+logsource:
+    product: bit9:carbonblack:json
+    service: cbr
+detection:
+    selection:
+        command_line:
+            - 'watchdogproc*'
+    condition: selection
+fields:
+    - command_line
+falsepositives:
+    - Not very common, but occurs.
+level: medium

--- a/rules/windows/carbonblack_response/cbr_webshell_spawn.yml
+++ b/rules/windows/carbonblack_response/cbr_webshell_spawn.yml
@@ -1,0 +1,26 @@
+title: Shells Spawned by Web Servers
+status: experimental
+description: Web servers that spawn shell processes could be the result of a successfully placed web shell or an other attack
+author: Thomas Patzke
+logsource:
+    product: bit9:carbonblack:json
+    service: cbr
+detection:
+    selection:
+        parent_path:
+            - '*\w3wp.exe'
+            - '*\httpd.exe'
+            - '*\nginx.exe'
+            - '*\php-cgi.exe'
+        process:
+            - 'cmd.exe'
+            - 'sh.exe'
+            - 'bash.exe'
+            - 'powershell.exe'
+    condition: selection
+fields:
+    - command_line
+    - parent_path
+falsepositives:
+    - Particular web applications may spawn a shell process legitimately
+level: high

--- a/rules/windows/carbonblack_response/cbr_win_binary_github_com.yml
+++ b/rules/windows/carbonblack_response/cbr_win_binary_github_com.yml
@@ -1,0 +1,19 @@
+title: Microsoft Binary Github Communication
+status: experimental
+description: Detects an executable in the Windows folder accessing github.com
+references:
+    - https://twitter.com/M_haggis/status/900741347035889665
+author: Michael Haag (idea), Florian Roth (rule)
+logsource:
+    product: bit9:carbonblack:json
+    service: cbr
+detection:
+    selection:
+        domain: '.githubusercontent.com'
+        domain: 'dl.dropboxusercontent.com'
+        process_path: 'C:\Windows\*'
+    condition: selection
+falsepositives:
+    - 'Unknown'
+    - '@subTee in your network'
+level: high


### PR DESCRIPTION
Within this PR is some generic Sigma rules for both CrowdStrike Falcon and Carbon Black Response.
I find this very helpful for organizations with one of these products to be able to easily convert and begin running the Sigma rules against the data quickly in a log aggregation solution.

I'd like to see if there is a lot of interest, but more than happy to convert and add more for both platforms.