### PR TITLE
Remove backslashes in CommandLine for sticky key rule

### DIFF
--- a/rules/windows/sysmon/sysmon_stickykey_like_backdoor.yml
+++ b/rules/windows/sysmon/sysmon_stickykey_like_backdoor.yml
@@ -39,9 +39,9 @@ detection:
         ParentImage:
             - '*\winlogon.exe'
         CommandLine:
-            - '*\cmd.exe sethc.exe *'
-            - '*\cmd.exe utilman.exe *'
-            - '*\cmd.exe osk.exe *'
-            - '*\cmd.exe Magnify.exe *'
-            - '*\cmd.exe Narrator.exe *'
-            - '*\cmd.exe DisplaySwitch.exe *'
+            - '*cmd.exe sethc.exe *'
+            - '*cmd.exe utilman.exe *'
+            - '*cmd.exe osk.exe *'
+            - '*cmd.exe Magnify.exe *'
+            - '*cmd.exe Narrator.exe *'
+            - '*cmd.exe DisplaySwitch.exe *'


### PR DESCRIPTION
Remove backslashes in CommandLine for sticky key rule to match command line which is exactly "cmd.exe sethc.exe 211" after triggering the backdoor. The detection with *\cmd.exe... would not match.