### PR TITLE
Distinct count in aggragation function

### DIFF
--- a/tools/sigma/backends/splunk.py
+++ b/tools/sigma/backends/splunk.py
@@ -75,6 +75,7 @@ class SplunkBackend(SingleTextQueryBackend):
             fields = " | table " + fields
 
         except KeyError:    # no 'fields' attribute
+            mapped = None
             pass
 
         for parsed in sigmaparser.condparsed:

--- a/tools/sigma/backends/splunk.py
+++ b/tools/sigma/backends/splunk.py
@@ -57,6 +57,44 @@ class SplunkBackend(SingleTextQueryBackend):
                 agg.aggfunc_notrans = 'dc'
             return " | stats %s(%s) as val by %s | search val %s %s" % (agg.aggfunc_notrans, agg.aggfield or "", agg.groupfield or "", agg.cond_op, agg.condition)
 
+        
+    def generate(self, sigmaparser):
+    """Method is called for each sigma rule and receives the parsed rule (SigmaParser)"""
+
+    columns = list()
+    try:
+        for field in sigmaparser.parsedyaml["fields"]:
+            mapped = sigmaparser.config.get_fieldmapping(field).resolve_fieldname(field)
+            if type(mapped) == str:
+                columns.append(mapped)
+            elif type(mapped) == list:
+                columns.extend(mapped)
+            else:
+                raise TypeError("Field mapping must return string or list")
+
+        fields = ",".join(str(x) for x in columns)
+        fields = " | table " + fields
+
+    except KeyError:    # no 'fields' attribute
+        pass
+
+    for parsed in sigmaparser.condparsed:
+        query = self.generateQuery(parsed)
+        before = self.generateBefore(parsed)
+        after = self.generateAfter(parsed)
+
+        result = ""
+        if before is not None:
+            result = before
+        if query is not None:
+            result += query
+        if after is not None:
+            result += after
+        if mapped is not None:
+            result += fields
+            
+        return result
+    
 class SplunkXMLBackend(SingleTextQueryBackend, MultiRuleOutputMixin):
     """Converts Sigma rule into XML used for Splunk Dashboard Panels"""
     identifier = "splunkxml"

--- a/tools/sigma/backends/splunk.py
+++ b/tools/sigma/backends/splunk.py
@@ -59,41 +59,40 @@ class SplunkBackend(SingleTextQueryBackend):
 
         
     def generate(self, sigmaparser):
-    """Method is called for each sigma rule and receives the parsed rule (SigmaParser)"""
+        """Method is called for each sigma rule and receives the parsed rule (SigmaParser)"""
+        columns = list()
+        try:
+            for field in sigmaparser.parsedyaml["fields"]:
+                mapped = sigmaparser.config.get_fieldmapping(field).resolve_fieldname(field)
+                if type(mapped) == str:
+                    columns.append(mapped)
+                elif type(mapped) == list:
+                    columns.extend(mapped)
+                else:
+                    raise TypeError("Field mapping must return string or list")
 
-    columns = list()
-    try:
-        for field in sigmaparser.parsedyaml["fields"]:
-            mapped = sigmaparser.config.get_fieldmapping(field).resolve_fieldname(field)
-            if type(mapped) == str:
-                columns.append(mapped)
-            elif type(mapped) == list:
-                columns.extend(mapped)
-            else:
-                raise TypeError("Field mapping must return string or list")
+            fields = ",".join(str(x) for x in columns)
+            fields = " | table " + fields
 
-        fields = ",".join(str(x) for x in columns)
-        fields = " | table " + fields
+        except KeyError:    # no 'fields' attribute
+            pass
 
-    except KeyError:    # no 'fields' attribute
-        pass
+        for parsed in sigmaparser.condparsed:
+            query = self.generateQuery(parsed)
+            before = self.generateBefore(parsed)
+            after = self.generateAfter(parsed)
 
-    for parsed in sigmaparser.condparsed:
-        query = self.generateQuery(parsed)
-        before = self.generateBefore(parsed)
-        after = self.generateAfter(parsed)
+            result = ""
+            if before is not None:
+                result = before
+            if query is not None:
+                result += query
+            if after is not None:
+                result += after
+            if mapped is not None:
+                result += fields
 
-        result = ""
-        if before is not None:
-            result = before
-        if query is not None:
-            result += query
-        if after is not None:
-            result += after
-        if mapped is not None:
-            result += fields
-            
-        return result
+            return result
     
 class SplunkXMLBackend(SingleTextQueryBackend, MultiRuleOutputMixin):
     """Converts Sigma rule into XML used for Splunk Dashboard Panels"""

--- a/tools/sigma/backends/splunk.py
+++ b/tools/sigma/backends/splunk.py
@@ -53,6 +53,8 @@ class SplunkBackend(SingleTextQueryBackend):
         if agg.groupfield == None:
             return " | stats %s(%s) as val | search val %s %s" % (agg.aggfunc_notrans, agg.aggfield or "", agg.cond_op, agg.condition)
         else:
+            if agg.aggfunc_notrans == 'count':
+                agg.aggfunc_notrans = 'dc'
             return " | stats %s(%s) as val by %s | search val %s %s" % (agg.aggfunc_notrans, agg.aggfield or "", agg.groupfield or "", agg.cond_op, agg.condition)
 
 class SplunkXMLBackend(SingleTextQueryBackend, MultiRuleOutputMixin):


### PR DESCRIPTION
Added dc() instead of count() when group-by field is present. Because count() doesn't do a distinct count in Splunk. Must be the dc() function instead.