### PR TITLE
extending the qradar backend to allow for timeframe query

### DIFF
--- a/tools/config/qradar.yml
+++ b/tools/config/qradar.yml
@@ -26,11 +26,14 @@ logsources:
    index: flows
 
 fieldmappings:
-  dst:
-    - destinationIP
-  dst_ip:
-    - destinationIP
-  src:
-    - sourceIP
-  src_ip:
-    - sourceIP
+    EventID:
+        - Event ID Code
+    dst:
+        - destinationIP
+    dst_ip:
+        - destinationIP
+    src:
+        - sourceIP
+    src_ip:
+        - sourceIP
+    ServiceFileName: Service Name


### PR DESCRIPTION
This PR will bring the option for Qradar timeframe. It's not a hard requirement so timeframe query will only be generate if the users have specifically picked timeframe: 7d for example.

```
title: Rare Service Installs
description: Detects rare service installs that only appear a few times per time frame and could reveal password dumpers, backdoor installs or other types of malicious services 
status: experimental
author: Florian Roth
tags:
    - attack.persistence
    - attack.privilege_escalation
    - attack.t1050
logsource:
    product: windows
    service: system
detection:
    selection:
        EventID: 7045
    timeframe: 7d
    condition: selection | count() by ServiceFileName < 5 
falsepositives: 
    - Software installation
    - Software updates
level: low
```
```
SELECT count(None) as agg_val from events where EventID='7045' group by ServiceFileName having agg_val < 5 LAST 7 days
```