### PR TITLE
Corrected reference to references as per Sigma's standard

### DIFF
--- a/rules/windows/builtin/win_hack_rubeus.yml
+++ b/rules/windows/builtin/win_hack_rubeus.yml
@@ -3,7 +3,7 @@ action: global
 title: Rubeus Hack Tool
 description: Detects command line parameters used by Rubeus hack tool 
 author: Florian Roth
-reference: 
+references: 
     - https://www.harmj0y.net/blog/redteaming/from-kekeo-to-rubeus/
 date: 2018/12/19
 tags:

--- a/rules/windows/builtin/win_net_ntlm_downgrade.yml
+++ b/rules/windows/builtin/win_net_ntlm_downgrade.yml
@@ -2,7 +2,7 @@
 action: global
 title: NetNTLM Downgrade Attack
 description: Detects post exploitation using NetNTLM downgrade attacks
-reference: 
+references: 
     - https://www.optiv.com/blog/post-exploitation-using-netntlm-downgrade-attacks
 author: Florian Roth
 date: 2018/03/20

--- a/rules/windows/sysmon/sysmon_cmdkey_recon.yml
+++ b/rules/windows/sysmon/sysmon_cmdkey_recon.yml
@@ -1,7 +1,7 @@
 title: Cmdkey Cached Credentials Recon
 status: experimental
 description: Detects usage of cmdkey to look for cached credentials
-reference: 
+references: 
     - https://www.peew.pw/blog/2017/11/26/exploring-cmdkey-an-edge-case-for-privilege-escalation
     - https://technet.microsoft.com/en-us/library/cc754243(v=ws.11).aspx
 author: jmallette

--- a/rules/windows/sysmon/sysmon_susp_reg_persist_explorer_run.yml
+++ b/rules/windows/sysmon/sysmon_susp_reg_persist_explorer_run.yml
@@ -3,7 +3,7 @@ status: experimental
 description: Detects a possible persistence mechanism using RUN key for Windows Explorer and poiting to a suspicious folder
 author: Florian Roth
 date: 2018/07/18
-reference:
+references:
     - https://researchcenter.paloaltonetworks.com/2018/07/unit42-upatre-continues-evolve-new-anti-analysis-techniques/
 logsource:
     product: windows

--- a/rules/windows/sysmon/sysmon_susp_tscon_localsystem.yml
+++ b/rules/windows/sysmon/sysmon_susp_tscon_localsystem.yml
@@ -1,7 +1,7 @@
 title: Suspicious TSCON Start
 status: experimental
 description: Detects a tscon.exe start as LOCAL SYSTEM 
-reference: 
+references: 
     - http://www.korznikov.com/2017/03/0-day-or-feature-privilege-escalation.html
     - https://medium.com/@networksecurity/rdp-hijacking-how-to-hijack-rds-and-remoteapp-sessions-transparently-to-move-through-an-da2a1e73a5f6
 author: Florian Roth

--- a/rules/windows/sysmon/sysmon_susp_tscon_rdp_redirect.yml
+++ b/rules/windows/sysmon/sysmon_susp_tscon_rdp_redirect.yml
@@ -3,7 +3,7 @@ action: global
 title: Suspicious RDP Redirect Using TSCON
 status: experimental
 description: Detects a suspicious RDP session redirect using tscon.exe
-reference: 
+references: 
     - http://www.korznikov.com/2017/03/0-day-or-feature-privilege-escalation.html
     - https://medium.com/@networksecurity/rdp-hijacking-how-to-hijack-rds-and-remoteapp-sessions-transparently-to-move-through-an-da2a1e73a5f6
 author: Florian Roth


### PR DESCRIPTION
As per the Sigma standard here:
https://github.com/Neo23x0/sigma/wiki/Specification
Changed all tags named "reference" to "references". 