### PR TITLE
Added esentutl copy command to sysmon_susp_vssadmin_ntds_activity.yml

### DIFF
--- a/rules/windows/sysmon/sysmon_susp_vssadmin_ntds_activity.yml
+++ b/rules/windows/sysmon/sysmon_susp_vssadmin_ntds_activity.yml
@@ -7,6 +7,7 @@ references:
     - https://room362.com/post/2013/2013-06-10-volume-shadow-copy-ntdsdit-domain-hashes-remotely-part-1/
     - https://www.trustwave.com/Resources/SpiderLabs-Blog/Tutorial-for-NTDS-goodness-(VSSADMIN,-WMIS,-NTDS-dit,-SYSTEM)/
     - https://securingtomorrow.mcafee.com/mcafee-labs/new-teslacrypt-ransomware-arrives-via-spam/
+    - https://dfironthemountain.wordpress.com/2018/12/06/locked-file-access-using-esentutl-exe/
 logsource:
     product: windows
     service: sysmon
@@ -22,6 +23,7 @@ detection:
             - 'copy \\?\GLOBALROOT\Device\\*\config\SAM'
             - 'vssadmin delete shadows /for=C:'
             - 'reg SAVE HKLM\SYSTEM '
+            - 'esentutl.exe /y /vss *\ntds.dit*'
     condition: selection
 fields:
     - CommandLine


### PR DESCRIPTION
Added esentutl command to sysmon_susp_vssadmin_ntds_activity.yml to detect attempts to copy ntds.dit. Note that the vss flag is only supported on win10 and windows 2016. 

Saw in a tweet from @bohops and @grayfold3d this morning, seemed like a good thing to add to the rule.