### PR TITLE
Missing Character

### DIFF
--- a/rules/windows/powershell/powershell_malicious_keywords.yml
+++ b/rules/windows/powershell/powershell_malicious_keywords.yml
@@ -5,7 +5,7 @@ references:
     - https://adsecurity.org/?p=2921
 tags:
     - attack.execution
-    - attack.1086
+    - attack.T1086
 author: Sean Metcalf (source), Florian Roth (rule)
 logsource:
     product: windows

--- a/rules/windows/powershell/powershell_malicious_keywords.yml
+++ b/rules/windows/powershell/powershell_malicious_keywords.yml
@@ -5,7 +5,7 @@ references:
     - https://adsecurity.org/?p=2921
 tags:
     - attack.execution
-    - attack.T1086
+    - attack.t1086
 author: Sean Metcalf (source), Florian Roth (rule)
 logsource:
     product: windows


### PR DESCRIPTION
Parsed the MITRE ATT&CK informations from the rules. My script crashed because the identifier "T" was missing.
Thanks for your work Flo & Tom!