### PR TITLE
Add group by to windows multiple suspicious cli rule

### DIFF
--- a/rules/windows/builtin/win_multiple_suspicious_cli.yml
+++ b/rules/windows/builtin/win_multiple_suspicious_cli.yml
@@ -48,7 +48,7 @@ detection:
             - icacls.exe
             - diskpart.exe
     timeframe: 5min
-    condition: selection | count() > 5
+    condition: selection | count() by MachineName > 5
 falsepositives:
     - False positives depend on scripts and administrative tools used in the monitored environment
 level: low


### PR DESCRIPTION
I thinkg the group by is missing for this rule. For the detection it's important that these cli tools are started on the same machine for alerting.