### PR TITLE
fix tagging in turla png dropper service rule

### DIFF
--- a/rules/apt/apt_turla_service_png.yml
+++ b/rules/apt/apt_turla_service_png.yml
@@ -5,9 +5,9 @@ references:
 author: Florian Roth
 date: 2018/11/23
 tags:
-    - attack.command_and_control
-    - attack.g0016
-    - attack.t1172
+    - attack.persistence
+    - attack.g0010
+    - attack.t1050
 logsource:
     product: windows
     service: system


### PR DESCRIPTION
Fixed tagging in Turla PNG Dropper Service rule with correct group (Turla, `attack.g0010`) and technique usage (New Service, `attack.t1050`).