### PR TITLE
Added two common paths to mssecex.exe to reduce FPs

### DIFF
--- a/rules/windows/builtin/win_plugx_susp_exe_locations.yml
+++ b/rules/windows/builtin/win_plugx_susp_exe_locations.yml
@@ -92,7 +92,10 @@ detection:
         CommandLine: '*\msseces.exe'
     filter_msseces:
         EventID: 4688
-        CommandLine: '*\Microsoft Security Center\\*'
+        CommandLine: 
+        - '*\Microsoft Security Center\\*'
+        - '*\Microsoft Security Client\\*'
+        - '*\Microsoft Security Essentials\\*'
 
     # Microsoft Office 2003 OInfo
     selection_oinfo:

--- a/rules/windows/sysmon/sysmon_plugx_susp_exe_locations.yml
+++ b/rules/windows/sysmon/sysmon_plugx_susp_exe_locations.yml
@@ -90,7 +90,10 @@ detection:
         Image: '*\msseces.exe'
     filter_msseces:
         EventID: 1
-        Image: '*\Microsoft Security Center\\*'
+        Image:
+        - '*\Microsoft Security Center\\*'
+        - '*\Microsoft Security Client\\*'
+        - '*\Microsoft Security Essentials\\*'
 
     # Microsoft Office 2003 OInfo
     selection_oinfo:


### PR DESCRIPTION
Added two entries to the msseces.exe filter to include two other legitimate paths the binary may reside in.
This should reduce False positives

\*\Microsoft Security Client\\\*
\*\Microsoft Security Essentials\\\*


ref:
https://www.file.net/process/msseces.exe.html
https://answers.microsoft.com/en-us/protect/forum/all/what-is-mssecesexe-hide-runkey/4df575f4-812e-4b02-bd89-90f9c9dba91a