### PR TITLE
Fix CommandLine in rule sysmon_susp_certutil_command

### DIFF
--- a/rules/windows/sysmon/sysmon_susp_certutil_command.yml
+++ b/rules/windows/sysmon/sysmon_susp_certutil_command.yml
@@ -15,12 +15,12 @@ detection:
     selection:
         EventID: 1
         CommandLine: 
-            - '*\certutil.exe * -decode *'
-            - '*\certutil.exe * -decodehex *'
-            - '*\certutil.exe *-urlcache* http*'
-            - '*\certutil.exe *-urlcache* ftp*'
-            - '*\certutil.exe *-URL*'
-            - '*\certutil.exe *-ping*'
+            - '*certutil * -decode *'
+            - '*certutil * -decodehex *'
+            - '*certutil *-urlcache* http*'
+            - '*certutil *-urlcache* ftp*'
+            - '*certutil *-URL*'
+            - '*certutil *-ping*'
     condition: selection
 fields:
     - CommandLine

--- a/rules/windows/sysmon/sysmon_susp_certutil_command.yml
+++ b/rules/windows/sysmon/sysmon_susp_certutil_command.yml
@@ -21,6 +21,12 @@ detection:
             - '*certutil *-urlcache* ftp*'
             - '*certutil *-URL*'
             - '*certutil *-ping*'
+            - '*certutil.exe * -decode *'
+            - '*certutil.exe * -decodehex *'
+            - '*certutil.exe *-urlcache* http*'
+            - '*certutil.exe *-urlcache* ftp*'
+            - '*certutil.exe *-URL*'
+            - '*certutil.exe *-ping*'
     condition: selection
 fields:
     - CommandLine


### PR DESCRIPTION
Below is an example of a test - the command line does not
include the path nor the .exe. I think this comes from the
initial detection on the Image path and the later switch to
command line.

We could also use both the Image path and the Command Line...

Message: 
Process Create:
Image: C:\Windows\SysWOW64\certutil.exe
CommandLine: certutil  xx -decode xxx
Hashes: SHA1=8186D64DD28CD63CA883B1D3CE5F07AEABAD67C0
ParentImage: C:\Windows\System32\cmd.exe
ParentCommandLine: "C:\Windows\system32\cmd.exe"