### PR TITLE
Remove too loose filter in notepad++ updater rule

### DIFF
--- a/rules/windows/process_creation/win_susp_gup.yml
+++ b/rules/windows/process_creation/win_susp_gup.yml
@@ -16,6 +16,7 @@ detection:
         Image: '*\GUP.exe'
     filter:
         Image:
+            - 'C:\Users\*\AppData\Local\Notepad++\updater\gup.exe'
             - 'C:\Users\*\AppData\Roaming\Notepad++\updater\gup.exe'
             - 'C:\Program Files\Notepad++\updater\gup.exe'
             - 'C:\Program Files (x86)\Notepad++\updater\gup.exe'

--- a/rules/windows/process_creation/win_susp_gup.yml
+++ b/rules/windows/process_creation/win_susp_gup.yml
@@ -14,8 +14,6 @@ logsource:
 detection:
     selection:
         Image: '*\GUP.exe'
-    filter:
-        Image: '*\updater\*'
     condition: selection and not filter
 falsepositives:
     - Execution of tools named GUP.exe and located in folders different than Notepad++\updater

--- a/rules/windows/process_creation/win_susp_gup.yml
+++ b/rules/windows/process_creation/win_susp_gup.yml
@@ -14,7 +14,7 @@ logsource:
 detection:
     selection:
         Image: '*\GUP.exe'
-    condition: selection and not filter
+    condition: selection
 falsepositives:
     - Execution of tools named GUP.exe and located in folders different than Notepad++\updater
 level: high

--- a/rules/windows/process_creation/win_susp_gup.yml
+++ b/rules/windows/process_creation/win_susp_gup.yml
@@ -14,7 +14,12 @@ logsource:
 detection:
     selection:
         Image: '*\GUP.exe'
-    condition: selection
+    filter:
+        Image:
+            - 'C:\Users\*\AppData\Roaming\Notepad++\updater\gup.exe'
+            - 'C:\Program Files\Notepad++\updater\gup.exe'
+            - 'C:\Program Files (x86)\Notepad++\updater\gup.exe'
+    condition: selection and not filter
 falsepositives:
     - Execution of tools named GUP.exe and located in folders different than Notepad++\updater
 level: high


### PR DESCRIPTION
We should remove such a loose filter as default filter (`'*\updater\*'`).

Instead of removing the filter completely, we could make a more restricted filters for default Notepad++ installation paths. According to [Notepad++ Install Folder](http://docs.notepad-plus-plus.org/index.php/Notepad%2B%2B_Install_Folder) folders are typically ` %APPDATA%\Notepad++\` or `C:\Program Files\Notepad++\`. But filtering for AppData may again be more dangerous than it might help.