### PR TITLE
Create win_etw_trace_evasion.yml

### DIFF
--- a/rules/windows/process_creation/win_etw_trace_evasion.yml
+++ b/rules/windows/process_creation/win_etw_trace_evasion.yml
@@ -1,0 +1,25 @@
+title: Disable of ETW Trace
+description: Detects a command that clears or disables any ETW trace log which could indicate a logging evasion.
+references:
+    - https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/wevtutil
+    - https://github.com/Neo23x0/sigma/blob/master/rules/windows/process_creation/win_mal_lockergoga.yml
+    - https://abuse.io/lockergoga.txt
+author: @neu5ron, Florian Roth
+date: 2019/03/22
+tags:
+    - attack.execution
+    - attack.T1070    
+level: high
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection_clear_1:
+        CommandLine: '* cl */Trace*'
+    selection_clear_2:
+        CommandLine: '* clear-log */Trace*'
+    selection_disable_1:
+        CommandLine: '* sl* /e:false*'
+    selection_disable_2:
+        CommandLine: '* set-log* /e:false*'
+    condition: selection_clear_1 or selection_clear_2 or selection_disable_1 or selection_disable_2


### PR DESCRIPTION
there are two versions of clear and two variations of set that can be used with something like wevtutil
`wevtutil cl | wevtutil clear-log | wevtutil sl | wevtutil set-log `

Also, I am adding a `*` match at the end, because there are other parameters that could be placed on the end -- so unless this was used on a general search on a text/analyzed field then the `*` is necessary.

example `wevtutil set-log Microsoft-Windows-WMI-Activity/Trace /e:disable /q:true`