### PR TITLE
Unnecessary 1/all of them

### DIFF
--- a/rules/windows/builtin/win_psexesvc_start.yml
+++ b/rules/windows/builtin/win_psexesvc_start.yml
@@ -15,7 +15,7 @@ detection:
     selection:
         EventID: 4688
         ProcessCommandLine: 'C:\Windows\PSEXESVC.exe'
-    condition: 1 of them
+    condition: selection
 falsepositives:
     - Administrative activity
 level: low

--- a/rules/windows/sysmon/sysmon_win_reg_persistence.yml
+++ b/rules/windows/sysmon/sysmon_win_reg_persistence.yml
@@ -15,7 +15,7 @@ detection:
             - '*\SOFTWARE\Microsoft\Windows NT\CurrentVersion\SilentProcessExit\\*\ReportingMode'
             - '*\SOFTWARE\Microsoft\Windows NT\CurrentVersion\SilentProcessExit\\*\MonitorProcess'
         EventType: 'SetValue'
-    condition: 1 of them
+    condition: selection_reg1
 tags:
     - attack.privilege_escalation
     - attack.persistence

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -108,5 +108,25 @@ class TestRules(unittest.TestCase):
                          "There are rules with duplicate filters")
 
 
+    def test_single_named_condition_with_x_of_them(self):
+        faulty_detections = []
+
+        for file in self.yield_next_rule_file_path(self.path_to_rules):
+            yaml = self.get_rule_yaml(file_path = file)
+            detection = self.get_rule_part(file_path = file, part_name = "detection")
+            
+            has_them_in_condition = "them" in detection["condition"]
+            has_only_one_named_condition = len(detection) == 2
+            not_multipart_yaml_file = len(yaml) == 1
+
+            if has_them_in_condition and \
+                has_only_one_named_condition and \
+                    not_multipart_yaml_file:
+                faulty_detections.append(file)
+
+        self.assertEqual(faulty_detections, [], 
+                         "There are rules using '1/all of them' style conditions but only have one condition")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
I added a test for when a rule uses "1/all of them" style conditions but only has one named condition. 

This one is not a big deal but at least it keeps things consistent.