### PR TITLE
Adapt count function when aggfield not present

### DIFF
--- a/tools/sigma/backends/splunk.py
+++ b/tools/sigma/backends/splunk.py
@@ -56,17 +56,17 @@ class SplunkBackend(SingleTextQueryBackend):
         if agg.groupfield == None:
             if agg.aggfunc_notrans == 'count':
                 if agg.aggfield == None :
-                    return " | stats count as val | search val %s %s" % (agg.cond_op, agg.condition)
+                    return " | eventstats count as val | search val %s %s" % (agg.cond_op, agg.condition)
                 else:
                     agg.aggfunc_notrans = 'dc'
-            return " | stats %s(%s) as val | search val %s %s" % (agg.aggfunc_notrans, agg.aggfield or "", agg.cond_op, agg.condition)
+            return " | eventstats %s(%s) as val | search val %s %s" % (agg.aggfunc_notrans, agg.aggfield or "", agg.cond_op, agg.condition)
         else:
             if agg.aggfunc_notrans == 'count':
                 if agg.aggfield == None :
-                    return " | stats count as val by %s| search val %s %s" % (agg.groupfield, agg.cond_op, agg.condition)
+                    return " | eventstats count as val by %s| search val %s %s" % (agg.groupfield, agg.cond_op, agg.condition)
                 else:
                     agg.aggfunc_notrans = 'dc'
-            return " | stats %s(%s) as val by %s | search val %s %s" % (agg.aggfunc_notrans, agg.aggfield or "", agg.groupfield or "", agg.cond_op, agg.condition)
+            return " | eventstats %s(%s) as val by %s | search val %s %s" % (agg.aggfunc_notrans, agg.aggfield or "", agg.groupfield or "", agg.cond_op, agg.condition)
 
         
     def generate(self, sigmaparser):

--- a/tools/sigma/backends/splunk.py
+++ b/tools/sigma/backends/splunk.py
@@ -54,10 +54,18 @@ class SplunkBackend(SingleTextQueryBackend):
         if agg.aggfunc == sigma.parser.condition.SigmaAggregationParser.AGGFUNC_NEAR:
             raise NotImplementedError("The 'near' aggregation operator is not yet implemented for this backend")
         if agg.groupfield == None:
+            if agg.aggfunc_notrans == 'count':
+                if agg.aggfield == None :
+                    return " | stats count as val | search val %s %s" % (agg.cond_op, agg.condition)
+                else:
+                    agg.aggfunc_notrans = 'dc'
             return " | stats %s(%s) as val | search val %s %s" % (agg.aggfunc_notrans, agg.aggfield or "", agg.cond_op, agg.condition)
         else:
             if agg.aggfunc_notrans == 'count':
-                agg.aggfunc_notrans = 'dc'
+                if agg.aggfield == None :
+                    return " | stats count as val by %s| search val %s %s" % (agg.groupfield, agg.cond_op, agg.condition)
+                else:
+                    agg.aggfunc_notrans = 'dc'
             return " | stats %s(%s) as val by %s | search val %s %s" % (agg.aggfunc_notrans, agg.aggfield or "", agg.groupfield or "", agg.cond_op, agg.condition)
 
         


### PR DESCRIPTION
When no field is present, use "count" , when field is present use "dc(field)". As described in the Sigma specifications.
Splunk throws errors when using "count()" with empy fields. use "count" instead.