### PR TITLE
Update win_susp_process_creations.yml

### DIFF
--- a/rules/windows/builtin/win_susp_process_creations.yml
+++ b/rules/windows/builtin/win_susp_process_creations.yml
@@ -138,3 +138,8 @@ detection:
             # Keyloggers and Password-Stealers abusing NirSoft tools(Limitless Logger, Predator Pain, HawkEye Keylogger, iSpy Keylogger, KeyBase Keylogger)
             - '* /stext *'
             - '* /scomma *'
+            - '* /stab *'
+            - '* /stabular *'
+            - '* /shtml *'
+            - '* /sverhtml *'
+            - '* /sxml *'

--- a/rules/windows/builtin/win_susp_process_creations.yml
+++ b/rules/windows/builtin/win_susp_process_creations.yml
@@ -14,6 +14,7 @@ references:
     - https://subt0x10.blogspot.ca/2017/04/bypassing-application-whitelisting.html
     - https://gist.github.com/subTee/7937a8ef07409715f15b84781e180c46#file-rat-bat
     - https://twitter.com/vector_sec/status/896049052642533376
+    - http://security-research.dyndns.org/pub/slides/FIRST-TC-2018/FIRST-TC-2018_Tom-Ueltschi_Sysmon_PUBLIC.pdf
 author: Florian Roth
 modified: 2018/12/11
 detection:
@@ -134,3 +135,6 @@ detection:
             - '*AddInProcess*'
             # NotPowershell (nps) attack
             # - '*msbuild*'  # too many false positives
+            # Keyloggers and Password-Stealers abusing NirSoft tools(Limitless Logger, Predator Pain, HawkEye Keylogger, iSpy Keylogger, KeyBase Keylogger)
+            - '* /stext *'
+            - '* /scomma *'


### PR DESCRIPTION
I added two comandline keywords for Keyloggers and Password-Stealers abusing NirSoft tools (Limitless Logger, Predator Pain, HawkEye Keylogger, iSpy Keylogger, KeyBase Keylogger)

Example:
CommandLine: <PATH-TO-EXE>\*.exe _**/stext**_ <PATH-TO-TXT>\*.txt
CommandLine: <PATH-TO-EXE>\*.exe _**/scomma**_ ...

Source:
[http://security-research.dyndns.org/pub/slides/FIRST-TC-2018/FIRST-TC-2018_Tom-Ueltschi_Sysmon_PUBLIC.pdf](url)
