### PR TITLE
adding MPreter as McAfee classifies it

### DIFF
--- a/rules/windows/malware/av_exploiting.yml
+++ b/rules/windows/malware/av_exploiting.yml
@@ -16,6 +16,7 @@ detection:
     selection:
         Signature: 
             - "*MeteTool*"
+            - "*MPreter*"
             - "*Meterpreter*"
             - "*Metasploit*"
             - "*PowerSploit*"


### PR DESCRIPTION
McAfee classifies some Meterpreter events with the "Mpreter" keyword