### PR TITLE
Add HTTP POST alert type to the Elastalert backend (closes #256)

### DIFF
--- a/tools/sigma/backends/elasticsearch.py
+++ b/tools/sigma/backends/elasticsearch.py
@@ -16,6 +16,8 @@
 
 import json
 import re
+import sys
+
 import sigma
 import yaml
 from .base import BaseBackend, SingleTextQueryBackend
@@ -563,11 +565,22 @@ class ElastalertBackend(MultiRuleOutputMixin, ElasticsearchQuerystringBackend):
     """Elastalert backend"""
     identifier = 'elastalert'
     active = True
+    supported_alert_methods = {'email', 'http_post'}
+
     options = ElasticsearchQuerystringBackend.options + (
+        ("alert_methods", "", "Alert method(s) to use when the rule triggers, comma separated. Supported: " + ', '.join(supported_alert_methods), None),
+
+        # Options for HTTP POST alerting
+        ("http_post_url", None, "Webhook URL used for HTTP POST alert notification", None),
+        ("http_post_include_rule_metadata", None, "Indicates if metadata about the rule which triggered should be included in the paylod of the HTTP POST alert notification", None),
+
+        # Options for email alerting
         ("emails", None, "Email addresses for Elastalert notification, if you want to alert several email addresses put them coma separated", None),
         ("smtp_host", None, "SMTP server address", None),
         ("from_addr", None, "Email sender address", None),
         ("smtp_auth_file", None, "Local path with login info", None),
+
+        # Generic alerting options
         ("realert_time", "0m", "Ignore repeating alerts for a period of time", None),
         ("expo_realert_time", "60m", "This option causes the value of realert to exponentially increase while alerts continue to fire", None)
     )
@@ -644,7 +657,8 @@ class ElastalertBackend(MultiRuleOutputMixin, ElasticsearchQuerystringBackend):
 
             #Handle alert action
             rule_object['alert'] = []
-            if self.emails:
+            alert_methods = self.alert_methods.split(',')
+            if 'email' in alert_methods:
                 rule_object['alert'].append('email')
                 rule_object['email'] = []
                 for address in self.emails.split(','):
@@ -655,6 +669,21 @@ class ElastalertBackend(MultiRuleOutputMixin, ElasticsearchQuerystringBackend):
                     rule_object['from_addr'] = self.from_addr
                 if self.smtp_auth_file:
                     rule_object['smtp_auth_file'] = self.smtp_auth_file
+            if 'http_post' in alert_methods:
+                if self.http_post_url is None:
+                    print('Warning: the Elastalert HTTP POST method is selected but no URL has been provided. This alert method will be ignored', file=sys.stderr)
+                else:
+                    rule_object['alert'].append('post')
+                    rule_object['http_post_url'] = self.http_post_url
+                    if self.http_post_include_rule_metadata:
+                        rule_object['http_post_static_payload'] = {
+                            'sigma_rule_metadata': {
+                                'title': title,
+                                'description': description,
+                                'level': level,
+                                'tags': rule_tag
+                            }
+                        }
             #If alert is not define put debug as default
             if len(rule_object['alert']) == 0:
                 rule_object['alert'].append('debug')


### PR DESCRIPTION
## Goal 

This PR adds:
- The ability to have multiple alert types in the generated elastalert alert
- Support for the [HTTP POST](https://elastalert.readthedocs.io/en/latest/ruletypes.html#http-post) elastalert alert type

## Sample usage

With a simple rule `logs_cleared.yml`:

```yaml
title: Windows security event logs cleared
description: Detects when security logs are cleared
tags:
  - defense evasion
logsource: 
  product: windows
detection:
  selection: 
    EventID: 1102
  condition: selection
level: high
```

```
$ python3 tools/sigmac logs_cleared.yml -c config.yml \
    -t elastalert \
    -O alert_methods=http_post \
    -O http_post_url=http://127.0.0.1:4444 \
    -O http_post_include_rule_metadata
```

Result:

```yaml
alert:
- post
description: Detects when security logs are cleared
filter:
- query:
    query_string:
      query: EventID:"1102"
http_post_static_payload:
  sigma_rule_metadata:
    description: Detects when security logs are cleared
    level: high
    tags:
    - defense evasion
    title: Windows security event logs cleared
http_post_url: http://127.0.0.1:4444
index: windows_*
name: Windows-security-event-logs-cleared_0
priority: 2
realert:
  minutes: 0
type: any
``` 

Other example using both e-mail and HTTP POST alert types:

```
$ python3 tools/sigmac logs_cleared.yml -c config.yml \
    -t elastalert \
    -O alert_methods=http_post,email \
    -O emails=alert@mydomain.tld \
    -O http_post_url=http://127.0.0.1:4444
```

Result: 

```yaml
alert:
- email
- post
description: Detects when security logs are cleared
email:
- alert@mydomain.tld
filter:
- query:
    query_string:
      query: EventID:"1102"
http_post_url: http://127.0.0.1:4444
index: windows_*
name: Windows-security-event-logs-cleared_0
priority: 2
realert:
  minutes: 0
type: any
```

Here is a sample alert sent by elastalert on `127.0.0.1:4444` once this rule triggers:

```json
{
    "Category": "Log clear",
    "ProcessID": "1340",
    "Hostname": "DESKTOP-9I0OJG2",
    "_type": "message",
    "sigma_rule_metadata": {
        "title": "test rule",
        "tags": [
            "evasion"
        ],
        "description": "",
        "level": "high"
    },
    "Channel": "Security",
    "EventTime": "2019-02-23",
    "timestamp": "2019-02-23T13:02:58.252Z",
    "EventID": "1102",
    "_index": "windows_0",
}
```
## Other

Additional more advanced options can be provided to Elastalert via its config file when it is run (`http_post_payload`, `http_post_proxy`, `http_post_all_values`, `http_post_timeout`) 