### PR TITLE
Elastalert Integration Updates to SIGMA Rules

### DIFF
--- a/rules/windows/builtin/win_eventlog_cleared.yml
+++ b/rules/windows/builtin/win_eventlog_cleared.yml
@@ -1,4 +1,4 @@
-title: Eventlog Cleared
+title: Eventlog Cleared Experimental
 status: experimental
 description: Detects a cleared Windows Eventlog as e.g. caused by "wevtutil cl" command execution  
 author: Florian Roth

--- a/rules/windows/builtin/win_rare_schtasks_creations.yml
+++ b/rules/windows/builtin/win_rare_schtasks_creations.yml
@@ -15,7 +15,7 @@ detection:
     selection:
         EventID: 4698
     timeframe: 7d
-    condition: selection | count(TaskName) < 5 
+    condition: selection | count() by TaskName < 5 
 falsepositives: 
     - Software installation
     - Software updates

--- a/rules/windows/builtin/win_rare_service_installs.yml
+++ b/rules/windows/builtin/win_rare_service_installs.yml
@@ -13,7 +13,7 @@ detection:
     selection:
         EventID: 7045
     timeframe: 7d
-    condition: selection | count(ServiceFileName) < 5 
+    condition: selection | count() by ServiceFileName < 5 
 falsepositives: 
     - Software installation
     - Software updates

--- a/rules/windows/builtin/win_susp_commands_recon_activity.yml
+++ b/rules/windows/builtin/win_susp_commands_recon_activity.yml
@@ -34,7 +34,7 @@ detection:
             - '*\net1 user net localgroup administrators' 
             - 'netstat -an'
     timeframe: 15s 
-    condition: selection | count() > 4
+    condition: selection | count() by CommandLine > 4
 falsepositives: 
     - False positives depend on scripts and administrative tools used in the monitored environment
 level: medium

--- a/rules/windows/malware/av_relevant_files.yml
+++ b/rules/windows/malware/av_relevant_files.yml
@@ -1,4 +1,4 @@
-title: Antivirus Exploitation Framework Detection
+title: Antivirus Relevant File Paths Alerts
 description: Detects an Antivirus alert in a highly relevant file path or with a relevant file name
 date: 2018/09/09
 author: Florian Roth

--- a/rules/windows/powershell/powershell_xor_commandline.yml
+++ b/rules/windows/powershell/powershell_xor_commandline.yml
@@ -1,5 +1,5 @@
 action: global
-title: Suspicious Encoded PowerShell Command Line
+title: Suspicious XOR Encoded PowerShell Command Line
 description: Detects suspicious powershell process which includes bxor command, alternatvide obfuscation method to b64 encoded commands.
 status: experimental
 author: Sami Ruohonen

--- a/rules/windows/sysmon/sysmon_plugx_susp_exe_locations.yml
+++ b/rules/windows/sysmon/sysmon_plugx_susp_exe_locations.yml
@@ -1,4 +1,4 @@
-title: Executable used by PlugX in Uncommon Location
+title: Executable used by PlugX in Uncommon Location - Sysmon Version
 status: experimental
 description: Detects the execution of an executable that is typically used by PlugX for DLL side loading started from an uncommon location
 references:


### PR DESCRIPTION
I'm pushing Elastalert rules to HELK, and while transforming rules from SIGMA to Elastalert format with Sigmac, I had to updated several rules due to:
* Duplicate Rule names (SIGMA rules with the same title)
* "count() by FIELDNAME" statements added to replace "count(FIELD_NAME)"