### PR TITLE
Update net_susp_dns_txt_exec_strings.yml

### DIFF
--- a/rules/network/net_susp_dns_txt_exec_strings.yml
+++ b/rules/network/net_susp_dns_txt_exec_strings.yml
@@ -12,6 +12,7 @@ logsource:
     category: dns
 detection:
     selection:
+        - record_type: 'TXT'
         answer:
             - '*IEX*'
             - '*Invoke-Expression*'

--- a/rules/network/net_susp_dns_txt_exec_strings.yml
+++ b/rules/network/net_susp_dns_txt_exec_strings.yml
@@ -12,11 +12,12 @@ logsource:
     category: dns
 detection:
     selection:
-        - record_type: 'TXT'
-        answer:
-            - '*IEX*'
-            - '*Invoke-Expression*'
-            - '*cmd.exe*'
+        -
+            record_type: 'TXT'
+            answer:
+                - '*IEX*'
+                - '*Invoke-Expression*'
+                - '*cmd.exe*'
     condition: selection
 falsepositives:
     - Unknown


### PR DESCRIPTION
The references indicate that this rule should apply to TXT records, but without specifying that the "record_type" must be "TXT" there's the potential for a lot of false positives.

"record_type" was chosen as that fits with Splunks "Network Resolution (DNS)" datamodel.