### PR TITLE
Remove too loose filter in mshta rule

### DIFF
--- a/rules/windows/process_creation/win_mshta_spawn_shell.yml
+++ b/rules/windows/process_creation/win_mshta_spawn_shell.yml
@@ -20,10 +20,6 @@ detection:
             - '*\reg.exe'
             - '*\regsvr32.exe'
             - '*\BITSADMIN*'
-    filter:
-        CommandLine:
-            - '*/HP/HP*'
-            - '*\HP\HP*'
     condition: selection and not filter
 fields:
     - CommandLine

--- a/rules/windows/process_creation/win_mshta_spawn_shell.yml
+++ b/rules/windows/process_creation/win_mshta_spawn_shell.yml
@@ -20,7 +20,7 @@ detection:
             - '*\reg.exe'
             - '*\regsvr32.exe'
             - '*\BITSADMIN*'
-    condition: selection and not filter
+    condition: selection
 fields:
     - CommandLine
     - ParentCommandLine

--- a/rules/windows/process_creation/win_mshta_spawn_shell.yml
+++ b/rules/windows/process_creation/win_mshta_spawn_shell.yml
@@ -30,4 +30,5 @@ tags:
     - attack.t1170
 falsepositives:
     - Printer software / driver installations
+    - HP software
 level: high


### PR DESCRIPTION
I know there are HP printers which trigger this detection rule. But such loose filters allow simple bypasses.

```
mshta vbscript:CreateObject("wscript.Shell").Run("wscript.exe test.js /HP/HP")
```

| Field | Value |
| ------------- | ------------- |
| ParentImage |  C:\Windows\System32\mshta.exe  |
| CommandLine | "C:\Windows\System32\wscript.exe" test.js /HP/HP |