### PR TITLE
Improve default field handling in PowerShell backend

### DIFF
--- a/tools/sigma/backends/powershell.py
+++ b/tools/sigma/backends/powershell.py
@@ -111,9 +111,13 @@ class PowerShellBackend(SingleTextQueryBackend):
     def generateMapItemNode(self, node):
         key, value = node
         if self.mapListsSpecialHandling == False and type(value) in (str, int, list) or self.mapListsSpecialHandling == True and type(value) in (str, int):
-            if key in ("LogName"):
+            if key in ("LogName","source"):
+                if key == "source":
+                    key = "LogName"
                 return self.mapExpression % (key, self.generateValueNode(value, True))
-            elif key in ("ID"):
+            elif key in ("ID", "EventID"):
+                if key == "EventID":
+                    key = "ID"
                 return self.mapExpression % (key, self.generateValueNode(value, True))
             elif type(value) == str and "*" in value:
                 value = value.replace("*", ".*")


### PR DESCRIPTION
Improve handling for default naming of event id's ("EventID") and source. This makes the config file for at least the event id optional. Due to the nature of event logs, without this change the powershell config file was mandatory for the event id, otherwiese the ID was matched against the wrong field. See https://github.com/Neo23x0/sigma/issues/94#issuecomment-424077049. For `Get-WinEvent` the parameter is always `-LogName` for the log source and `ID` for the event id.
