### PR TITLE
Process create

### DIFF
--- a/rules/apt/apt_apt29_thinktanks.yml
+++ b/rules/apt/apt_apt29_thinktanks.yml
@@ -1,32 +1,16 @@
----
-action: global
 title: APT29 
 description: 'This method detects a suspicious powershell command line combination as used by APT29 in a campaign against US think tanks' 
 references:
     - https://cloudblogs.microsoft.com/microsoftsecure/2018/12/03/analysis-of-cyberattack-on-u-s-think-tanks-non-profits-public-sector-by-unidentified-attackers/
-logsource:
-    product: windows
 author: Florian Roth
 date: 2018/12/04 
+logsource:
+    category: process_creation
+    product: windows
 detection:
+    selection:
+        CommandLine: '*-noni -ep bypass $*'
     condition: selection
 falsepositives:
     - unknown
 level: critical
----
-logsource:
-    product: windows
-    service: sysmon
-detection:
-    selection:
-        EventID: 1
-        CommandLine: '*-noni -ep bypass $*'
----
-logsource:
-    product: windows
-    service: security
-    description: 'Requirements: Audit Policy : Detailed Tracking > Audit Process creation, Group Policy : Administrative Templates\System\Audit Process Creation'
-detection:
-    selection:
-        EventID: 4688
-        ProcessCommandLine: '*-noni -ep bypass $*'

--- a/rules/apt/apt_cloudhopper.yml
+++ b/rules/apt/apt_cloudhopper.yml
@@ -8,11 +8,10 @@ tags:
     - attack.g0045
     - attack.t1064
 logsource:
+    category: process_creation
     product: windows
-    service: sysmon
 detection:
     selection:
-        EventID: 1
         Image: '*\cscript.exe'
         CommandLine: '*.vbs /shell *'
     condition: selection

--- a/rules/apt/apt_dragonfly.yml
+++ b/rules/apt/apt_dragonfly.yml
@@ -1,5 +1,3 @@
----
-action: global
 title: CrackMapExecWin 
 description: Detects CrackMapExecWin Activity as Described by NCSC
 status: experimental
@@ -8,31 +6,14 @@ references:
 tags:
     - attack.g0035
 author: Markus Neis
+logsource:
+    category: process_creation
+    product: windows
 detection:
-    condition: 1 of them
+    selection:
+        Image:
+            - '*\crackmapexec.exe'
+    condition: selection
 falsepositives: 
     - None 
 level: critical
----
-# Windows Audit Log
-logsource:
-    product: windows
-    service: security
-    definition: 'Requirements: Audit Policy : Detailed Tracking > Audit Process creation, Group Policy : Administrative Templates\System\Audit Process Creation'
-detection:
-    selection1:
-        # Does not require group policy 'Audit Process Creation' > Include command line in process creation events
-        EventID: 4688
-        NewProcessName:
-            - '*\crackmapexec.exe'
----
-# Sysmon
-logsource:
-    product: windows
-    service: sysmon
-detection:
-    selection1:
-        # Does not require group policy 'Audit Process Creation' > Include command line in process creation events
-        EventID: 1
-        Image:
-            - '*\crackmapexec.exe'

--- a/rules/apt/apt_elise.yml
+++ b/rules/apt/apt_elise.yml
@@ -10,15 +10,13 @@ tags:
 author: Florian Roth
 date: 2018/01/31
 logsource:
+    category: process_creation
     product: windows
-    service: sysmon
 detection:
     selection1:
-        EventID: 1
         Image: 'C:\Windows\SysWOW64\cmd.exe'
         CommandLine: '*\Windows\Caches\NavShExt.dll *'
     selection2:
-        EventID: 1
         CommandLine: '*\AppData\Roaming\MICROS~1\Windows\Caches\NavShExt.dll,Setting'
     condition: 1 of them
 falsepositives:

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -9,6 +9,7 @@ Run using the command
 import os
 import unittest
 import yaml
+import re
 
 class TestRules(unittest.TestCase):
     MITRE_TECHNIQUES = ["t1075", "t1189", "t1190", "t1200", "t1091", "t1193", "t1192", "t1194", "t1195", "t1199", "t1078", "t1155", "t1191", "t1059", "t1223", "t1196", "t1173", "t1106", "t1129", "t1203", "t1061", "t1118", "t1152", "t1168", "t1177", "t1170", "t1086", "t1121", "t1117", "t1085", "t1053", "t1064", "t1035", "t1218", "t1216", "t1153", "t1151", "t1072", "t1154", "t1127", "t1204", "t1047", "t1028", "t1220", "t1156", "t1015", "t1098", "t1182", "t1103", "t1138", "t1131", "t1197", "t1067", "t1176", "t1042", "t1109", "t1122", "t1136", "t1038", "t1157", "t1133", "t1044", "t1158", "t1179", "t1062", "t1183", "t1215", "t1159", "t1160", "t1152", "t1161", "t1168", "t1162", "t1037", "t1031", "t1128", "t1050", "t1137", "t1034", "t1150", "t1205", "t1013", "t1163", "t1164", "t1108", "t1060", "t1053", "t1180", "t1101", "t1058", "t1166", "t1023", "t1198", "t1165", "t1019", "t1209", "t1154", "t1078", "t1100", "t1084", "t1004", "t1134", "t1015", "t1182", "t1103", "t1138", "t1088", "t1038", "t1157", "t1068", "t1181", "t1044", "t1179", "t1183", "t1160", "t1050", "t1034", "t1150", "t1013", "t1055", "t1053", "t1058", "t1166", "t1178", "t1165", "t1169", "t1206", "t1078", "t1100", "t1134", "t1009", "t1197", "t1088", "t1146", "t1191", "t1116", "t1223", "t1109", "t1122", "t1196", "t1207", "t1140", "t1089", "t1038", "t1073", "t1211", "t1181", "t1107", "t1222", "t1006", "t1144", "t1158", "t1147", "t1143", "t1148", "t1183", "t1054", "t1066", "t1070", "t1202", "t1130", "t1118", "t1152", "t1149", "t1036", "t1112", "t1170", "t1126", "t1096", "t1027", "t1150", "t1205", "t1186", "t1093", "t1055", "t1108", "t1121", "t1117", "t1014", "t1085", "t1064", "t1218", "t1216", "t1198", "t1045", "t1151", "t1221", "t1099", "t1127", "t1078", "t1102", "t1220", "t1098", "t1139", "t1110", "t1003", "t1081", "t1214", "t1212", "t1187", "t1179", "t1056", "t1141", "t1208", "t1142", "t1171", "t1040", "t1174", "t1145", "t1167", "t1111", "t1087", "t1010", "t1217", "t1083", "t1046", "t1135", "t1040", "t1201", "t1120", "t1069", "t1057", "t1012", "t1018", "t1063", "t1082", "t1016", "t1049", "t1033", "t1124", "t1155", "t1017", "t1175", "t1210", "t1037", "t1097", "t1076", "t1105", "t1021", "t1091", "t1051", "t1184", "t1080", "t1072", "t1077", "t1028", "t1123", "t1119", "t1115", "t1213", "t1005", "t1039", "t1025", "t1074", "t1114", "t1056", "t1185", "t1113", "t1125", "t1020", "t1002", "t1022", "t1030", "t1048", "t1041", "t1011", "t1052", "t1029", "t1043", "t1092", "t1090", "t1094", "t1024", "t1132", "t1001", "t1172", "t1008", "t1188", "t1104", "t1026", "t1079", "t1205", "t1219", "t1105", "t1071", "t1032", "t1095", "t1065", "t1102"]
@@ -197,6 +198,27 @@ class TestRules(unittest.TestCase):
 
         self.assertEqual(faulty_detections, [],
                          "There are detections with 'Source: Eventlog'. This does not add value to the detection.")
+
+
+    def test_event_id_instead_of_process_create(self):
+        faulty_detections = []
+        for file in self.yield_next_rule_file_path(self.path_to_rules):
+            with open(file) as f:
+                for line in f:
+                    if re.search(r'.*EventID: (?:1|4688).*', line) and file not in faulty_detections:
+                        faulty_detections.append(file)
+
+        # Tareq won't enable until all existing rules are migrated to prevent breaking all CI builds
+        # self.assertEqual(faulty_detections, [],
+        #                  "There are rules still using Sysmon 1 or Event ID 4688. Please migrate to the process_creation category.")
+
+        # Report but do not throw an error
+        if faulty_detections:
+            print("The following rules still use Sysmon 1 or Event ID 4688.")
+            print("Please migrate to the process_creation category.")
+            print("List length is: {}".format(len(faulty_detections)))
+            print("------------------------------------------------")
+            print(*faulty_detections, sep='\n')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Added a new test to check if a rule still uses Sysmon 1 or EID 4688. The test does not cause a failure since there are a number of rules that still need updating.

Also, updated four rules to use process_creation, though I quickly realized I need to automate the conversion somehow since the process is so error prone. 