### PR TITLE
Create win_rdp_session_hijacking.yml

### DIFF
--- a/rules/windows/builtin/win_rdp_session_hijacking.yml
+++ b/rules/windows/builtin/win_rdp_session_hijacking.yml
@@ -1,0 +1,24 @@
+title: RDP Session Hijacking detection
+description: Adversaries may perform RDP session hijacking which involves stealing a legitimate user's remote session.
+references:
+    - http://blog.gentilkiwi.com/securite/vol-de-session-rdp
+    - http://www.korznikov.com/2017/03/0-day-or-feature-privilege-escalation.html
+date: 2019/02/27
+modified: 2019/02/27
+tags:
+    - attack.lateral_movement
+status: experimental
+author: vburov
+logsource:
+    product: windows
+    service: security
+definition: 'Requirements: Audit Policy : Detailed Tracking > Audit Process creation, Group Policy : Administrative Templates\System\Audit Process Creation'
+detection:
+    selection:
+        EventID: 4688
+        NewProcessName: "*\tscon.exe"
+        SecurityID: "System"
+    condition: selection
+falsepositives:
+    - Unknown
+level: high


### PR DESCRIPTION
Adversaries may perform RDP session hijacking which involves stealing a legitimate user's remote session. With System permissions and using Terminal Services Console, an adversary can hijack a session without the need for credentials or prompts to the user. This can be done remotely or locally and with active or disconnected sessions. It can also lead to Remote System Discovery and Privilege Escalation by stealing a Domain Admin or higher privileged account session. 
This rule will detects the execution of Terminal Services Console under LocalSystem.