### PR TITLE
Added a detection path through process spawn

### DIFF
--- a/rules/windows/sysmon/sysmon_sysinternals_eula_accepted.yml
+++ b/rules/windows/sysmon/sysmon_sysinternals_eula_accepted.yml
@@ -9,10 +9,13 @@ logsource:
     product: windows
     service: sysmon
 detection:
-    selection:
+    selection1:
         EventID: 13
         TargetObject: '*\EulaAccepted'
-    condition: selection
+    selection2:
+        EventID: 1
+        CommandLine: '* -accepteula*'
+    condition: selection1 or selection2
 falsepositives:
     - Legitimate use of SysInternals tools
     - Programs that use the same Registry Key


### PR DESCRIPTION
Mostly inspired by "Ps.exe Renamed SysInternals Tool". This provides another method to detect Sysinternals tools if the registry change was missed for whatever reason.

Tested. Only fires on what it should fire on.