### PR TITLE
ATC windows rules review

### DIFF
--- a/rules/windows/builtin/win_alert_ad_user_backdoors.yml
+++ b/rules/windows/builtin/win_alert_ad_user_backdoors.yml
@@ -8,6 +8,7 @@ author: '@neu5ron'
 tags:
     - attack.t1098
     - attack.credential_access
+    - attack.persistence
 logsource:
     product: windows
     service: security

--- a/rules/windows/builtin/win_alert_enable_weak_encryption.yml
+++ b/rules/windows/builtin/win_alert_enable_weak_encryption.yml
@@ -4,6 +4,9 @@ references:
     - https://adsecurity.org/?p=2053
     - https://www.harmj0y.net/blog/activedirectory/roasting-as-reps/
 author: '@neu5ron'
+tags:
+    - attack.defense_evasion
+    - attack.t1089
 logsource:
     product: windows
     service: security

--- a/rules/windows/builtin/win_mal_creddumper.yml
+++ b/rules/windows/builtin/win_mal_creddumper.yml
@@ -1,3 +1,5 @@
+---
+action: global
 title: Malicious Service Install
 description: This method detects well-known keywords of malicious services in the Windows System Eventlog 
 author: Florian Roth
@@ -24,3 +26,10 @@ detection:
 falsepositives:
     - Unlikely
 level: high
+---
+logsource:
+    product: windows
+    service: security
+detection:
+    selection:
+        EventID: 4697

--- a/rules/windows/builtin/win_rdp_localhost_login.yml
+++ b/rules/windows/builtin/win_rdp_localhost_login.yml
@@ -6,6 +6,7 @@ date: 2019/01/28
 modified: 2019/01/29
 tags:
     - attack.lateral_movement
+    - attack.t1076
 status: experimental
 author: Thomas Patzke
 logsource:

--- a/rules/windows/builtin/win_susp_dhcp_config.yml
+++ b/rules/windows/builtin/win_susp_dhcp_config.yml
@@ -9,6 +9,7 @@ date: 2017/05/15
 author: Dimitrios Slamaris
 tags:
     - attack.defense_evasion
+    - attack.t1073
 logsource:
     product: windows
     service: system

--- a/rules/windows/builtin/win_susp_dhcp_config_failed.yml
+++ b/rules/windows/builtin/win_susp_dhcp_config_failed.yml
@@ -6,6 +6,9 @@ references:
     - https://technet.microsoft.com/en-us/library/cc726884(v=ws.10).aspx
     - https://msdn.microsoft.com/de-de/library/windows/desktop/aa363389(v=vs.85).aspx
 date: 2017/05/15
+tags:
+    - attack.defense_evasion
+    - attack.t1073
 author: Dimitrios Slamaris
 logsource:
     product: windows

--- a/rules/windows/builtin/win_susp_dns_config.yml
+++ b/rules/windows/builtin/win_susp_dns_config.yml
@@ -6,6 +6,9 @@ references:
     - https://medium.com/@esnesenon/feature-not-bug-dnsadmin-to-dc-compromise-in-one-line-a0f779b8dc83
     - https://technet.microsoft.com/en-us/library/cc735829(v=ws.10).aspx
     - https://twitter.com/gentilkiwi/status/861641945944391680
+tags:
+    - attack.defense_evasion
+    - attack.t1073
 author: Florian Roth
 logsource:
     product: windows

--- a/rules/windows/builtin/win_susp_dsrm_password_change.yml
+++ b/rules/windows/builtin/win_susp_dsrm_password_change.yml
@@ -7,6 +7,7 @@ author: Thomas Patzke
 tags:
     - attack.persistence
     - attack.privilege_escalation
+    - attack.t1098
 logsource:
     product: windows
     service: security

--- a/rules/windows/builtin/win_susp_ntlm_auth.yml
+++ b/rules/windows/builtin/win_susp_ntlm_auth.yml
@@ -7,8 +7,8 @@ references:
 author: Florian Roth
 date: 2018/06/08
 tags:
-    - attack.credential_access
-    - attack.t1208
+    - attack.lateral_movement
+    - attack.t1075
 logsource:
     product: windows
     service: ntlm

--- a/rules/windows/builtin/win_susp_sdelete.yml
+++ b/rules/windows/builtin/win_susp_sdelete.yml
@@ -9,7 +9,7 @@ references:
 tags:
     - attack.defense_evasion
     - attack.t1107
-    - attack.t1116
+    - attack.t1066
     - attack.s0195
 logsource:
     product: windows

--- a/rules/windows/builtin/win_susp_time_modification.yml
+++ b/rules/windows/builtin/win_susp_time_modification.yml
@@ -7,6 +7,7 @@ references:
     - Live environment caused by malware
 date: 2019/02/05
 tags:
+    - attack.defense_evasion
     - attack.t1099
 logsource:
     product: windows

--- a/rules/windows/builtin/win_usb_device_plugged.yml
+++ b/rules/windows/builtin/win_usb_device_plugged.yml
@@ -5,6 +5,9 @@ references:
     - https://www.techrepublic.com/article/how-to-track-down-usb-flash-drive-usage-in-windows-10s-event-viewer/
 status: experimental
 author: Florian Roth
+tags:
+    - attack.initial_access
+    - attack.t1200
 logsource:
     product: windows
     service: driver-framework

--- a/rules/windows/builtin/win_user_added_to_local_administrators.yml
+++ b/rules/windows/builtin/win_user_added_to_local_administrators.yml
@@ -4,6 +4,7 @@ status: stable
 author: Florian Roth
 tags:
     - attack.privilege_escalation
+    - attack.t1078
 logsource:
     product: windows
     service: security

--- a/rules/windows/other/win_rare_schtask_creation.yml
+++ b/rules/windows/other/win_rare_schtask_creation.yml
@@ -2,6 +2,7 @@ title: Rare Scheduled Task Creations
 status: experimental
 description: This rule detects rare scheduled task creations. Typically software gets installed on multiple systems and not only on a few. The aggregation and count function selects tasks with rare names. 
 tags:
+    - attack.persistence
     - attack.t1053
     - attack.s0111
 author: Florian Roth

--- a/rules/windows/powershell/powershell_shellcode_b64.yml
+++ b/rules/windows/powershell/powershell_shellcode_b64.yml
@@ -4,7 +4,10 @@ description: Detects Base64 encoded Shellcode
 references:
     - https://twitter.com/cyb3rops/status/1063072865992523776
 tags:
+    - attack.privilege_escalation
     - attack.execution
+    - attack.t1055
+    - attack.t1086
 author: David Ledbetter (shellcode), Florian Roth (rule)
 date: 2018/11/17
 logsource:

--- a/rules/windows/process_creation/powershell_xor_commandline.yml
+++ b/rules/windows/process_creation/powershell_xor_commandline.yml
@@ -3,6 +3,9 @@ description: Detects suspicious powershell process which includes bxor command, 
 status: experimental
 author: Sami Ruohonen
 date: 2018/09/05
+tags:
+    - attack.execution
+    - attack.t1086
 detection:
     selection:
         CommandLine:

--- a/rules/windows/process_creation/win_cmdkey_recon.yml
+++ b/rules/windows/process_creation/win_cmdkey_recon.yml
@@ -5,6 +5,9 @@ references:
     - https://www.peew.pw/blog/2017/11/26/exploring-cmdkey-an-edge-case-for-privilege-escalation
     - https://technet.microsoft.com/en-us/library/cc754243(v=ws.11).aspx
 author: jmallette
+tags:
+    - attack.credential_access
+    - attack.t1003
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_exploit_cve_2015_1641.yml
+++ b/rules/windows/process_creation/win_exploit_cve_2015_1641.yml
@@ -6,6 +6,9 @@ references:
     - https://www.hybrid-analysis.com/sample/5567408950b744c4e846ba8ae726883cb15268a539f3bb21758a466e47021ae8?environmentId=100
 author: Florian Roth
 date: 2018/02/22
+tags:
+    - attack.defense_evasion
+    - attack.1036
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_exploit_cve_2015_1641.yml
+++ b/rules/windows/process_creation/win_exploit_cve_2015_1641.yml
@@ -8,7 +8,7 @@ author: Florian Roth
 date: 2018/02/22
 tags:
     - attack.defense_evasion
-    - attack.1036
+    - attack.t1036
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_exploit_cve_2017_0261.yml
+++ b/rules/windows/process_creation/win_exploit_cve_2017_0261.yml
@@ -5,6 +5,10 @@ references:
     - https://www.fireeye.com/blog/threat-research/2017/05/eps-processing-zero-days.html
 author: Florian Roth
 date: 2018/02/22
+tags:
+  - attack.defense_evasion
+  - attack.privilege_escalation
+  - attack.t1055
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_exploit_cve_2017_11882.yml
+++ b/rules/windows/process_creation/win_exploit_cve_2017_11882.yml
@@ -6,6 +6,9 @@ references:
     - https://www.google.com/url?hl=en&q=https://embedi.com/blog/skeleton-closet-ms-office-vulnerability-you-didnt-know-about&source=gmail&ust=1511481120837000&usg=AFQjCNGdL7gVwLXaNSl2Td8ylDYbSJFmPw
 author: Florian Roth
 date: 2017/11/23
+tags:
+    - attack.defense_evasion
+    - attack.t1211
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_exploit_cve_2017_8759.yml
+++ b/rules/windows/process_creation/win_exploit_cve_2017_8759.yml
@@ -3,6 +3,9 @@ description: Detects Winword starting uncommon sub process csc.exe as used in ex
 references:
     - https://www.hybrid-analysis.com/sample/0b4ef455e385b750d9f90749f1467eaf00e46e8d6c2885c260e1b78211a51684?environmentId=100
     - https://www.reverse.it/sample/0b4ef455e385b750d9f90749f1467eaf00e46e8d6c2885c260e1b78211a51684?environmentId=100
+tags:
+    - attack.execution
+    - attack.t1203
 author: Florian Roth
 date: 15.09.2017
 logsource:

--- a/rules/windows/process_creation/win_lethalhta.yml
+++ b/rules/windows/process_creation/win_lethalhta.yml
@@ -3,6 +3,10 @@ status: experimental
 description: Detects MSHTA.EXE spwaned by SVCHOST described in report
 references:
     - https://codewhitesec.blogspot.com/2018/07/lethalhta.html
+tags:
+    - attack.defense_evasion
+    - attack.execution
+    - attack.t1170
 author: Markus Neis
 date: 2018/06/07
 logsource:

--- a/rules/windows/process_creation/win_mal_adwind.yml
+++ b/rules/windows/process_creation/win_mal_adwind.yml
@@ -8,6 +8,9 @@ references:
 author: Florian Roth, Tom Ueltschi
 date: 2017/11/10
 modified: 2018/12/11
+tags:
+    - attack.execution
+    - attack.t1064
 detection:
     condition: selection
 level: high

--- a/rules/windows/process_creation/win_malware_dridex.yml
+++ b/rules/windows/process_creation/win_malware_dridex.yml
@@ -5,6 +5,10 @@ references:
     - https://app.any.run/tasks/993daa5e-112a-4ff6-8b5a-edbcec7c7ba3
 author: Florian Roth
 date: 2019/01/10
+tags:
+    - attack.defense_evasion
+    - attack.privilege_escalation
+    - attack.t1055
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_malware_script_dropper.yml
+++ b/rules/windows/process_creation/win_malware_script_dropper.yml
@@ -5,7 +5,7 @@ author: Margaritis Dimitrios (idea), Florian Roth (rule)
 tags:
     - attack.defense_evasion
     - attack.execution
-    - attack.1064
+    - attack.t1064
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_malware_script_dropper.yml
+++ b/rules/windows/process_creation/win_malware_script_dropper.yml
@@ -2,6 +2,10 @@ title: WScript or CScript Dropper
 status: experimental
 description: Detects wscript/cscript executions of scripts located in user directories
 author: Margaritis Dimitrios (idea), Florian Roth (rule)
+tags:
+    - attack.defense_evasion
+    - attack.execution
+    - attack.1064
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_netsh_port_fwd.yml
+++ b/rules/windows/process_creation/win_netsh_port_fwd.yml
@@ -5,6 +5,8 @@ references:
 date: 2019/01/29
 tags:
     - attack.lateral_movement
+    - attack.command_and_control
+    - attack.t1090
 status: experimental
 author: Florian Roth
 logsource:

--- a/rules/windows/process_creation/win_netsh_port_fwd_3389.yml
+++ b/rules/windows/process_creation/win_netsh_port_fwd_3389.yml
@@ -5,6 +5,7 @@ references:
 date: 2019/01/29
 tags:
     - attack.lateral_movement
+    - attack.t1021
 status: experimental
 author: Florian Roth
 logsource:

--- a/rules/windows/process_creation/win_plugx_susp_exe_locations.yml
+++ b/rules/windows/process_creation/win_plugx_susp_exe_locations.yml
@@ -6,6 +6,10 @@ references:
     - https://countuponsecurity.com/2017/06/07/threat-hunting-in-the-enterprise-with-appcompatprocessor/
 author: Florian Roth
 date: 2017/06/12
+tags:
+    - attack.s0013
+    - attack.defense_evasion
+    - attack.t1073
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_possible_applocker_bypass.yml
+++ b/rules/windows/process_creation/win_possible_applocker_bypass.yml
@@ -7,6 +7,7 @@ references:
 author: juju4
 tags:
     - attack.defense_evasion
+    - attack.t1088
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_possible_applocker_bypass.yml
+++ b/rules/windows/process_creation/win_possible_applocker_bypass.yml
@@ -7,7 +7,10 @@ references:
 author: juju4
 tags:
     - attack.defense_evasion
-    - attack.t1088
+    - attack.t1118
+    - attack.t1121
+    - attack.t1127
+    - attack.t1170
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_powershell_amsi_bypass.yml
+++ b/rules/windows/process_creation/win_powershell_amsi_bypass.yml
@@ -6,6 +6,7 @@ references:
     - https://www.hybrid-analysis.com/sample/0ced17419e01663a0cd836c9c2eb925e3031ffb5b18ccf35f4dea5d586d0203e?environmentId=120
 tags:
     - attack.execution
+    - attack.defense_evasion
     - attack.t1086
 author: Markus Neis
 date: 2018/08/17

--- a/rules/windows/process_creation/win_sdbinst_shim_persistence.yml
+++ b/rules/windows/process_creation/win_sdbinst_shim_persistence.yml
@@ -7,7 +7,7 @@ tags:
     - attack.persistence
     - attack.t1138
 author: Markus Neis
-date: 2018-08-03
+date: 2018/08/03
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_shell_spawn_susp_program.yml
+++ b/rules/windows/process_creation/win_shell_spawn_susp_program.yml
@@ -6,6 +6,10 @@ references:
 author: Florian Roth
 date: 2018/04/06
 modified: 2019/02/05
+tags:
+    - attack.execution
+    - attack.defense_evasion
+    - attack.t1064
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_susp_bcdedit.yml
+++ b/rules/windows/process_creation/win_susp_bcdedit.yml
@@ -5,6 +5,11 @@ references:
     - https://docs.microsoft.com/en-us/windows-hardware/drivers/devtest/bcdedit--set
 author: '@neu5ron'
 date: 2019/02/07
+tags:
+    - attack.defense_evasion
+    - attack.t1070
+    - attack.persistence
+    - attack.t1067
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_susp_calc.yml
+++ b/rules/windows/process_creation/win_susp_calc.yml
@@ -5,15 +5,16 @@ references:
         - https://twitter.com/ItsReallyNick/status/1094080242686312448
 author: Florian Roth
 date: 2019/02/09
+tags:
+    - attack.defense_evasion
+    - attack.t1036
 logsource:
-        product: windows
+        category: process_creation
         service: sysmon
 detection:
         selection1:
-                EventID: 1
                 CommandLine: '*\calc.exe *'
         selection2:
-                EventID: 1
                 Image: '*\calc.exe'
         filter2:
                 Image: '*\Windows\Sys*'

--- a/rules/windows/process_creation/win_susp_calc.yml
+++ b/rules/windows/process_creation/win_susp_calc.yml
@@ -10,7 +10,7 @@ tags:
     - attack.t1036
 logsource:
         category: process_creation
-        service: sysmon
+        product: windows
 detection:
         selection1:
                 CommandLine: '*\calc.exe *'

--- a/rules/windows/process_creation/win_susp_cmd_http_appdata.yml
+++ b/rules/windows/process_creation/win_susp_cmd_http_appdata.yml
@@ -1,11 +1,13 @@
 title: Command Line Execution with suspicious URL and AppData Strings
 status: experimental
-description: Detects a suspicious command line execution that includes an URL and AppData string in the command line parameters as used by several droppers (js/vbs
-    > powershell)
+description: Detects a suspicious command line execution that includes an URL and AppData string in the command line parameters as used by several droppers (js/vbs > powershell)
 references:
     - https://www.hybrid-analysis.com/sample/3a1f01206684410dbe8f1900bbeaaa543adfcd07368ba646b499fa5274b9edf6?environmentId=100
     - https://www.hybrid-analysis.com/sample/f16c729aad5c74f19784a24257236a8bbe27f7cdc4a89806031ec7f1bebbd475?environmentId=100
 author: Florian Roth
+tags:
+    - attack.execution
+    - attack.t1059
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_susp_commands_recon_activity.yml
+++ b/rules/windows/process_creation/win_susp_commands_recon_activity.yml
@@ -10,8 +10,8 @@ date: 2018/08/22
 modified: 2018/12/11
 tags:
     - attack.discovery
-    - attack.t1073
-    - attack.t1012
+    - attack.t1087
+    - attack.t1082
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_susp_control_dll_load.yml
+++ b/rules/windows/process_creation/win_susp_control_dll_load.yml
@@ -5,6 +5,10 @@ author: Florian Roth
 date: 2017/04/15
 references:
     - https://twitter.com/rikvduijn/status/853251879320662017
+tags:
+    - attack.defense_evasion
+    - attack.t1073
+    - attack.t1085
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_susp_exec_folder.yml
+++ b/rules/windows/process_creation/win_susp_exec_folder.yml
@@ -8,6 +8,9 @@ references:
     - https://github.com/mbevilacqua/appcompatprocessor/blob/master/AppCompatSearch.txt
     - https://www.secureworks.com/research/bronze-butler-targets-japanese-businesses
     - https://www.crowdstrike.com/resources/reports/2019-crowdstrike-global-threat-report/
+tags:
+    - attack.defense_evasion
+    - attack.t1036
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_susp_execution_path.yml
+++ b/rules/windows/process_creation/win_susp_execution_path.yml
@@ -2,6 +2,9 @@ title: Execution in Non-Executable Folder
 status: experimental
 description: Detects a suspicious exection from an uncommon folder
 author: Florian Roth
+tags:
+    - attack.defense_evasion
+    - attack.t1036
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_susp_execution_path_webserver.yml
+++ b/rules/windows/process_creation/win_susp_execution_path_webserver.yml
@@ -2,6 +2,9 @@ title: Execution in Webserver Root Folder
 status: experimental
 description: Detects a suspicious program execution in a web service root folder (filter out false positives)
 author: Florian Roth
+tags:
+    - attack.persistence
+    - attack.1100
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_susp_execution_path_webserver.yml
+++ b/rules/windows/process_creation/win_susp_execution_path_webserver.yml
@@ -4,7 +4,7 @@ description: Detects a suspicious program execution in a web service root folder
 author: Florian Roth
 tags:
     - attack.persistence
-    - attack.1100
+    - attack.t1100
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_susp_gup.yml
+++ b/rules/windows/process_creation/win_susp_gup.yml
@@ -3,6 +3,9 @@ description: Detects execution of the Notepad++ updater in a suspicious director
 status: experimental
 references:
     - https://www.fireeye.com/blog/threat-research/2018/09/apt10-targeting-japanese-corporations-using-updated-ttps.html
+tags:
+  - attack.defense_evasion
+  - attack.t1073
 author: Florian Roth
 date: 2019/02/06
 logsource:

--- a/rules/windows/process_creation/win_susp_mmc_source.yml
+++ b/rules/windows/process_creation/win_susp_mmc_source.yml
@@ -3,6 +3,9 @@ status: experimental
 description: Processes started by MMC could be a sign of lateral movement using MMC application COM object
 references:
     - https://enigma0x3.net/2017/01/05/lateral-movement-using-the-mmc20-application-com-object/
+tags:
+    - attack.lateral_movement
+    - attack.t1175
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_susp_msiexec_web_install.yml
+++ b/rules/windows/process_creation/win_susp_msiexec_web_install.yml
@@ -1,8 +1,10 @@
 title: MsiExec Web Install
 status: experimental
-description: Detects suspicious msiexec proess starts with web addreses as parameter
+description: Detects suspicious msiexec process starts with web addreses as parameter
 references:
     - https://blog.trendmicro.com/trendlabs-security-intelligence/attack-using-windows-installer-msiexec-exe-leads-lokibot/
+tags:
+  - attack.defense_evasion
 author: Florian Roth
 date: 2018/02/09
 modified: 2012/12/11

--- a/rules/windows/process_creation/win_susp_ping_hex_ip.yml
+++ b/rules/windows/process_creation/win_susp_ping_hex_ip.yml
@@ -5,6 +5,10 @@ references:
     - https://twitter.com/vysecurity/status/977198418354491392
 author: Florian Roth
 date: 2018/03/23
+tags:
+    - attack.defense_evasion
+    - attack.t1140
+    - attack.t1027
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_susp_powershell_enc_cmd.yml
+++ b/rules/windows/process_creation/win_susp_powershell_enc_cmd.yml
@@ -5,6 +5,9 @@ references:
     - https://app.any.run/tasks/6217d77d-3189-4db2-a957-8ab239f3e01e
 author: Florian Roth, Markus Neis
 date: 2018/09/03
+tags:
+  - attack.execution
+  - attack.t1086
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_susp_prog_location_process_starts.yml
+++ b/rules/windows/process_creation/win_susp_prog_location_process_starts.yml
@@ -3,6 +3,9 @@ status: experimental
 description: Detects programs running in suspicious files system locations
 references:
     - https://docs.google.com/spreadsheets/d/17pSTDNpa0sf6pHeRhusvWG6rThciE8CsXTSlDUAZDyo
+tags:
+    - attack.defense_evasion
+    - attack.t1036
 author: Florian Roth
 date: 2019/01/15
 logsource:

--- a/rules/windows/process_creation/win_susp_ps_appdata.yml
+++ b/rules/windows/process_creation/win_susp_ps_appdata.yml
@@ -4,6 +4,9 @@ description: Detects a suspicious command line execution that invokes PowerShell
 references:
     - https://twitter.com/JohnLaTwC/status/1082851155481288706
     - https://app.any.run/tasks/f87f1c4e-47e2-4c46-9cf4-31454c06ce03
+tags:
+    - attack.execution
+    - attack.t1086
 author: Florian Roth
 date: 2019/01/09
 logsource:

--- a/rules/windows/process_creation/win_susp_rasdial_activity.yml
+++ b/rules/windows/process_creation/win_susp_rasdial_activity.yml
@@ -4,6 +4,10 @@ status: experimental
 references:
     - https://twitter.com/subTee/status/891298217907830785
 author: juju4
+tags:
+    - attack.defense_evasion
+    - attack.execution
+    - attack.t1064
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_susp_recon_activity.yml
+++ b/rules/windows/process_creation/win_susp_recon_activity.yml
@@ -2,6 +2,9 @@ title: Suspicious Reconnaissance Activity
 status: experimental
 description: Detects suspicious command line activity on Windows systems
 author: Florian Roth
+tags:
+    - attack.discovery
+    - attack.t1087
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_susp_script_execution.yml
+++ b/rules/windows/process_creation/win_susp_script_execution.yml
@@ -2,6 +2,9 @@ title: WSF/JSE/JS/VBA/VBE File Execution
 status: experimental
 description: Detects suspicious file execution by wscript and cscript
 author: Michael Haag
+tags:
+    - attack.execution
+    - attack.t1064
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_susp_svchost.yml
+++ b/rules/windows/process_creation/win_susp_svchost.yml
@@ -1,6 +1,9 @@
 title: Suspicious Svchost Process
 status: experimental
 description: Detects a suspicious svchost process start
+tags:
+    - attack.defense_evasion
+    - attack.t1036
 author: Florian Roth
 date: 2017/08/15
 logsource:

--- a/rules/windows/process_creation/win_susp_svchost.yml
+++ b/rules/windows/process_creation/win_susp_svchost.yml
@@ -20,8 +20,6 @@ detection:
 fields:
     - CommandLine
     - ParentCommandLine
-tags:
-    - attack.defense_evasion
 falsepositives:
     - Unknown
 level: high

--- a/rules/windows/process_creation/win_susp_sysprep_appdata.yml
+++ b/rules/windows/process_creation/win_susp_sysprep_appdata.yml
@@ -4,6 +4,8 @@ description: Detects suspicious sysprep process start with AppData folder as tar
 references:
     - https://www.symantec.com/blogs/threat-intelligence/thrip-hits-satellite-telecoms-defense-targets
     - https://app.any.run/tasks/61a296bb-81ad-4fee-955f-3b399f4aaf4b
+tags:
+    - attack.execution
 author: Florian Roth
 date: 2018/06/22
 modified: 2018/12/11

--- a/rules/windows/process_creation/win_susp_taskmgr_localsystem.yml
+++ b/rules/windows/process_creation/win_susp_taskmgr_localsystem.yml
@@ -1,6 +1,9 @@
 title: Taskmgr as LOCAL_SYSTEM
 status: experimental
 description: Detects the creation of taskmgr.exe process in context of LOCAL_SYSTEM
+tags:
+    - attack.defense_evasion
+    - attack.t1036
 author: Florian Roth
 date: 2018/03/18
 logsource:

--- a/rules/windows/process_creation/win_susp_taskmgr_parent.yml
+++ b/rules/windows/process_creation/win_susp_taskmgr_parent.yml
@@ -1,6 +1,9 @@
 title: Taskmgr as Parent
 status: experimental
 description: Detects the creation of a process from Windows task manager
+tags:
+    - attack.defense_evasion
+    - attack.t1036
 author: Florian Roth
 date: 2018/03/13
 logsource:

--- a/rules/windows/process_creation/win_susp_tscon_localsystem.yml
+++ b/rules/windows/process_creation/win_susp_tscon_localsystem.yml
@@ -6,6 +6,9 @@ references:
     - https://medium.com/@networksecurity/rdp-hijacking-how-to-hijack-rds-and-remoteapp-sessions-transparently-to-move-through-an-da2a1e73a5f6
 author: Florian Roth
 date: 2018/03/17
+tags:
+    - attack.command_and_control
+    - attack.t1219
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_susp_tscon_rdp_redirect.yml
+++ b/rules/windows/process_creation/win_susp_tscon_rdp_redirect.yml
@@ -4,6 +4,10 @@ description: Detects a suspicious RDP session redirect using tscon.exe
 references:
     - http://www.korznikov.com/2017/03/0-day-or-feature-privilege-escalation.html
     - https://medium.com/@networksecurity/rdp-hijacking-how-to-hijack-rds-and-remoteapp-sessions-transparently-to-move-through-an-da2a1e73a5f6
+tags:
+    - attack.lateral_movement
+    - attack.privilege_escalation
+    - attack.t1076
 author: Florian Roth
 date: 2018/03/17
 modified: 2018/12/11

--- a/rules/windows/process_creation/win_system_exe_anomaly.yml
+++ b/rules/windows/process_creation/win_system_exe_anomaly.yml
@@ -29,8 +29,6 @@ detection:
             - '*\System32\\*'
             - '*\SysWow64\\*'
     condition: selection and not filter
-tags:
-    - attack.defense_evasion
 falsepositives:
     - Exotic software
 level: high

--- a/rules/windows/process_creation/win_system_exe_anomaly.yml
+++ b/rules/windows/process_creation/win_system_exe_anomaly.yml
@@ -5,6 +5,9 @@ references:
     - https://twitter.com/GelosSnake/status/934900723426439170
 author: Florian Roth
 date: 2017/11/27
+tags:
+    - attack.defense_evasion
+    - attack.t1036
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_vul_java_remote_debugging.yml
+++ b/rules/windows/process_creation/win_vul_java_remote_debugging.yml
@@ -1,6 +1,9 @@
 title: Java Running with Remote Debugging
 description: Detects a JAVA process running with remote debugging allowing more than just localhost to connect
 author: Florian Roth
+tags:
+    - attack.discovery
+    - attack.t1046
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_workflow_compiler.yml
+++ b/rules/windows/process_creation/win_workflow_compiler.yml
@@ -4,6 +4,7 @@ description: Detects invocation of Microsoft Workflow Compiler, which may permit
 tags:
     - attack.defense_evasion
     - attack.execution
+    - attack.t1127
 author: Nik Seetharaman
 references:
     - https://posts.specterops.io/arbitrary-unsigned-code-execution-vector-in-microsoft-workflow-compiler-exe-3d9294bc5efb

--- a/rules/windows/sysmon/sysmon_cobaltstrike_process_injection.yml
+++ b/rules/windows/sysmon/sysmon_cobaltstrike_process_injection.yml
@@ -2,6 +2,9 @@ title: CobaltStrike Process Injection
 description: Detects a possible remote threat creation with certain characteristics which are typical for Cobalt Strike beacons 
 references:
     - https://medium.com/@olafhartong/cobalt-strike-remote-threads-detection-206372d11d0f
+tags:
+    - attack.defense_evasion
+    - attack.t1055
 status: experimental
 author: Olaf Hartong, Florian Roth
 logsource:
@@ -12,9 +15,6 @@ detection:
         EventID: 8
         TargetProcessAddress: '*0B80'
     condition: selection
-tags:
-    - attack.defense_evasion
-    - attack.t1055
 falsepositives:
     - unknown
 level: high

--- a/rules/windows/sysmon/sysmon_cobaltstrike_process_injection.yml
+++ b/rules/windows/sysmon/sysmon_cobaltstrike_process_injection.yml
@@ -13,7 +13,7 @@ detection:
         TargetProcessAddress: '*0B80'
     condition: selection
 tags:
-    - attack.process_injection
+    - attack.defense_evasion
     - attack.t1055
 falsepositives:
     - unknown

--- a/rules/windows/sysmon/sysmon_dhcp_calloutdll.yml
+++ b/rules/windows/sysmon/sysmon_dhcp_calloutdll.yml
@@ -7,6 +7,10 @@ references:
     - https://msdn.microsoft.com/de-de/library/windows/desktop/aa363389(v=vs.85).aspx
 date: 2017/05/15
 author: Dimitrios Slamaris
+tags:
+    - attack.defense_evasion
+    - attack.t1073
+    - attack.t1112
 logsource:
     product: windows
     service: sysmon

--- a/rules/windows/sysmon/sysmon_dns_serverlevelplugindll.yml
+++ b/rules/windows/sysmon/sysmon_dns_serverlevelplugindll.yml
@@ -5,6 +5,9 @@ references:
     - https://medium.com/@esnesenon/feature-not-bug-dnsadmin-to-dc-compromise-in-one-line-a0f779b8dc83
 date: 2017/05/08
 author: Florian Roth
+tags:
+    - attack.defense_evasion
+    - attack.t1073
 logsource:
     product: windows
     service: sysmon

--- a/rules/windows/sysmon/sysmon_ghostpack_safetykatz.yml
+++ b/rules/windows/sysmon/sysmon_ghostpack_safetykatz.yml
@@ -7,7 +7,7 @@ tags:
     - attack.credential_access
     - attack.t1003
 author: Markus Neis
-date: 2018/24/07
+date: 2018/07/24
 logsource:
     product: windows
     service: sysmon

--- a/rules/windows/sysmon/sysmon_logon_scripts_userinitmprlogonscript.yml
+++ b/rules/windows/sysmon/sysmon_logon_scripts_userinitmprlogonscript.yml
@@ -14,10 +14,10 @@ logsource:
 detection:
     exec_selection:
         EventID: 1
-        ParentImage: userinit.exe
+        ParentImage: '*\userinit.exe'
     exec_exclusion:
-        Image: explorer.exe
-        CommandLine: netlogon.bat
+        Image: '*\explorer.exe'
+        CommandLine: '*\netlogon.bat'
     create_selection:
         EventID:
             - 1

--- a/rules/windows/sysmon/sysmon_malware_backconnect_ports.yml
+++ b/rules/windows/sysmon/sysmon_malware_backconnect_ports.yml
@@ -5,6 +5,9 @@ references:
     - https://docs.google.com/spreadsheets/d/17pSTDNpa0sf6pHeRhusvWG6rThciE8CsXTSlDUAZDyo
 author: Florian Roth
 date: 2017/03/19
+tags:
+    - attack.command_and_control
+    - attack.t1043
 logsource:
     product: windows
     service: sysmon
@@ -85,7 +88,7 @@ detection:
             - '172.29.*'
             - '172.30.*'
             - '172.31.*'
-            - '127.0.0.1'
+            - '127.*'
         DestinationIsIpv6: 'false'
     condition: selection and not ( filter1 or filter2 )
 falsepositives:

--- a/rules/windows/sysmon/sysmon_malware_verclsid_shellcode.yml
+++ b/rules/windows/sysmon/sysmon_malware_verclsid_shellcode.yml
@@ -3,6 +3,10 @@ status: experimental
 description: Detects a process access to verclsid.exe that injects shellcode from a Microsoft Office application / VBA macro
 references:
     - https://twitter.com/JohnLaTwC/status/837743453039534080
+tags:
+    - attack.defense_evasion
+    - attack.privilege_escalation
+    - attack.t1055
 author: John Lambert (tech), Florian Roth (rule)
 date: 2017/03/04
 logsource:

--- a/rules/windows/sysmon/sysmon_mimikatz_detection_lsass.yml
+++ b/rules/windows/sysmon/sysmon_mimikatz_detection_lsass.yml
@@ -6,7 +6,6 @@ references:
 tags:
     - attack.t1003
     - attack.s0002
-    - attack.lateral_movement
     - attack.credential_access
 logsource:
     product: windows

--- a/rules/windows/sysmon/sysmon_mimikatz_inmemory_detection.yml
+++ b/rules/windows/sysmon/sysmon_mimikatz_inmemory_detection.yml
@@ -5,6 +5,7 @@ references:
     - https://securityriskadvisors.com/blog/post/detecting-in-memory-mimikatz/
 tags:
     - attack.s0002
+    - attack.t1003
     - attack.lateral_movement
     - attack.credential_access
 logsource:

--- a/rules/windows/sysmon/sysmon_quarkspw_filedump.yml
+++ b/rules/windows/sysmon/sysmon_quarkspw_filedump.yml
@@ -5,6 +5,9 @@ references:
     - https://jpcertcc.github.io/ToolAnalysisResultSheet/details/QuarksPWDump.htm
 author: Florian Roth
 date: 2018/02/10
+tags:
+  - attack.credential_access
+  - attack.t1003
 level: critical
 logsource:
     product: windows

--- a/rules/windows/sysmon/sysmon_rundll32_net_connections.yml
+++ b/rules/windows/sysmon/sysmon_rundll32_net_connections.yml
@@ -36,7 +36,7 @@ detection:
             - '172.29.*'
             - '172.30.*'
             - '172.31.*'
-            - '127.0.0.1'
+            - '127.*'
     condition: selection and not filter
 falsepositives:
     - Communication to other corporate systems that use IP addresses from public address spaces

--- a/rules/windows/sysmon/sysmon_susp_driver_load.yml
+++ b/rules/windows/sysmon/sysmon_susp_driver_load.yml
@@ -2,9 +2,8 @@ title: Suspicious Driver Load from Temp
 description: Detects a driver load from a temporary directory
 author: Florian Roth
 tags: 
-  - attack.execution
   - attack.persistence
-  - attack.t1177
+  - attack.t1050
 logsource:
     product: windows
     service: sysmon

--- a/rules/windows/sysmon/sysmon_susp_driver_load.yml
+++ b/rules/windows/sysmon/sysmon_susp_driver_load.yml
@@ -1,6 +1,10 @@
 title: Suspicious Driver Load from Temp
 description: Detects a driver load from a temporary directory
 author: Florian Roth
+tags: 
+  - attack.execution
+  - attack.persistence
+  - attack.t1177
 logsource:
     product: windows
     service: sysmon

--- a/rules/windows/sysmon/sysmon_susp_file_characteristics.yml
+++ b/rules/windows/sysmon/sysmon_susp_file_characteristics.yml
@@ -7,8 +7,9 @@ references:
 author: Markus Neis
 date: 2018/11/22
 tags:
-    - attack.credential_access
-    - attack.t1208
+    - attack.defense_evasion
+    - attack.execution
+    - attack.t1064
 logsource:
     product: windows
     service: sysmon

--- a/rules/windows/sysmon/sysmon_susp_image_load.yml
+++ b/rules/windows/sysmon/sysmon_susp_image_load.yml
@@ -5,6 +5,9 @@ references:
     - https://cyberwardog.blogspot.com/2017/03/chronicles-of-threat-hunter-hunting-for.html
 author: Markus Neis
 date: 2018/01/07
+tags:
+    - attack.defense_evasion
+    - attack.t1073
 logsource:
     product: windows
     service: sysmon

--- a/rules/windows/sysmon/sysmon_win_binary_github_com.yml
+++ b/rules/windows/sysmon/sysmon_win_binary_github_com.yml
@@ -5,6 +5,9 @@ references:
     - https://twitter.com/M_haggis/status/900741347035889665
     - https://twitter.com/M_haggis/status/1032799638213066752
 author: Michael Haag (idea), Florian Roth (rule)
+tags:
+    - attack.lateral_movement
+    - attack.t1105
 logsource:
     product: windows
     service: sysmon

--- a/rules/windows/sysmon/sysmon_win_binary_susp_com.yml
+++ b/rules/windows/sysmon/sysmon_win_binary_susp_com.yml
@@ -6,6 +6,9 @@ references:
     - https://twitter.com/M_haggis/status/1032799638213066752
 author: Florian Roth
 date: 2018/08/30
+tags:
+    - attack.lateral_movement
+    - attack.t1105
 logsource:
     product: windows
     service: sysmon


### PR DESCRIPTION
Hello guys. We've reviewed your windows rules and made some changes, added tags an have a few proposals regarding some rules specifically:

### [Relevant Anti-Virus Event](https://github.com/Neo23x0/sigma/blob/c3d582bc132c82cd0af85abc431d4785817cf545/rules/windows/builtin/win_av_relevant_match.yml)

This rule should be split into multiple rules by tactic/technique.
For example "Portscan" should go to rule about Network Service Scanning (T1046), mimikatz to Credential Dumping/Kerberoasting/etc (T1003/T1208).
Of course it's not possible to clearly define tactic/technique for all av signatures listed in the rule, but it's important to make it as contextualised as possible.

### [Net.exe Execution](https://github.com/Neo23x0/sigma/blob/99b15edf8add183543ca5738ec93f87416c34bd9/rules/windows/process_creation/win_susp_net_execution.yml)

This rule should be split into multiple rules by tactic/technique.
For example execution of "net" with "localgroup" is Account Discovery (T1087), "net use" is System Network Connections Discovery (T1049) etc.
It impossible for now to clearly define tactic/technique, in other words this rule will generate alerts which will not provide enough context for Analysts.
We cannot rewrite this rule into multiple because we have developed them for internal SOC already.

### [Suspicious WMI execution](https://github.com/Neo23x0/sigma/blob/99b15edf8add183543ca5738ec93f87416c34bd9/rules/windows/process_creation/win_susp_wmi_execution.yml)

This rule should be split into multiple rules by tactic/technique.
For example execution of "wmic" with "shadowcopy delete" is nothing but Indicator Removal on Host (T1070), "wmic" with "AntiVirusProduct"/"FirewallProduct" is Security Software Discovery (T1063) etc.
It impossible for now to clearly define tactic/technique, in other words this rule will generate alerts which will not provide enough context for Analysts.
We cannot rewrite this rule into multiple because we have developed them for internal SOC already.

### [Mimikatz Detection LSASS Access](https://github.com/Neo23x0/sigma/blob/81515b530cc8e359d5fa3df541145c2670ba9229/rules/windows/sysmon/sysmon_mimikatz_detection_lsass.yml)

This rule can be enhanced with Windows Events (at least one specific event).
We cannot enhance this rule because we have developed it for internal SOC already.

### [Suspicious PowerShell Download](https://github.com/Neo23x0/sigma/blob/0fa914139ca85966b49f0a8eda40a3f26608e86b/rules/windows/powershell/powershell_suspicious_download.yml)

This rule is too narrow. First of all, there are more options to download something with powerhsell.
At the same time there are other rules for downloading with powershell (i.e. [win_powershell_download.yml](https://github.com/Neo23x0/sigma/blob/99b15edf8add183543ca5738ec93f87416c34bd9/rules/windows/process_creation/win_powershell_download.yml)).
We believe that there should be unified rule about downloading something with powershell.
We cannot rewrite this rule because we have developed it for internal SOC already.

### [Quick Execution of a Series of Suspicious Commands](https://github.com/Neo23x0/sigma/blob/99b15edf8add183543ca5738ec93f87416c34bd9/rules/windows/process_creation/win_multiple_suspicious_cli.yml)

This rule should be split into multiple rules by tactic/technique.
For example execution of "systeminfo.exe"/"hostname.exe" is nothing but System Information Discovery (T1082), "taskkill.exe" could be considered as Disabling Security Tools (T1089) etc.
Of course it's not possible to clearly define tactic/technique for all executables listed in the rule, but it's important to make it as contextualized as possible.
We cannot rewrite this rule into multiple because we have developed them for internal SOC already.

### [Malicious Service Install](https://github.com/Neo23x0/sigma/blob/bfc7012043317632265a897c8a4901f266cda992/rules/windows/builtin/win_mal_creddumper.yml)

This rule could be enhanced with at least 4 service names for credendial dumping tools.
We cannot rewrite this rule because we have developed it for internal SOC already.

### [Suspicious Process Creation](https://github.com/Neo23x0/sigma/blob/7b3d67ae66f8edb06bacb3ac546e48e675c7d257/rules/windows/process_creation/win_susp_process_creations.yml)

This rule should be split into multiple rules by tactic/technique.
For example execution of "icacls * /grant Everyone:F /T /C /Q" is nothing but File Permissions Modification (T1222), "vssadmin delete shadows" cound be considered as Indicator Removal on Host (T1070) etc.
There are intersections with [Suspicious WMI execution](https://github.com/Neo23x0/sigma/blob/99b15edf8add183543ca5738ec93f87416c34bd9/rules/windows/process_creation/win_susp_wmi_execution.yml) rule and others.
Of course it's not possible to clearly define tactic/technique for all commandline strings listed in the rule, but it's important to make it as contextualized as possible.
We cannot rewrite this rule into multiple because we have developed them for internal SOC already.

### [Malicious Service Installations](https://github.com/Neo23x0/sigma/blob/bfc7012043317632265a897c8a4901f266cda992/rules/windows/builtin/win_mal_service_installs.yml)

This rule should be split into multiple rules by tactic/technique.
There are intersections with Malicious Service Install | sigma/rules/windows/builtin/win_mal_creddumper.yml.
`PAExec` is not malicious, it's just an open source version of PsExec and should be treated in the same way.
There are more (more that mentioned across all sigma rules) tools which can do remote code execution via services execution and they have hardcoded service/executable names.
There are more (more that mentioned across all sigma rules) tools which can do credential dumping via services execution and they have hardcoded service/executable names.
We cannot rewrite this rule into multiple because we have developed them for internal SOC already.

### [smbexec.py Service Installation](https://github.com/Neo23x0/sigma/blob/bfc7012043317632265a897c8a4901f266cda992/rules/windows/builtin/win_hack_smbexec.yml)

`smbexec.py` has no difference with PsExec or PaExec and a few other tools which works in the same way.
These are just remote administration tools which should be treated in the same way.
There are Linux/macOS guys who have to (for some reason) work with Windows systems remotely, and by obvious reason, they cannot use PsExec.
We are not saying that this rule is reduntant, just unification with other remote administration tools which use Service Execution is needed.
At the same time we believe that all rules with 7045 event (system) should have 4697 event (security) as well.

### [Suspicious Driver Load from Temp](https://github.com/Neo23x0/sigma/blob/3ef930b0943eae586144513fe9732604946843bc/rules/windows/sysmon/sysmon_susp_driver_load.yml)

This rule could be enhanced with at least 1 native windows event for driver/service load/creation.
We cannot enhance this rule because we have developed it for internal SOC already.

### [Registry Persistence Mechanisms](https://github.com/Neo23x0/sigma/blob/2e61233e310f113dc71c295a65d95481cfa12173/rules/windows/sysmon/sysmon_win_reg_persistence.yml)

This rule could be enhanced with at least 1 native windows event for registry changes.
We cannot rewrite this rule because we have developed it for internal SOC already.

### [Activity Related to NTDS.dit Domain Hash Retrieval](https://github.com/Neo23x0/sigma/blob/99b15edf8add183543ca5738ec93f87416c34bd9/rules/windows/process_creation/win_susp_vssadmin_ntds_activity.yml)

This rule should be split into multiple rules by tactic/technique.
For example execution of "reg SAVE HKLM\SYSTEM" could be used separetely even without relateion to NTDS.dit retrieval, at the same time "vssadmin delete shadows" cound be considered as Indicator Removal on Host (T1070) etc.
We cannot rewrite this rule into multiple because we have developed them for internal SOC already.

### [Reconnaissance Activity with Net Command](https://github.com/Neo23x0/sigma/blob/99b15edf8add183543ca5738ec93f87416c34bd9/rules/windows/process_creation/win_susp_commands_recon_activity.yml)

This rule should be split into multiple rules by tactic/technique.
For example execution of "net" with "localgroup" is Account Discovery (T1087), "netstat -an" is System Network Connections Discovery (T1049) etc.
We cannot rewrite this rule into multiple because we have developed them for internal SOC already.

### [Usage of Sysinternals Tools](https://github.com/Neo23x0/sigma/blob/8b7f0508a759c7a8a794f129c06477ba2b7bcb1c/rules/windows/sysmon/sysmon_sysinternals_eula_accepted.yml)

The rule is too broad, those tools can be used for many purposes. Each tool creates its own registry key by tool name and we can monitor `EulaAccepted` DWORD per tool, this way we can somehow split rules and do detection per tactic/technique, at least somehow contextualised. We cannot rewrite this rule into multiple because we have developed them for internal SOC already.

### redundant rules

- [Suspicious Program Location Process Starts](https://github.com/Neo23x0/sigma/blob/99b15edf8add183543ca5738ec93f87416c34bd9/rules/windows/process_creation/win_susp_prog_location_process_starts.yml)
- [Suspicious Process Start Locations](https://github.com/Neo23x0/sigma/blob/99b15edf8add183543ca5738ec93f87416c34bd9/rules/windows/process_creation/win_susp_run_locations.yml)
- [Executables Started in Suspicious Folder](https://github.com/Neo23x0/sigma/blob/1a583c158d5a23b60444afbb93b94b53f04cdf41/rules/windows/process_creation/win_susp_exec_folder.yml)

We believe there should be only one such rule.

Thank you for your project and efforts you've put into it.
We look forward to meeting you next EU ATT&CK workshop in Brussels or other conferences (:

Cheers,

Daniil Yugoslavskiy
Jakob Weinzettl
Mateusz Wydra
Mikhail Aksenov