### PR TITLE
Migrated the last detections to process_creation

### DIFF
--- a/rules/apt/apt_chafer_mar18.yml
+++ b/rules/apt/apt_chafer_mar18.yml
@@ -55,17 +55,19 @@ detection:
         TargetObject: '*\Control\SecurityProviders\WDigest\UseLogonCredential'
         EventType: 'SetValue'
         Details: 'DWORD (0x00000001)'
+---
+logsource:
+    category: process_creation
+    product: windows
+detection:
     selection_process1:
-        EventID: 1 
         CommandLine: 
             - '*\Service.exe i'
             - '*\Service.exe u'
             - '*\microsoft\Taskbar\autoit3.exe'
             - 'C:\wsc.exe*'
     selection_process2:
-        EventID: 1
         Image: '*\Windows\Temp\DB\\*.exe'
     selection_process3:
-        EventID: 1
         CommandLine: '*\nslookup.exe -q=TXT*'
         ParentImage: '*\Autoit*'

--- a/rules/apt/apt_pandemic.yml
+++ b/rules/apt/apt_pandemic.yml
@@ -1,3 +1,5 @@
+---
+action: global
 title: Pandemic Registry Key
 status: experimental
 description: Detects Pandemic Windows Implant
@@ -8,19 +10,7 @@ tags:
     - attack.lateral_movement
     - attack.t1105
 author: Florian Roth
-logsource:
-    product: windows
-    service: sysmon
 detection:
-    selection1:
-        EventID: 13
-        TargetObject: 
-            - '\REGISTRY\MACHINE\SYSTEM\CurrentControlSet\services\null\Instance*'
-            - '\REGISTRY\MACHINE\SYSTEM\ControlSet001\services\null\Instance*'
-            - '\REGISTRY\MACHINE\SYSTEM\ControlSet002\services\null\Instance*'
-    selection2:
-        EventID: 1
-        Command: 'loaddll -a *'
     condition: 1 of them
 fields:
     - EventID
@@ -32,4 +22,22 @@ fields:
 falsepositives:
     - unknown
 level: critical
+---
+logsource:
+    product: windows
+    service: sysmon
+detection:
+    selection1:
+        EventID: 13
+        TargetObject: 
+            - '\REGISTRY\MACHINE\SYSTEM\CurrentControlSet\services\null\Instance*'
+            - '\REGISTRY\MACHINE\SYSTEM\ControlSet001\services\null\Instance*'
+            - '\REGISTRY\MACHINE\SYSTEM\ControlSet002\services\null\Instance*'
+---
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection2:
+        Command: 'loaddll -a *'
 

--- a/rules/apt/apt_ta17_293a_ps.yml
+++ b/rules/apt/apt_ta17_293a_ps.yml
@@ -9,11 +9,10 @@ tags:
 author: Florian Roth
 date: 2017/10/22
 logsource:
+    category: process_creation
     product: windows
-    service: sysmon
 detection:
     selection:
-        EventID: 1
         CommandLine: 'ps.exe -accepteula'
     condition: selection
 falsepositives:

--- a/rules/apt/apt_zxshell.yml
+++ b/rules/apt/apt_zxshell.yml
@@ -6,11 +6,10 @@ references:
 tags:
     - attack.g0001
 logsource:
+    category: process_creation
     product: windows
-    service: sysmon
 detection:
     selection:
-        EventID: 1
         Command: 
             - 'rundll32.exe *,zxFunction*'
             - 'rundll32.exe *,RemoteDiskXXXXX'

--- a/rules/apt/crime_fireball.yml
+++ b/rules/apt/crime_fireball.yml
@@ -7,11 +7,10 @@ references:
     - https://www.virustotal.com/en/file/9b4971349ae85aa09c0a69852ed3e626c954954a3927b3d1b6646f139b930022/analysis/
     - https://www.hybrid-analysis.com/sample/9b4971349ae85aa09c0a69852ed3e626c954954a3927b3d1b6646f139b930022?environmentId=100
 logsource:
+    category: process_creation
     product: windows
-    service: sysmon
 detection:
     selection:
-        EventID: 1
         CommandLine: '*\rundll32.exe *,InstallArcherSvc'
     condition: selection
 fields:

--- a/rules/windows/other/win_tool_psexec.yml
+++ b/rules/windows/other/win_tool_psexec.yml
@@ -1,3 +1,5 @@
+---
+action: global
 title: PsExec Tool Execution
 status: experimental
 description: Detects PsExec service installation and execution events (service and Sysmon)
@@ -9,20 +11,7 @@ tags:
     - attack.execution
     - attack.t1035
     - attack.s0029
-logsource:
-    product: windows
 detection:
-    service_installation:
-        EventID: 7045
-        ServiceName: 'PSEXESVC'
-        ServiceFileName: '*\PSEXESVC.exe'
-    service_execution:
-        EventID: 7036
-        ServiceName: 'PSEXESVC'
-    sysmon_processcreation:
-        EventID: 1
-        Image: '*\PSEXESVC.exe'
-        User: 'NT AUTHORITY\SYSTEM'
     condition: 1 of them
 fields:
     - EventID
@@ -33,3 +22,24 @@ fields:
 falsepositives:
     - unknown
 level: low
+---
+logsource:
+    product: windows
+    service: system
+detection:
+    service_installation:
+        EventID: 7045
+        ServiceName: 'PSEXESVC'
+        ServiceFileName: '*\PSEXESVC.exe'
+    service_execution:
+        EventID: 7036
+        ServiceName: 'PSEXESVC'
+---
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    sysmon_processcreation:
+        Image: '*\PSEXESVC.exe'
+        User: 'NT AUTHORITY\SYSTEM'
+

--- a/rules/windows/sysmon/sysmon_cmstp_execution.yml
+++ b/rules/windows/sysmon/sysmon_cmstp_execution.yml
@@ -1,3 +1,5 @@
+---
+action: global
 title: CMSTP Execution
 status: stable
 description: Detects various indicators of Microsoft Connection Manager Profile Installer execution
@@ -9,14 +11,20 @@ tags:
 author: Nik Seetharaman
 references:
     - http://www.endurant.io/cmstp/detecting-cmstp-enabled-code-execution-and-uac-bypass-with-sysmon/
+detection:
+    condition: 1 of them
+fields:
+    - CommandLine
+    - ParentCommandLine
+    - Details
+falsepositives:
+    - Legitimate CMSTP use (unlikely in modern enterprise environments)
+level: high
+---
 logsource:
     product: windows
     service: sysmon
 detection:
-    # CMSTP Spawning Child Process
-    selection1:
-        EventID: 1
-        ParentImage: '*\cmstp.exe'
     # Registry Object Add
     selection2:
         EventID: 12
@@ -29,11 +37,11 @@ detection:
     selection4:
         EventID: 10
         CallTrace: '*cmlua.dll*'
-    condition: 1 of them
-fields:
-    - CommandLine
-    - ParentCommandLine
-    - Details
-falsepositives:
-    - Legitimate CMSTP use (unlikely in modern enterprise environments)
-level: high
+---
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    # CMSTP Spawning Child Process
+    selection1:
+        ParentImage: '*\cmstp.exe'

--- a/rules/windows/sysmon/sysmon_dns_serverlevelplugindll.yml
+++ b/rules/windows/sysmon/sysmon_dns_serverlevelplugindll.yml
@@ -1,3 +1,5 @@
+---
+action: global
 title: DNS ServerLevelPluginDll Install
 status: experimental
 description: Detects the installation of a plugin DLL via ServerLevelPluginDll parameter in Registry, which can be used to execute code in context of the DNS server (restart required)
@@ -8,16 +10,7 @@ author: Florian Roth
 tags:
     - attack.defense_evasion
     - attack.t1073
-logsource:
-    product: windows
-    service: sysmon
 detection:
-    dnsadmin:
-        EventID: 1
-        CommandLine: 'dnscmd.exe /config /serverlevelplugindll *'
-    dnsregmod:
-        EventID: 13
-        TargetObject: '*\services\DNS\Parameters\ServerLevelPluginDll'
     condition: 1 of them
 fields:
     - EventID
@@ -29,5 +22,18 @@ fields:
 falsepositives:
     - unknown
 level: high
-
-
+---
+logsource:
+    product: windows
+    service: sysmon
+detection:
+    dnsregmod:
+        EventID: 13
+        TargetObject: '*\services\DNS\Parameters\ServerLevelPluginDll'
+---
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    dnsadmin:
+        CommandLine: 'dnscmd.exe /config /serverlevelplugindll *'

--- a/rules/windows/sysmon/sysmon_logon_scripts_userinitmprlogonscript.yml
+++ b/rules/windows/sysmon/sysmon_logon_scripts_userinitmprlogonscript.yml
@@ -8,33 +8,27 @@ tags:
     - attack.persistence
     - attack.lateral_movement
 author: Tom Ueltschi (@c_APT_ure)
-detection:
-    condition: (exec_selection and not exec_exclusion) or (create_selection and create_keywords)
-falsepositives:
-    - exclude legitimate logon scripts
-    - penetration tests, red teaming
-level: high
----
 logsource:
     product: windows
     service: sysmon
 detection:
+    exec_selection:
+        EventID: 1 # Migration to process_creation requires multipart YAML
+        ParentImage: '*\userinit.exe'
+    exec_exclusion:
+        Image: '*\explorer.exe'
+        CommandLine: '*\netlogon.bat'
     create_selection:
         EventID:
-            - 1 # This too should be in the process_creation source but it's not worth the effort given the structure of the filter.
+            - 1
             - 11
             - 12
             - 13
             - 14
     create_keywords:
         - UserInitMprLogonScript
----
-logsource:
-    category: process_creation
-    product: windows
-detection:
-    exec_selection:
-        ParentImage: '*\userinit.exe'
-    exec_exclusion:
-        Image: '*\explorer.exe'
-        CommandLine: '*\netlogon.bat'
+    condition: (exec_selection and not exec_exclusion) or (create_selection and create_keywords)
+falsepositives:
+    - exclude legitimate logon scripts
+    - penetration tests, red teaming
+level: high

--- a/rules/windows/sysmon/sysmon_logon_scripts_userinitmprlogonscript.yml
+++ b/rules/windows/sysmon/sysmon_logon_scripts_userinitmprlogonscript.yml
@@ -8,27 +8,33 @@ tags:
     - attack.persistence
     - attack.lateral_movement
 author: Tom Ueltschi (@c_APT_ure)
+detection:
+    condition: (exec_selection and not exec_exclusion) or (create_selection and create_keywords)
+falsepositives:
+    - exclude legitimate logon scripts
+    - penetration tests, red teaming
+level: high
+---
 logsource:
     product: windows
     service: sysmon
 detection:
-    exec_selection:
-        EventID: 1
-        ParentImage: '*\userinit.exe'
-    exec_exclusion:
-        Image: '*\explorer.exe'
-        CommandLine: '*\netlogon.bat'
     create_selection:
         EventID:
-            - 1
+            - 1 # This too should be in the process_creation source but it's not worth the effort given the structure of the filter.
             - 11
             - 12
             - 13
             - 14
     create_keywords:
         - UserInitMprLogonScript
-    condition: (exec_selection and not exec_exclusion) or (create_selection and create_keywords)
-falsepositives:
-    - exclude legitimate logon scripts
-    - penetration tests, red teaming
-level: high
+---
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    exec_selection:
+        ParentImage: '*\userinit.exe'
+    exec_exclusion:
+        Image: '*\explorer.exe'
+        CommandLine: '*\netlogon.bat'

--- a/rules/windows/sysmon/sysmon_stickykey_like_backdoor.yml
+++ b/rules/windows/sysmon/sysmon_stickykey_like_backdoor.yml
@@ -1,3 +1,5 @@
+---
+action: global
 title: Sticky Key Like Backdoor Usage
 description: Detects the usage and installation of a backdoor that uses an option to register a malicious debugger for built-in tools that are accessible in the login screen
 references:
@@ -8,21 +10,16 @@ tags:
     - attack.t1015
 author: Florian Roth, @twjackomo
 date: 2018/03/15
+detection:
+    condition: 1 of them
+falsepositives:
+    - Unlikely
+level: critical
+---
 logsource:
     product: windows
     service: sysmon
 detection:
-    selection_process:
-        EventID: 1
-        ParentImage:
-            - '*\winlogon.exe'
-        CommandLine:
-            - '*\cmd.exe sethc.exe *'
-            - '*\cmd.exe utilman.exe *'
-            - '*\cmd.exe osk.exe *'
-            - '*\cmd.exe Magnify.exe *'
-            - '*\cmd.exe Narrator.exe *'
-            - '*\cmd.exe DisplaySwitch.exe *'
     selection_registry:
         EventID: 13
         TargetObject: 
@@ -33,8 +30,18 @@ detection:
             - '*\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\Narrator.exe\Debugger'
             - '*\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\DisplaySwitch.exe\Debugger'
         EventType: 'SetValue'
-    condition: 1 of them
-falsepositives:
-    - Unlikely
-level: critical
-
+---
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection_process:
+        ParentImage:
+            - '*\winlogon.exe'
+        CommandLine:
+            - '*\cmd.exe sethc.exe *'
+            - '*\cmd.exe utilman.exe *'
+            - '*\cmd.exe osk.exe *'
+            - '*\cmd.exe Magnify.exe *'
+            - '*\cmd.exe Narrator.exe *'
+            - '*\cmd.exe DisplaySwitch.exe *'

--- a/rules/windows/sysmon/sysmon_sysinternals_eula_accepted.yml
+++ b/rules/windows/sysmon/sysmon_sysinternals_eula_accepted.yml
@@ -1,3 +1,5 @@
+---
+action: global
 title: Usage of Sysinternals Tools 
 status: experimental
 description: Detects the usage of Sysinternals Tools due to accepteula key beeing added to Registry 
@@ -5,6 +7,13 @@ references:
     - https://twitter.com/Moti_B/status/1008587936735035392
 date: 2017/08/28
 author: Markus Neis
+detection:
+    condition: 1 of them
+falsepositives:
+    - Legitimate use of SysInternals tools
+    - Programs that use the same Registry Key
+level: low
+---
 logsource:
     product: windows
     service: sysmon
@@ -12,12 +21,10 @@ detection:
     selection1:
         EventID: 13
         TargetObject: '*\EulaAccepted'
+---
+logsource:
+    category: process_creation
+    product: windows
+detection:
     selection2:
-        EventID: 1
         CommandLine: '* -accepteula*'
-    condition: selection1 or selection2
-falsepositives:
-    - Legitimate use of SysInternals tools
-    - Programs that use the same Registry Key
-level: low
-

--- a/rules/windows/sysmon/sysmon_uac_bypass_eventvwr.yml
+++ b/rules/windows/sysmon/sysmon_uac_bypass_eventvwr.yml
@@ -1,3 +1,5 @@
+---
+action: global
 title: UAC Bypass via Event Viewer
 status: experimental
 description: Detects UAC bypass method using Windows event viewer
@@ -5,18 +7,7 @@ references:
     - https://enigma0x3.net/2016/08/15/fileless-uac-bypass-using-eventvwr-exe-and-registry-hijacking/
     - https://www.hybrid-analysis.com/sample/e122bc8bf291f15cab182a5d2d27b8db1e7019e4e96bb5cdbd1dfe7446f3f51f?environmentId=100
 author: Florian Roth
-logsource:
-    product: windows
-    service: sysmon
 detection:
-    methregistry:
-        EventID: 13
-        TargetObject: 'HKEY_USERS\\*\mscfile\shell\open\command'
-    methprocess:
-        EventID: 1
-        ParentImage: '*\eventvwr.exe'
-    filterprocess:
-        Image: '*\mmc.exe'
     condition: methregistry or ( methprocess and not filterprocess )
 fields:
     - CommandLine
@@ -28,3 +19,21 @@ tags:
 falsepositives:
     - unknown
 level: critical
+---
+logsource:
+    product: windows
+    service: sysmon
+detection:
+    methregistry:
+        EventID: 13
+        TargetObject: 'HKEY_USERS\\*\mscfile\shell\open\command'
+---
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    methprocess:
+        ParentImage: '*\eventvwr.exe'
+    filterprocess:
+        Image: '*\mmc.exe'
+

--- a/rules/windows/sysmon/sysmon_uac_bypass_eventvwr.yml
+++ b/rules/windows/sysmon/sysmon_uac_bypass_eventvwr.yml
@@ -1,5 +1,3 @@
----
-action: global
 title: UAC Bypass via Event Viewer
 status: experimental
 description: Detects UAC bypass method using Windows event viewer
@@ -7,7 +5,18 @@ references:
     - https://enigma0x3.net/2016/08/15/fileless-uac-bypass-using-eventvwr-exe-and-registry-hijacking/
     - https://www.hybrid-analysis.com/sample/e122bc8bf291f15cab182a5d2d27b8db1e7019e4e96bb5cdbd1dfe7446f3f51f?environmentId=100
 author: Florian Roth
+logsource:
+    product: windows
+    service: sysmon
 detection:
+    methregistry:
+        EventID: 13
+        TargetObject: 'HKEY_USERS\\*\mscfile\shell\open\command'
+    methprocess:
+        EventID: 1 # Migration to process_creation requires multipart YAML
+        ParentImage: '*\eventvwr.exe'
+    filterprocess:
+        Image: '*\mmc.exe'
     condition: methregistry or ( methprocess and not filterprocess )
 fields:
     - CommandLine
@@ -19,21 +28,3 @@ tags:
 falsepositives:
     - unknown
 level: critical
----
-logsource:
-    product: windows
-    service: sysmon
-detection:
-    methregistry:
-        EventID: 13
-        TargetObject: 'HKEY_USERS\\*\mscfile\shell\open\command'
----
-logsource:
-    category: process_creation
-    product: windows
-detection:
-    methprocess:
-        ParentImage: '*\eventvwr.exe'
-    filterprocess:
-        Image: '*\mmc.exe'
-

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -200,7 +200,7 @@ class TestRules(unittest.TestCase):
                          "There are detections with 'Source: Eventlog'. This does not add value to the detection.")
 
 
-    def test_event_id_instead_of_process_create(self):
+    def test_event_id_instead_of_process_creation(self):
         faulty_detections = []
         for file in self.yield_next_rule_file_path(self.path_to_rules):
             with open(file) as f:
@@ -208,17 +208,8 @@ class TestRules(unittest.TestCase):
                     if re.search(r'.*EventID: (?:1|4688)\s*$', line) and file not in faulty_detections:
                         faulty_detections.append(file)
 
-        # Tareq won't enable until all existing rules are migrated to prevent breaking all CI builds
-        # self.assertEqual(faulty_detections, [],
-        #                  "There are rules still using Sysmon 1 or Event ID 4688. Please migrate to the process_creation category.")
-
-        # Report but do not throw an error
-        if faulty_detections:
-            print("The following rules still use Sysmon 1 or Event ID 4688.")
-            print("Please migrate to the process_creation category.")
-            print("List length is: {}".format(len(faulty_detections)))
-            print("------------------------------------------------")
-            print(*faulty_detections, sep='\n')
+        self.assertEqual(faulty_detections, [],
+                         "There are rules still using Sysmon 1 or Event ID 4688. Please migrate to the process_creation category.")
 
 
 if __name__ == "__main__":

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -205,7 +205,7 @@ class TestRules(unittest.TestCase):
         for file in self.yield_next_rule_file_path(self.path_to_rules):
             with open(file) as f:
                 for line in f:
-                    if re.search(r'.*EventID: (?:1|4688).*', line) and file not in faulty_detections:
+                    if re.search(r'.*EventID: (?:1|4688)\s*$', line) and file not in faulty_detections:
                         faulty_detections.append(file)
 
         # Tareq won't enable until all existing rules are migrated to prevent breaking all CI builds


### PR DESCRIPTION
In this pull request:
- Migrated the last detection strategies to the new process_creation log source
- Enabled test for Sysmon 1 / EID 4688 instead of process_creation

Also, I still have a few tests I'd like to implement but I would love to hear what rule tests you guys would find useful. Tweet at me here:
https://twitter.com/alkhatib_tareq
