### PR TITLE
Allow generating Elastalert rules with the http_post alert type without specifying a URL at generation time

### DIFF
--- a/tools/sigma/backends/elasticsearch.py
+++ b/tools/sigma/backends/elasticsearch.py
@@ -671,19 +671,20 @@ class ElastalertBackend(MultiRuleOutputMixin, ElasticsearchQuerystringBackend):
                     rule_object['smtp_auth_file'] = self.smtp_auth_file
             if 'http_post' in alert_methods:
                 if self.http_post_url is None:
-                    print('Warning: the Elastalert HTTP POST method is selected but no URL has been provided. This alert method will be ignored', file=sys.stderr)
+                    print('Warning: the Elastalert HTTP POST method is selected but no URL has been provided.', file=sys.stderr)
                 else:
-                    rule_object['alert'].append('post')
                     rule_object['http_post_url'] = self.http_post_url
-                    if self.http_post_include_rule_metadata:
-                        rule_object['http_post_static_payload'] = {
-                            'sigma_rule_metadata': {
-                                'title': title,
-                                'description': description,
-                                'level': level,
-                                'tags': rule_tag
-                            }
+
+                rule_object['alert'].append('post')
+                if self.http_post_include_rule_metadata:
+                    rule_object['http_post_static_payload'] = {
+                        'sigma_rule_metadata': {
+                            'title': title,
+                            'description': description,
+                            'level': level,
+                            'tags': rule_tag
                         }
+                    }
             #If alert is not define put debug as default
             if len(rule_object['alert']) == 0:
                 rule_object['alert'].append('debug')


### PR DESCRIPTION
I noticed that in some cases, it is desirable to allow generating Elastalert rules with the `http_post` alert type without a `http_post_url` set. This is because you don't necessarily know at compile-time where Elastalert will send alerts, which is something you might want to specify later, in the elastalert configuration file. This is especially true if you compile a sigma rule once but use it in several elastaler environments

Example before the patch:

```yaml
$ ./tools/sigmac -O alert_methods=http_post -t elastalert sample.sigma

alert:
- debug
description: ''
filter:
- query:
    query_string:
      query: EventID:"1102"
index: logstash-*
name: Detect-event-logs-cleared_0
priority: 2
realert:
  minutes: 0
type: any
```

After the patch:

```yaml
$ ./tools/sigmac -O alert_methods=http_post -t elastalert sample.sigma

alert:
- post
description: ''
filter:
- query:
    query_string:
      query: EventID:"1102"
index: logstash-*
name: Detect-event-logs-cleared_0
priority: 2
realert:
  minutes: 0
type: any
```

The diff being only the alert type specified in the rule