### PR TITLE
Fix yamllint config

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,4 +1,12 @@
 ---
 # https://yamllint.readthedocs.io/en/latest/configuration.html
+extends: default
 rules:
+  comments: disable
+  comments-indentation: disable
   document-start: disable
+  empty-lines: {max: 2, max-start: 2, max-end: 2}
+  indentation: disable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  trailing-spaces: disable

--- a/rules/windows/builtin/win_susp_commands_recon_activity.yml
+++ b/rules/windows/builtin/win_susp_commands_recon_activity.yml
@@ -7,7 +7,7 @@ references:
     - https://twitter.com/haroonmeer/status/939099379834658817
     - https://twitter.com/c_APT_ure/status/939475433711722497
     - https://www.fireeye.com/blog/threat-research/2016/05/targeted_attacksaga.html
-author:  Florian Roth, Markus Neis
+author: Florian Roth, Markus Neis
 date: 2018/08/22
 modified: 2018/12/11
 tags:

--- a/tools/config/arcsight.yml
+++ b/tools/config/arcsight.yml
@@ -85,7 +85,7 @@ logsources:
     conditions:
       deviceProduct: Apache
       categoryDeviceGroup: /Application
-    firewall:
+  firewall:
     product: firewall
     conditions:
       categoryDeviceGroup: /Firewall


### PR DESCRIPTION
### Really run yamllint (it wasn't checking any rule)

Fix the yamllint config in `.yamllint` to "extend" the default rule.
Previously, it didn't extend anything and only disabled a rule, which
means no rule at all were checked.

Also disable some rules in this file, because they report many errors in
the Sigma code base.

In the future, I suggest fixing these errors and re-enabling standard
rules like `trailing-spaces` or `indentation`.

Fixes #220.

---

### Fix YAML errors reported by yamllint

Especially the config for ArcSight, that was invalid:

    tools/config/arcsight.yml
      89:5      error    duplication of key "product" in mapping  (key-duplicates)
      90:5      error    duplication of key "conditions" in mapping  (key-duplicates)

    rules/windows/builtin/win_susp_commands_recon_activity.yml
      10:9      error    too many spaces after colon  (colons)
