### PR TITLE
Remove invalid link

### DIFF
--- a/rules/windows/process_creation/win_office_shell.yml
+++ b/rules/windows/process_creation/win_office_shell.yml
@@ -4,7 +4,6 @@ description: Detects a Windows command line executable started from Microsoft Wo
 references:
     - https://www.hybrid-analysis.com/sample/465aabe132ccb949e75b8ab9c5bda36d80cf2fd503d52b8bad54e295f28bbc21?environmentId=100
     - https://mgreen27.github.io/posts/2018/04/02/DownloadCradle.html
-    - https://www2.cybereason.com/asset/60:research-cobalt-kitty-attack-lifecycle
 tags:
     - attack.execution
     - attack.defense_evasion


### PR DESCRIPTION
Cybereason link was broken. Couldn't find anything with a super similar file path. The below link might be a valid replacement but went better safe than sorry and just removed it completely. https://www.cybereason.com/hubfs/Cybereason%20Labs%20Analysis%20Operation%20Cobalt%20Kitty-Part1.pdf