### PR TITLE
Fixing typo in technique

### DIFF
--- a/rules/windows/sysmon/sysmon_ssp_added_lsa_config.yml
+++ b/rules/windows/sysmon/sysmon_ssp_added_lsa_config.yml
@@ -6,7 +6,7 @@ references:
     - https://powersploit.readthedocs.io/en/latest/Persistence/Install-SSP/
 tags:
     - attack.persistence
-    - attack.t1011
+    - attack.t1101
 author: iwillkeepwatch
 date: 2019/01/18
 logsource:


### PR DESCRIPTION
There is a typo in the tags section which points to Exfiltration Over Other Network Medium technique instead of the Security Support Provider.