### PR TITLE
Add new signature for linux clear command history

### DIFF
--- a/rules/linux/lnx_shell_clear_cmd_history.yml
+++ b/rules/linux/lnx_shell_clear_cmd_history.yml
@@ -1,0 +1,26 @@
+title: Clear Command History
+description: Clear command history in linux which is used for defense evasion. 
+references:
+    - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1146/T1146.yaml
+    - https://attack.mitre.org/techniques/T1146/
+author: Patrick Bareiss
+date: 2019/03/24
+logsource:
+    product: linux
+detection:
+    keywords:
+        - 'rm *bash_history'
+        - 'echo "" > *bash_history'
+        - 'cat /dev/null > *bash_history' 
+        - 'ln -sf /dev/null *bash_history'
+        - 'truncate -s0 *bash_history'
+        - 'unset HISTFILE'
+        - 'export HISTFILESIZE=0'
+        - 'history -c'
+    condition: keywords
+falsepositives:
+    - Unknown
+level: high
+tags:
+    - attack.defense_evasion
+    - attack.t1146

--- a/rules/linux/lnx_shell_clear_cmd_history.yml
+++ b/rules/linux/lnx_shell_clear_cmd_history.yml
@@ -1,4 +1,5 @@
 title: Clear Command History
+status: experimental
 description: Clear command history in linux which is used for defense evasion. 
 references:
     - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1146/T1146.yaml
@@ -14,7 +15,7 @@ detection:
         - 'cat /dev/null > *bash_history' 
         - 'ln -sf /dev/null *bash_history'
         - 'truncate -s0 *bash_history'
-        - 'unset HISTFILE'
+        # - 'unset HISTFILE'  # prone to false positives
         - 'export HISTFILESIZE=0'
         - 'history -c'
     condition: keywords


### PR DESCRIPTION
I developed a new signature for linux in order to detect, when the command history was cleared for defense evasion. The signature was tested with Atomic Test T1146, https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1146/T1146.yaml .