### PR TITLE
Optimize the boolean expressions in the AST before generating output

### DIFF
--- a/tools/sigma/backends/base.py
+++ b/tools/sigma/backends/base.py
@@ -139,6 +139,9 @@ class BaseBackend:
             # Remove empty OR(X), AND(X)
             if len(node.items) == 0:
                 return None, True
+            if None in node.items:
+                node.items = [item for item in node.items if item != None]
+                return self.optimizeNode(node, changes=True)
 
             # OR(X), AND(X)                 =>  X
             if len(node.items) == 1:

--- a/tools/sigma/backends/base.py
+++ b/tools/sigma/backends/base.py
@@ -80,8 +80,161 @@ class BaseBackend:
 
             return result
 
+    def dumpNode(self, node, indent=''):
+        """
+        Recursively print the AST rooted at *node* for debugging.
+        """
+        import sys
+        if hasattr(node, 'items'):
+            print("%s%s<%s>" % (indent, type(node).__name__,
+                                type(node.items).__name__), file=sys.stderr)
+            if type(node.items) != list:
+                self.dumpNode(node.items, indent + '  ')
+            else:
+                for item in node.items:
+                    self.dumpNode(item, indent + '  ')
+        else:
+            print("%s%s=%s" % (indent, type(node).__name__,
+                                       repr(node)), file=sys.stderr)
+        return node
+
+    def stripSubexpressionNode(self, node):
+        """
+        Recursively strips all subexpressions (i.e. brackets) from the AST.
+        """
+        if type(node) == sigma.parser.condition.NodeSubexpression:
+            assert(type(node.items) != list)
+            return self.stripSubexpressionNode(node.items)
+        if hasattr(node, 'items'):
+            node.items = list(map(self.stripSubexpressionNode, node.items))
+        return node
+
+    def unstripSubexpressionNode(self, node):
+        """
+        Recursively adds brackets around AND and OR operations in the AST.
+        """
+        if type(node) in (sigma.parser.condition.ConditionAND,
+                          sigma.parser.condition.ConditionOR,
+                          sigma.parser.condition.ConditionNOT):
+            newnode = sigma.parser.condition.NodeSubexpression(node)
+            node.items = list(map(self.unstripSubexpressionNode, node.items))
+            return newnode
+        return node
+
+    def optimizeNode(self, node, changes=False):
+        """
+        Recursively optimize the AST rooted at *node* once.  Returns the new
+        root node and a boolean indicating if the tree was changed in this
+        invocation or any of the sub-invocations.
+
+        You MUST remove all subexpression nodes from the AST before calling
+        this function.  Subexpressions are implicit around AND/OR/NOT nodes.
+        """
+        def fast_ordered_uniq(l):
+            seen = set()
+            return [x for x in node.items if x not in seen and not seen.add(x)]
+
+        if type(node) in (sigma.parser.condition.ConditionOR,
+                          sigma.parser.condition.ConditionAND):
+            # Remove empty OR(X), AND(X)
+            if len(node.items) == 0:
+                return None, True
+
+            # OR(X), AND(X)                 =>  X
+            if len(node.items) == 1:
+                return self.optimizeNode(node.items[0], changes=True)
+
+            # OR(X, X, ...), AND(X, X, ...) =>  OR(X, ...), AND(X, ...)
+            uniq_items = fast_ordered_uniq(node.items)
+            if len(uniq_items) < len(node.items):
+                node.items = uniq_items
+                return self.optimizeNode(node, changes=True)
+
+            # OR(X, OR(Y))                  =>  OR(X, Y)
+            if any(type(child) == type(node) for child in node.items) and \
+               all(type(child) in (type(node), tuple) for child in node.items):
+                newitems = []
+                for child in node.items:
+                    if hasattr(child, 'items'):
+                        newitems.extend(child.items)
+                    else:
+                        newitems.append(child)
+                node.items = newitems
+                return self.optimizeNode(node, changes=True)
+
+            # OR(AND(X, ...), AND(X, ...))  =>  AND(X, OR(AND(...), AND(...)))
+            if type(node) == sigma.parser.condition.ConditionOR:
+                othertype = sigma.parser.condition.ConditionAND
+            else:
+                othertype = sigma.parser.condition.ConditionOR
+            if all(type(child) == othertype for child in node.items):
+                promoted = []
+                for cand in node.items[0]:
+                    if all(cand in child for child in node.items[1:]):
+                        promoted.append(cand)
+                if len(promoted) > 0:
+                    for child in node.items:
+                        for cand in promoted:
+                            child.items.remove(cand)
+                    newnode = othertype()
+                    newnode.items = promoted
+                    newnode.add(node)
+                    return self.optimizeNode(newnode, changes=True)
+            # fallthrough
+        elif type(node) == sigma.parser.condition.ConditionNOT:
+            # NOT(NOT(X))                   =>  X
+            assert(len(node.items) == 1)
+            if type(node.items[0]) == sigma.parser.condition.ConditionNOT:
+                assert(len(node.items[0].items) == 1)
+                return self.optimizeNode(node.items[0].items[0], changes=True)
+            # fallthrough
+        else:
+            return node, changes
+
+        itemresults = [self.optimizeNode(item, changes) for item in node.items]
+        node.items = [res[0] for res in itemresults]
+        if any(res[1] for res in itemresults):
+            changes = True
+        return node, changes
+
+    def optimizeTree(self, tree):
+        """
+        Optimize the boolean expressions in the AST rooted at *node*.
+
+        The main idea behind optimizing the AST is that less repeated terms is
+        generally better for backend performance.  This is especially relevant
+        to backends that do not perform any query language optimization down
+        the road, such as those that generate code.
+
+        The following optimizations are currently performed:
+        -   Removal of empty OR(), AND()
+        -   OR(X), AND(X)                 =>  X
+        -   OR(X, X, ...), AND(X, X, ...) =>  OR(X, ...), AND(X, ...)
+        -   OR(X, OR(Y))                  =>  OR(X, Y)
+        -   OR(AND(X, ...), AND(X, ...))  =>  AND(X, OR(AND(...), AND(...)))
+        -   NOT(NOT(X))                   =>  X
+
+        A common example for when these suboptimal rules actually occur in
+        practice is when a rule has multiple alternative detections that are
+        OR'ed together in the condition, and all of the detections include a
+        common element, such as the same EventID.
+
+        This implementation is not optimized for performance and will perform
+        poorly on very large expressions.
+        """
+        #self.dumpNode(tree)
+        tree = self.stripSubexpressionNode(tree)
+        #self.dumpNode(tree)
+        changes = True
+        while changes:
+            tree, changes = self.optimizeNode(tree)
+        #self.dumpNode(tree)
+        tree = self.unstripSubexpressionNode(tree)
+        #self.dumpNode(tree)
+        return tree
+
     def generateQuery(self, parsed):
-        result = self.generateNode(parsed.parsedSearch)
+        result = self.generateNode(self.optimizeTree(parsed.parsedSearch))
         if parsed.parsedAgg:
             result += self.generateAggregation(parsed.parsedAgg)
         return result


### PR DESCRIPTION
Add code optimizing the boolean expressions in the abstract syntax tree before generating output using the backend.

The main idea behind optimizing the AST is that less repeated terms is generally better for backend performance.  This is especially relevant to backends that do not perform any query language optimization down the road, such as those that generate code.

The following optimizations are currently performed:

-   Removal of empty OR(), AND()
-   OR(X), AND(X)                 =>  X
-   OR(X, X, ...), AND(X, X, ...) =>  OR(X, ...), AND(X, ...)
-   OR(X, OR(Y))                  =>  OR(X, Y)
-   OR(AND(X, ...), AND(X, ...))  =>  AND(X, OR(AND(...), AND(...)))
-   NOT(NOT(X))                   =>  X
-   NOT(ConditionNULLValue)       => ConditionNotNULLValue
-   NOT(ConditionNotNULLValue)    => ConditionNULLValue

A common example for when these suboptimal rules actually occur in practice is when a rule has multiple alternative detections that are OR'ed together in the condition, and all of the detections include a common element, such as the same EventID.

This implementation is not optimized for performance and will perform poorly on very large expressions.

Fully implements: #100, and more.