### PR TITLE
Add rule filename to "not implemented" exception output

### DIFF
--- a/tools/sigmac
+++ b/tools/sigmac
@@ -177,7 +177,7 @@ for sigmafile in get_inputs(cmdargs.inputs, cmdargs.recurse):
             if not cmdargs.defer_abort:
                 sys.exit(error)
     except NotImplementedError as e:
-        print("An unsupported feature is required for this Sigma rule: " + str(e), file=sys.stderr)
+        print("An unsupported feature is required for this Sigma rule (%s): " % (sigmafile) + str(e), file=sys.stderr)
         print("Feel free to contribute for fun and fame, this is open source :) -> https://github.com/Neo23x0/sigma", file=sys.stderr)
         if not cmdargs.ignore_backend_errors:
             error = 42


### PR DESCRIPTION
It's useful to have the sigma rule name which raised the execption.

When using sigmac with the recursive option for a directory and searching for the "not implemented" error, it's hard to find which rule raised the exception.