### PR TITLE
Hiding files with attrib.exe sysmon rule

### DIFF
--- a/rules/windows/sysmon/sysmon_attrib_hiding_files.yml
+++ b/rules/windows/sysmon/sysmon_attrib_hiding_files.yml
@@ -10,9 +10,13 @@ detection:
         EventID: 1
         Image: '*\attrib.exe'
         CommandLine: '* +h *'
-    filter:
+    ini:
         CommandLine: '*\desktop.ini *'
-    condition: selection and not filter
+    intel:
+        ParentImage: '*\cmd.exe'
+        CommandLine: '+R +H +S +A *.cui'
+        ParentCommandLine: 'C:\WINDOWS\system32\*.bat'
+    condition: selection and not (ini or intel)
 fields:
     - CommandLine
     - ParentCommandLine

--- a/rules/windows/sysmon/sysmon_attrib_hiding_files.yml
+++ b/rules/windows/sysmon/sysmon_attrib_hiding_files.yml
@@ -17,6 +17,10 @@ fields:
     - CommandLine
     - ParentCommandLine
     - User
+tags:
+    - attack.defense_evasion
+    - attack.persistence
+    - attack.t1158
 falsepositives:
     - igfxCUIService.exe hiding *.cui files via .bat script (attrib.exe a child of cmd.exe and igfxCUIService.exe is the parent of the cmd.exe)
     - msiexec.exe hiding desktop.ini

--- a/rules/windows/sysmon/sysmon_attrib_hiding_files.yml
+++ b/rules/windows/sysmon/sysmon_attrib_hiding_files.yml
@@ -10,7 +10,9 @@ detection:
         EventID: 1
         Image: '*\attrib.exe'
         CommandLine: '* +h *'
-    condition: selection
+    filter:
+        CommandLine: '*\desktop.ini *'
+    condition: selection and not filter
 fields:
     - CommandLine
     - ParentCommandLine

--- a/rules/windows/sysmon/sysmon_attrib_hiding_files.yml
+++ b/rules/windows/sysmon/sysmon_attrib_hiding_files.yml
@@ -1,0 +1,21 @@
+title: Hiding files with attrib.exe
+status: experimental
+description: Detects usage of attrib.exe to hide files from users.
+author: Sami Ruohonen
+logsource:
+    product: windows
+    service: sysmon
+detection:
+    selection:
+        EventID: 1
+        Image: '*\attrib.exe'
+        CommandLine: '* +h *'
+    condition: selection
+fields:
+    - CommandLine
+    - ParentCommandLine
+    - User
+falsepositives:
+    - igfxCUIService.exe hiding *.cui files via .bat script (attrib.exe a child of cmd.exe and igfxCUIService.exe is the parent of the cmd.exe)
+    - msiexec.exe hiding desktop.ini
+level: low


### PR DESCRIPTION
In the Intel exclusion: CommandLine: '+R +H +S +A *.cui'
the asterisk is a literal asterisk in the commandline argument, not sure how to escape this?