### PR TITLE
Bugfix: wrong field for 4688 process creation events

### DIFF
--- a/rules/apt/apt_equationgroup_dll_u_load.yml
+++ b/rules/apt/apt_equationgroup_dll_u_load.yml
@@ -12,12 +12,8 @@ tags:
     - attack.t1059
 author: Florian Roth
 date: 2018/03/10 
+modified: 2018/12/11
 detection:
-    selection1:
-        Image: '*\rundll32.exe'
-        CommandLine: '*,dll_u'
-    selection2:
-        CommandLine: '* -export dll_u *'
     condition: 1 of them
 falsepositives:
     - Unknown
@@ -29,8 +25,11 @@ logsource:
 detection:
     selection1:
         EventID: 1
+        Image: '*\rundll32.exe'
+        CommandLine: '*,dll_u'
     selection2:
         EventID: 1
+        CommandLine: '* -export dll_u *'
 ---
 logsource:
     product: windows
@@ -39,5 +38,8 @@ logsource:
 detection:
     selection1:
         EventID: 4688
+        Image: '*\rundll32.exe'
+        ProcessCommandLine: '*,dll_u'
     selection2:
         EventID: 4688
+        ProcessCommandLine: '* -export dll_u *'

--- a/rules/apt/apt_hurricane_panda.yml
+++ b/rules/apt/apt_hurricane_panda.yml
@@ -11,11 +11,8 @@ tags:
     - attack.t1068
 author: Florian Roth
 date: 2018/02/25
+modified: 2018/12/11
 detection:
-    selection:
-        CommandLine: 
-            - '* localgroup administrators admin /add'
-            - '*\Win64.exe*'
     condition: selection
 falsepositives:
     - Unknown
@@ -27,6 +24,9 @@ logsource:
 detection:
     selection:
         EventID: 1
+        CommandLine: 
+            - '* localgroup administrators admin /add'
+            - '*\Win64.exe*'
 ---
 logsource:
     product: windows
@@ -35,5 +35,8 @@ logsource:
 detection:
     selection:
         EventID: 4688
+        ProcessCommandLine: 
+            - '* localgroup administrators admin /add'
+            - '*\Win64.exe*'
 
 

--- a/rules/apt/apt_sofacy.yml
+++ b/rules/apt/apt_sofacy.yml
@@ -1,4 +1,3 @@
-
 ---
 action: global
 title: Sofacy Trojan Loader Activity
@@ -12,11 +11,8 @@ tags:
     - attack.g0007
 author: Florian Roth
 date: 2018/03/01
+modified: 2018/12/11
 detection:
-    selection:
-        CommandLine: 
-            - 'rundll32.exe %APPDATA%\*.dat",*'
-            - 'rundll32.exe %APPDATA%\*.dll",#1'
     condition: selection
 falsepositives:
     - Unknown
@@ -28,6 +24,9 @@ logsource:
 detection:
     selection:
         EventID: 1
+        CommandLine: 
+            - 'rundll32.exe %APPDATA%\*.dat",*'
+            - 'rundll32.exe %APPDATA%\*.dll",#1'
 ---
 logsource:
     product: windows
@@ -36,3 +35,6 @@ logsource:
 detection:
     selection:
         EventID: 4688
+        ProcessCommandLine: 
+            - 'rundll32.exe %APPDATA%\*.dat",*'
+            - 'rundll32.exe %APPDATA%\*.dll",#1'

--- a/rules/apt/apt_sofacy_zebrocy.yml
+++ b/rules/apt/apt_sofacy_zebrocy.yml
@@ -9,7 +9,7 @@ tags:
     - attack.g0020
     - attack.t1059
 author: Florian Roth
-date: 2018/03/10 
+date: 2018/03/10
 detection:
     condition: selection
 falsepositives:

--- a/rules/apt/apt_tropictrooper.yml
+++ b/rules/apt/apt_tropictrooper.yml
@@ -6,6 +6,7 @@ references:
     - https://cloudblogs.microsoft.com/microsoftsecure/2018/11/28/windows-defender-atp-device-risk-score-exposes-new-cyberattack-drives-conditional-access-to-protect-networks/
 author: "@41thexplorer, Windows Defender ATP"
 date: 2018/11/30
+modified: 2018/12/11
 tags:
     - attack.execution
     - attack.t1085
@@ -21,7 +22,7 @@ logsource:
 detection:
     selection:
         EventID: 4688
-        CommandLine: '*abCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCc*'
+        ProcessCommandLine: '*abCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCc*'
 ---
 # Sysmon: Process Creation (ID 1)
 logsource:

--- a/rules/apt/apt_unidentified_nov_18.yml
+++ b/rules/apt/apt_unidentified_nov_18.yml
@@ -6,6 +6,7 @@ references:
     - https://twitter.com/DrunkBinary/status/1063075530180886529
 author: "@41thexplorer, Windows Defender ATP"
 date: 2018/11/20
+modified: 2018/12/11
 tags:
     - attack.execution
     - attack.t1085
@@ -21,7 +22,7 @@ logsource:
 detection:
     selection:
         EventID: 4688
-        CommandLine: '*cyzfc.dat, PointFunctionCall'
+        ProcessCommandLine: '*cyzfc.dat, PointFunctionCall'
 ---
 # Sysmon: Process Creation (ID 1)
 logsource:

--- a/rules/windows/builtin/win_multiple_suspicious_cli.yml
+++ b/rules/windows/builtin/win_multiple_suspicious_cli.yml
@@ -5,8 +5,69 @@ status: experimental
 references:
     - https://car.mitre.org/wiki/CAR-2013-04-002
 author: juju4
+modified: 2012/12/11
+falsepositives:
+    - False positives depend on scripts and administrative tools used in the monitored environment
+level: low
+---
+# Windows Audit Log
+logsource:
+    product: windows
+    service: security
+    definition: 'Requirements: Audit Policy : Detailed Tracking > Audit Process creation, Group Policy : Administrative Templates\System\Audit Process Creation'
 detection:
     selection:
+        EventID: 4688
+        ProcessCommandLine: 
+            - arp.exe
+            - at.exe
+            - attrib.exe
+            - cscript.exe
+            - dsquery.exe
+            - hostname.exe
+            - ipconfig.exe
+            - mimikatz.exe
+            - nbstat.exe
+            - net.exe
+            - netsh.exe
+            - nslookup.exe
+            - ping.exe
+            - quser.exe
+            - qwinsta.exe
+            - reg.exe
+            - runas.exe
+            - sc.exe
+            - schtasks.exe
+            - ssh.exe
+            - systeminfo.exe
+            - taskkill.exe
+            - telnet.exe
+            - tracert.exe
+            - wscript.exe
+            - xcopy.exe
+# others
+            - pscp.exe
+            - copy.exe
+            - robocopy.exe
+            - certutil.exe
+            - vssadmin.exe
+            - powershell.exe
+            - wevtutil.exe
+            - psexec.exe
+            - bcedit.exe
+            - wbadmin.exe
+            - icacls.exe
+            - diskpart.exe
+    timeframe: 5m
+    condition: selection | count() by MachineName > 5
+---
+# Sysmon
+logsource:
+    product: windows
+    service: sysmon
+detection:
+    selection:
+        EventID: 1
         CommandLine: 
             - arp.exe
             - at.exe
@@ -49,23 +110,3 @@ detection:
             - diskpart.exe
     timeframe: 5m
     condition: selection | count() by MachineName > 5
-falsepositives:
-    - False positives depend on scripts and administrative tools used in the monitored environment
-level: low
----
-# Windows Audit Log
-logsource:
-    product: windows
-    service: security
-    definition: 'Requirements: Audit Policy : Detailed Tracking > Audit Process creation, Group Policy : Administrative Templates\System\Audit Process Creation'
-detection:
-    selection:
-        EventID: 4688
----
-# Sysmon
-logsource:
-    product: windows
-    service: sysmon
-detection:
-    selection:
-        EventID: 1

--- a/rules/windows/builtin/win_psexesvc_start.yml
+++ b/rules/windows/builtin/win_psexesvc_start.yml
@@ -2,6 +2,7 @@ title: PsExec Service Start
 description: Detects a PsExec service start
 author: Florian Roth
 date: 2018/03/13
+modified: 2012/12/11
 tags:
     - attack.execution
     - attack.t1035
@@ -13,7 +14,7 @@ logsource:
 detection:
     selection:
         EventID: 4688
-        CommandLine: 'C:\Windows\PSEXESVC.exe'
+        ProcessCommandLine: 'C:\Windows\PSEXESVC.exe'
     condition: 1 of them
 falsepositives:
     - Administrative activity

--- a/rules/windows/builtin/win_susp_cli_escape.yml
+++ b/rules/windows/builtin/win_susp_cli_escape.yml
@@ -9,21 +9,11 @@ references:
     - https://www.fireeye.com/blog/threat-research/2017/06/obfuscation-in-the-wild.html
     - http://www.windowsinspired.com/understanding-the-command-line-string-and-arguments-received-by-a-windows-program/
 author: juju4
+modified: 2018/12/11
 tags:
     - attack.defense_evasion
     - attack.t1140
 detection:
-    selection:
-        CommandLine: 
-            #- '^'
-            #- '@'
-# 0x002D -, 0x2013 , 0x2014 , 0x2015 ― ... FIXME! how to match hexa form?
-            # - '-'
-            # - '―'
-            #- 'c:/'
-            - '<TAB>'
-            - '^h^t^t^p'
-            - 'h"t"t"p'
     condition: selection
 falsepositives: 
     - False positives depend on scripts and administrative tools used in the monitored environment
@@ -37,6 +27,16 @@ logsource:
 detection:
     selection:
         EventID: 4688
+        ProcessCommandLine: 
+            #- '^'
+            #- '@'
+# 0x002D -, 0x2013 , 0x2014 , 0x2015 ― ... FIXME! how to match hexa form?
+            # - '-'
+            # - '―'
+            #- 'c:/'
+            - '<TAB>'
+            - '^h^t^t^p'
+            - 'h"t"t"p'
 ---
 # Sysmon
 logsource:
@@ -45,3 +45,13 @@ logsource:
 detection:
     selection:
         EventID: 1
+        CommandLine: 
+            #- '^'
+            #- '@'
+# 0x002D -, 0x2013 , 0x2014 , 0x2015 ― ... FIXME! how to match hexa form?
+            # - '-'
+            # - '―'
+            #- 'c:/'
+            - '<TAB>'
+            - '^h^t^t^p'
+            - 'h"t"t"p'

--- a/rules/windows/builtin/win_susp_commands_recon_activity.yml
+++ b/rules/windows/builtin/win_susp_commands_recon_activity.yml
@@ -9,12 +9,24 @@ references:
     - https://www.fireeye.com/blog/threat-research/2016/05/targeted_attacksaga.html
 author:  Florian Roth, Markus Neis
 date: 2018/08/22
+modified: 2018/12/11
 tags:
     - attack.discovery
     - attack.t1073
     - attack.t1012 
 detection:
+    timeframe: 15s 
+    condition: selection | count() by CommandLine > 4
+falsepositives: 
+    - False positives depend on scripts and administrative tools used in the monitored environment
+level: medium
+---
+logsource:
+    product: windows
+    service: sysmon
+detection:
     selection:
+        EventID: 1
         CommandLine: 
             - 'tasklist'
             - 'net time'
@@ -33,18 +45,6 @@ detection:
             - '*\net1 accounts /domain' 
             - '*\net1 user net localgroup administrators' 
             - 'netstat -an'
-    timeframe: 15s 
-    condition: selection | count() by CommandLine > 4
-falsepositives: 
-    - False positives depend on scripts and administrative tools used in the monitored environment
-level: medium
----
-logsource:
-    product: windows
-    service: sysmon
-detection:
-    selection:
-        EventID: 1
 ---
 logsource:
     product: windows
@@ -53,3 +53,21 @@ logsource:
 detection:
     selection:
         EventID: 4688
+        ProcessCommandLine: 
+            - 'tasklist'
+            - 'net time'
+            - 'systeminfo'
+            - 'whoami'
+            - 'nbtstat'
+            - 'net start'
+            - '*\net1 start'
+            - 'qprocess'
+            - 'nslookup'
+            - 'hostname.exe'
+            - '*\net1 user /domain'
+            - '*\net1 group /domain'
+            - '*\net1 group "domain admins" /domain'
+            - '*\net1 group "Exchange Trusted Subsystem" /domain'
+            - '*\net1 accounts /domain' 
+            - '*\net1 user net localgroup administrators' 
+            - 'netstat -an'

--- a/rules/windows/builtin/win_susp_iss_module_install.yml
+++ b/rules/windows/builtin/win_susp_iss_module_install.yml
@@ -6,13 +6,11 @@ status: experimental
 references:
     - https://researchcenter.paloaltonetworks.com/2018/01/unit42-oilrig-uses-rgdoor-iis-backdoor-targets-middle-east/
 author: Florian Roth
+modified: 2012/12/11
 tags:
     - attack.persistence
     - attack.t1100
 detection:
-    selection:
-        CommandLine: 
-            - '*\APPCMD.EXE install module /name:*'
     condition: selection
 falsepositives: 
     - Unknown as it may vary from organisation to arganisation how admins use to install IIS modules
@@ -24,6 +22,8 @@ logsource:
 detection:
     selection:
         EventID: 1
+        CommandLine: 
+            - '*\APPCMD.EXE install module /name:*'
 ---
 logsource:
     product: windows
@@ -32,3 +32,5 @@ logsource:
 detection:
     selection:
         EventID: 4688
+        ProcessCommandLine: 
+            - '*\APPCMD.EXE install module /name:*'

--- a/rules/windows/builtin/win_susp_msiexec_web_install.yml
+++ b/rules/windows/builtin/win_susp_msiexec_web_install.yml
@@ -7,10 +7,8 @@ references:
     - https://blog.trendmicro.com/trendlabs-security-intelligence/attack-using-windows-installer-msiexec-exe-leads-lokibot/
 author: Florian Roth
 date: 2018/02/09
+modified: 2012/12/11
 detection:
-    selection:
-        CommandLine: 
-            - '* msiexec*:\/\/*'
     condition: selection
 falsepositives: 
     - False positives depend on scripts and administrative tools used in the monitored environment
@@ -22,6 +20,8 @@ logsource:
 detection:
     selection:
         EventID: 1
+        CommandLine: 
+            - '* msiexec*:\/\/*'
 ---
 logsource:
     product: windows
@@ -30,3 +30,5 @@ logsource:
 detection:
     selection:
         EventID: 4688
+        ProcessCommandLine: 
+            - '* msiexec*:\/\/*'

--- a/rules/windows/builtin/win_susp_process_creations.yml
+++ b/rules/windows/builtin/win_susp_process_creations.yml
@@ -15,8 +15,19 @@ references:
     - https://gist.github.com/subTee/7937a8ef07409715f15b84781e180c46#file-rat-bat
     - https://twitter.com/vector_sec/status/896049052642533376
 author: Florian Roth
+modified: 2012/12/11
+detection:
+    condition: selection
+falsepositives: 
+    - False positives depend on scripts and administrative tools used in the monitored environment
+level: medium
+---
+logsource:
+    product: windows
+    service: sysmon
 detection:
     selection:
+        EventID: 1
         CommandLine: 
             # Hacking activity
             - 'vssadmin.exe delete shadows*'
@@ -66,17 +77,6 @@ detection:
             - '*AddInProcess*'
             # NotPowershell (nps) attack
             # - '*msbuild*'  # too many false positives
-    condition: selection
-falsepositives: 
-    - False positives depend on scripts and administrative tools used in the monitored environment
-level: medium
----
-logsource:
-    product: windows
-    service: sysmon
-detection:
-    selection:
-        EventID: 1
 ---
 logsource:
     product: windows
@@ -85,3 +85,52 @@ logsource:
 detection:
     selection:
         EventID: 4688
+        ProcessCommandLine: 
+            # Hacking activity
+            - 'vssadmin.exe delete shadows*'
+            - 'vssadmin delete shadows*'
+            - 'vssadmin create shadow /for=C:*'
+            - 'copy \\?\GLOBALROOT\Device\*\windows\ntds\ntds.dit*'
+            - 'copy \\?\GLOBALROOT\Device\*\config\SAM*'
+            - 'reg SAVE HKLM\SYSTEM *'
+            - '* sekurlsa:*'
+            - 'net localgroup adminstrators * /add'
+            - 'net group "Domain Admins" * /ADD /DOMAIN'
+            - 'certutil.exe *-urlcache* http*'
+            - 'certutil.exe *-urlcache* ftp*'
+            # Malware
+            - 'netsh advfirewall firewall *\AppData\*'
+            - 'attrib +S +H +R *\AppData\*'
+            - 'schtasks* /create *\AppData\*'
+            - 'schtasks* /sc minute*'
+            - '*\Regasm.exe *\AppData\*'
+            - '*\Regasm *\AppData\*'
+            - '*\bitsadmin* /transfer*'
+            - '*\certutil.exe * -decode *'
+            - '*\certutil.exe * -decodehex *'
+            - '*\certutil.exe -ping *'
+            - 'icacls * /grant Everyone:F /T /C /Q'
+            - '* wmic shadowcopy delete *'
+            - '* wbadmin.exe delete catalog -quiet*'  # http://blog.talosintelligence.com/2018/02/olympic-destroyer.html
+            # Scripts
+            - '*\wscript.exe *.jse'
+            - '*\wscript.exe *.js'
+            - '*\wscript.exe *.vba'
+            - '*\wscript.exe *.vbe'
+            - '*\cscript.exe *.jse'
+            - '*\cscript.exe *.js'
+            - '*\cscript.exe *.vba'
+            - '*\cscript.exe *.vbe'
+            # UAC bypass
+            - '*\fodhelper.exe'
+            # persistence
+            - '*waitfor*/s*'
+            - '*waitfor*/si persist*'
+            # remote
+            - '*remote*/s*'
+            - '*remote*/c*'
+            - '*remote*/q*'
+            # AddInProcess
+            - '*AddInProcess*'
+            # NotPowershell (nps) attack
+            # - '*msbuild*'  # too many false positives

--- a/rules/windows/builtin/win_susp_sysprep_appdata.yml
+++ b/rules/windows/builtin/win_susp_sysprep_appdata.yml
@@ -8,11 +8,8 @@ references:
     - https://app.any.run/tasks/61a296bb-81ad-4fee-955f-3b399f4aaf4b
 author: Florian Roth
 date: 2018/06/22
+modified: 2018/12/11
 detection:
-    selection:
-        CommandLine: 
-            - '*\sysprep.exe *\AppData\*'
-            - 'sysprep.exe *\AppData\*'
     condition: selection
 falsepositives: 
     - False positives depend on scripts and administrative tools used in the monitored environment
@@ -24,6 +21,9 @@ logsource:
 detection:
     selection:
         EventID: 1
+        CommandLine: 
+            - '*\sysprep.exe *\AppData\*'
+            - 'sysprep.exe *\AppData\*'
 ---
 logsource:
     product: windows
@@ -32,3 +32,6 @@ logsource:
 detection:
     selection:
         EventID: 4688
+        ProcessCommandLine: 
+            - '*\sysprep.exe *\AppData\*'
+            - 'sysprep.exe *\AppData\*'

--- a/rules/windows/builtin/win_susp_sysvol_access.yml
+++ b/rules/windows/builtin/win_susp_sysvol_access.yml
@@ -8,12 +8,11 @@ references:
     - https://www.hybrid-analysis.com/sample/f2943f5e45befa52fb12748ca7171d30096e1d4fc3c365561497c618341299d5?environmentId=100
 author: Markus Neis
 date: 2018/04/09
+modified: 2018/12/11
 tags:
     - attack.credential_access
     - attack.t1003
 detection:
-    selection:
-        CommandLine: '*\SYSVOL\*\policies\*'
     condition: selection
 falsepositives: 
     - administrative activity 
@@ -25,6 +24,7 @@ logsource:
 detection:
     selection:
         EventID: 1
+        CommandLine: '*\SYSVOL\*\policies\*'
 ---
 logsource:
     product: windows
@@ -33,3 +33,4 @@ logsource:
 detection:
     selection:
         EventID: 4688
+        ProcessCommandLine: '*\SYSVOL\*\policies\*'

--- a/rules/windows/malware/win_mal_adwind.yml
+++ b/rules/windows/malware/win_mal_adwind.yml
@@ -8,6 +8,7 @@ references:
     - https://www.first.org/resources/papers/conf2017/Advanced-Incident-Detection-and-Threat-Hunting-using-Sysmon-and-Splunk.pdf
 author: Florian Roth, Tom Ueltschi
 date: 2017/11/10
+modified: 2018/12/11
 detection:
     condition: selection
 level: high
@@ -20,7 +21,7 @@ logsource:
 detection:
     selection:
         EventID: 4688
-        CommandLine: 
+        ProcessCommandLine: 
             - '*\AppData\Roaming\Oracle*\java*.exe *'
             - '*cscript.exe *Retrive*.vbs *'
 ---

--- a/rules/windows/sysmon/sysmon_susp_certutil_command.yml
+++ b/rules/windows/sysmon/sysmon_susp_certutil_command.yml
@@ -1,13 +1,30 @@
+---
+action: global
 title: Suspicious Certutil Command
 status: experimental
 description: Detects a suspicious Microsoft certutil execution with sub commands like 'decode' sub command, which is sometimes used to decode malicious code with the built-in certutil utility
 author: Florian Roth, juju4
+modified: 2018/12/11
 references:
     - https://twitter.com/JohnLaTwC/status/835149808817991680
     - https://twitter.com/subTee/status/888102593838362624
     - https://twitter.com/subTee/status/888071631528235010
     - https://blogs.technet.microsoft.com/pki/2006/11/30/basic-crl-checking-with-certutil/
     - https://www.trustedsec.com/2017/07/new-tool-release-nps_payload/
+detection:
+    condition: selection
+fields:
+    - CommandLine
+    - ParentCommandLine
+tags:
+    - attack.defense_evasion
+    - attack.t1140
+    - attack.s0189
+    - attack.g0007
+falsepositives:
+    - False positives depend on scripts and administrative tools used in the monitored environment
+level: high
+---
 logsource:
     product: windows
     service: sysmon
@@ -27,17 +44,24 @@ detection:
             - '*certutil.exe *-urlcache* ftp*'
             - '*certutil.exe *-URL*'
             - '*certutil.exe *-ping*'
-    condition: selection
-fields:
-    - CommandLine
-    - ParentCommandLine
-tags:
-    - attack.defense_evasion
-    - attack.t1140
-    - attack.s0189
-    - attack.g0007
-falsepositives:
-    - False positives depend on scripts and administrative tools used in the monitored environment
-level: high
-
-
+---
+logsource:
+    product: windows
+    service: security
+    definition: 'Requirements: Audit Policy : Detailed Tracking > Audit Process creation, Group Policy : Administrative Templates\System\Audit Process Creation'
+detection:
+    selection:
+        EventID: 4688
+        ProcessCommandLine: 
+            - '*certutil * -decode *'
+            - '*certutil * -decodehex *'
+            - '*certutil *-urlcache* http*'
+            - '*certutil *-urlcache* ftp*'
+            - '*certutil *-URL*'
+            - '*certutil *-ping*'
+            - '*certutil.exe * -decode *'
+            - '*certutil.exe * -decodehex *'
+            - '*certutil.exe *-urlcache* http*'
+            - '*certutil.exe *-urlcache* ftp*'
+            - '*certutil.exe *-URL*'
+            - '*certutil.exe *-ping*'

--- a/rules/windows/sysmon/sysmon_susp_tscon_rdp_redirect.yml
+++ b/rules/windows/sysmon/sysmon_susp_tscon_rdp_redirect.yml
@@ -8,9 +8,8 @@ reference:
     - https://medium.com/@networksecurity/rdp-hijacking-how-to-hijack-rds-and-remoteapp-sessions-transparently-to-move-through-an-da2a1e73a5f6
 author: Florian Roth
 date: 2018/03/17
+modified: 2018/12/11
 detection:
-    selection:
-        CommandLine: '* /dest:rdp-tcp:*'
     condition: selection
 falsepositives:
     - Unknown
@@ -22,6 +21,7 @@ logsource:
 detection:
     selection:
         EventID: 1
+        CommandLine: '* /dest:rdp-tcp:*'
 ---
 logsource:
     product: windows
@@ -30,3 +30,4 @@ logsource:
 detection:
     selection:
         EventID: 4688
+        ProcessCommandLine: '* /dest:rdp-tcp:*'


### PR DESCRIPTION
Please review before pulling:
- Changed all `CommandLine` fields to `ProcessCommandLine` in 4688 Event IDs
- Added a new field `modified` with a timestamp of last modification (I think that such a field is necessary)