### PR TITLE
updated detection logic

### DIFF
--- a/rules/windows/builtin/win_mal_creddumper.yml
+++ b/rules/windows/builtin/win_mal_creddumper.yml
@@ -11,10 +11,9 @@ logsource:
     product: windows
     service: system
 detection:
-    selection:
+    selection1:
         EventID: 
           - 7045
-          - 4697
     keywords:
       - 'WCE SERVICE'
       - 'WCESERVICE'
@@ -22,7 +21,7 @@ detection:
     quarkspwdump:
         EventID: 16
         HiveName: '*\AppData\Local\Temp\SAM*.dmp'
-    condition: ( selection and keywords ) or quarkspwdump
+    condition: ( selection1 and keywords ) or ( selection2 and keywords ) or quarkspwdump
 falsepositives:
     - Unlikely
 level: high
@@ -31,5 +30,5 @@ logsource:
     product: windows
     service: security
 detection:
-    selection:
+    selection2:
         EventID: 4697

--- a/rules/windows/process_creation/win_multiple_suspicious_cli.yml
+++ b/rules/windows/process_creation/win_multiple_suspicious_cli.yml
@@ -19,7 +19,7 @@ detection:
             - hostname.exe
             - ipconfig.exe
             - mimikatz.exe
-            - nbstat.exe
+            - nbtstat.exe
             - net.exe
             - netsh.exe
             - nslookup.exe


### PR DESCRIPTION
forgot to delete event id from wrong logsource last time. 

for some reason if we use simple "selection and ..." condition second document with logsource security / eid 4697 is not involved into final generated query (in case both documents have just "selection"). So decided to create multiple sections (1/2) and explicitly define them in condition.

Please let me know if there is simpler option.

update: `nbstat.exe` changed to `nbtstat.exe` in [Quick Execution of a Series of Suspicious Commands](https://github.com/Neo23x0/sigma/blob/99b15edf8add183543ca5738ec93f87416c34bd9/rules/windows/process_creation/win_multiple_suspicious_cli.yml) rule