### PR TITLE
Adding Sumologic backend

### DIFF
--- a/tools/config/sumologic.yml
+++ b/tools/config/sumologic.yml
@@ -1,0 +1,68 @@
+# Sumulogic mapping depends on customer configuration. Adapt to your context!
+# typically rule on _sourceCategory, _index or Field Extraction Rules (FER)
+# supposing existing FER for service, EventChannel, EventID
+logsources:
+  linux:
+    product: linux
+    index:
+      - _index=LINUX
+  linux-sshd:
+    product: linux
+    service: sshd
+    index:
+      - _index=LINUX
+  linux-auth:
+    product: linux
+    service: auth
+    index:
+      - _index=LINUX
+  linux-clamav:
+    product: linux
+    service: clamav
+    index:
+      - _index=LINUX
+  windows:
+    product: windows
+    index:
+      - _index=WINDOWS
+  windows-sysmon:
+    product: windows
+    service: sysmon
+    conditions:
+      EventChannel: Microsoft-Windows-Sysmon
+    index:
+      - _index=WINDOWS
+  windows-security:
+    product: windows
+    service: security
+    conditions:
+      EventChannel: Security
+    index:
+      - _index=WINDOWS
+  windows-powershell:
+    product: windows
+    service: powershell
+    conditions:
+      EventChannel: Microsoft-Windows-Powershell
+    index:
+      - _index=WINDOWS
+  windows-system:
+    product: windows
+    service: system
+    conditions:
+      EventChannel: System
+    index:
+      - _index=WINDOWS
+  apache:
+    product: apache
+    service: apache
+    index:
+      - _index=WEBSERVER
+  firewall:
+    product: firewall
+    index:
+      - _index=FIREWALL
+# if no index, search in all indexes
+defaultindex:
+# all mappings depends either on FER or on query parsing
+fieldmappings:

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -54,6 +54,7 @@ setup(
             'config/spark.yml',
             'config/netwitness.yml',
             'config/splunk-windows-all.yml',
+            'config/sumologic.yml',
         ])],
     scripts=[
         'sigmac',

--- a/tools/sigma/backends/sumologic.py
+++ b/tools/sigma/backends/sumologic.py
@@ -1,0 +1,63 @@
+# Output backends for sigmac
+# Copyright 2016-2018 Thomas Patzke, Florian Roth, juju4
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import re
+import sigma
+from .base import SingleTextQueryBackend
+
+# Sumo specifics
+# https://help.sumologic.com/05Search/Search-Query-Language
+# want _index or _sourceCategory for performance
+# try to get most string match on first line for performance
+# further sorting can be done with extra parsing
+# No regex match, must use 'parse regex' https://help.sumologic.com/05Search/Search-Query-Language/01-Parse-Operators/02-Parse-Variable-Patterns-Using-Regex
+# For some strings like Windows ProcessCmdline or LogonProcess, it might be good to force case lower and upper as Windows is inconsistent in logs
+
+class SumoLogicBackend(SingleTextQueryBackend):
+    """Converts Sigma rule into SumoLogic query"""
+    identifier = "sumologic"
+    active = True
+
+    reEscape = re.compile('("|\\\\(?![*?]))')
+    reClear = None
+    andToken = " AND "
+    orToken = " OR "
+    notToken = "!"
+    subExpression = "(%s)"
+    listExpression = "(%s)"
+    listSeparator = ", "
+    valueExpression = "\"%s\""
+    nullExpression = "isEmpty(%s)"
+    notNullExpression = "!isEmpty(%s)"
+    mapExpression = "%s=%s"
+    mapListsSpecialHandling = True
+    mapListValueExpression = "%s IN %s"
+
+    def generateAggregation(self, agg):
+        if agg == None:
+            return ""
+        if agg.aggfunc == sigma.parser.condition.SigmaAggregationParser.AGGFUNC_NEAR:
+            raise NotImplementedError("The 'near' aggregation operator is not yet implemented for this backend")
+        if agg.groupfield == None:
+            #return " | %s(%s) | when _count %s %s" % (agg.aggfunc_notrans, agg.aggfield or "", agg.cond_op, agg.condition)
+            return " | %s(%s) as val | when val %s %s" % (agg.aggfunc_notrans, agg.aggfield or "", agg.cond_op, agg.condition)
+        else:
+            return " | %s(%s) as val by %s | when val %s %s" % (agg.aggfunc_notrans, agg.aggfield or "", agg.groupfield or "", agg.cond_op, agg.condition)
+
+# TimeFrame condition / within timeframe
+# condition | timeslice 5m | count_distinct(f1) as val by f2 | where val > 5
+# Near condition => how near... like timeframe?
+


### PR DESCRIPTION
Adding Sumologic backend - https://www.sumologic.com/

Inside Sumologic, there is no default field mapping. It's either done at ingestion with Field Extraction Rules (FER) defined by customer, either at parsing, meaning it is arbitrary per customer.
If you want to use generated output, either support the same FER, either review field mappings.

Things missing
* adding _index=<INDEX> or _sourceCategory=<VAL> as prefix. required for efficient processing if no FER
* implement timeframe. It seems currently only elasticsearch backend has it and was not sure how to map it. Sumologic has a timeslice operator
https://help.sumologic.com/05Search/Search-Query-Language/Search-Operators/timeslice
* Sumologic has no regex match in its basic search. It is done after initial search with 'parse regex' statement. That will affect somes rules that will need extra work.

Few Examples
- win_susp_recon_activity.sumo
* without FER
```
_index=WINDOWS event_id=4661 and _sourceName=Security
| parse "InsertionStrings = {\"*\", \"*\", \"*\", \"*\", \"*\", \"*\", \"*\", \"*\", \"*\", \"*\", \"*\", \"*\", \"*\", \"*\", \"*\", \"*\"};" as SecurityID,AccountName,AccountDomain,LogonID,ObjectServer,ObjectType,ObjectName,ObjectHandleID,AccessTransactionID,Accesses,AccessMask,AccessPrivilegesUsed,AccessProperties,RestrictedSIDCount,ProcessID,ProcessName
| where (ObjectType="SAM_USER" and ObjectName="S-1-5-21-*-500" and AccessMask="0x2d") or (ObjectType="SAM_GROUP" and ObjectName="S-1-5-21-*-512" and AccessMask="0x2d")
```
* with FER
```
event_id=4661 and _sourceName=Security
| where (ObjectType="SAM_USER" and ObjectName="S-1-5-21-*-500" and AccessMask="0x2d") or (ObjectType="SAM_GROUP" and ObjectName="S-1-5-21-*-512" and AccessMask="0x2d")
```

- win_simultaneous_service_installs.sumo
* without FER
```
_index=WINDOWS event_id=7045 and _sourceName=System
| parse "InsertionStrings = {\"*\", \"*\", \"*\", \"*\", \"*\"};" as ServiceName,ServiceFileName,ServiceType,ServiceStartType,ServiceAccount
| timeslice 1m
| count _timeslice,hostname
| where _count > 1
```
* with FER
```
event_id=7045 and _sourceName=System
| timeslice 1m
| count _timeslice,hostname
| where _count > 1
```

- win_susp_samr_pwset.sumo
Better translated in multiple rules. partial example
* without FER
```
_index=WINDOWS _sourceName=security event_id=5145
| parse "Relative Target Name:\t*\n" as RelativeTargetName
| parse "Share Path:\t\t*\n" as SharePath
| parse "Share Name:\t\t*\n" as ShareName
| where RelativeTargetName = "samr"
```
* without FER and json log
```
_index=NXLOG_WINDOWS 5145 Microsoft-Windows-Security-Auditing
| json field=_raw "SourceName", "EventID", "RelativeTargetName"
| where EventID = "5145" and SourceName = "Microsoft-Windows-Security-Auditing" and RelativeTargetName = "samr"
```
=> keyword in first line to optimize processing. json keyword to do fields extraction
* with FER
```
EventID = "5145" and SourceName = "Microsoft-Windows-Security-Auditing" and RelativeTargetName = "samr"
```

Sometimes might need to play with case as not consistent
- psexec
* without FER
```
_index=WINDOWS _sourceCategory=*/*/WINDOWS event_id=7045 and _sourceName=System
| parse "InsertionStrings = {\"*\", \"*\", \"*\", \"*\", \"*\"};" as ServiceName,ServiceFileName,ServiceType,ServiceStartType,ServiceAccount
| where ToUpperCase(ServiceName) matches "*PSEXEC*" and ToUpperCase(ServiceFileName) matches "*\\PSEXESVC.EXE"
| count by b_sourceHost,ServiceName,ServiceFileName,ServiceAccount
```

And a parsing regex example
```
_index=POWERSHELL
(AdjustTokenPrivileges or
IMAGE_NT_OPTIONAL_HDR64_MAGIC or
Management.Automation.RuntimeException //...
)
| parse "\tUser = \"*\";" as User nodrop
| parse regex "ScriptBlock ID: (?<ScriptBlockID>[A-Za-z0-9-]*)" nodrop
| parse regex "function (?<FunctionName>[^\s]*)" nodrop
```