### PR TITLE
Added Sigma Use Case detecting Privilege Escalation Preparation in Linux

### DIFF
--- a/rules/linux/lnx_shell_priv_esc_prep.yml
+++ b/rules/linux/lnx_shell_priv_esc_prep.yml
@@ -1,0 +1,65 @@
+title: Privilege Escalation Preparation 
+status: experimental
+description: Detects suspicious shell commands indicating the information gathering phase as preparation for the Privilege Escalation.
+references:
+    - https://blog.g0tmi1k.com/2011/08/basic-linux-privilege-escalation/
+    - https://patrick-bareiss.com/detect-privilege-escalation-preparation-in-linux-with-sigma/
+author: Patrick Bareiss
+date: 2019/04/05
+logsource:
+    product: linux
+detection:
+    keywords:
+        # distribution type and kernel version
+        - 'cat /etc/issue'
+        - 'cat /etc/*-release'
+        - 'cat /proc/version'
+        - 'uname -a'
+        - 'uname -mrs'
+        - 'rpm -q kernel'
+        - 'dmesg | grep Linux'
+        - 'ls /boot | grep vmlinuz-'
+        # environment variables
+        - 'cat /etc/profile'
+        - 'cat /etc/bashrc'
+        - 'cat ~/.bash_profile'
+        - 'cat ~/.bashrc'
+        - 'cat ~/.bash_logout'
+        # applications and services as root
+        - 'ps -aux | grep root'
+        - 'ps -ef | grep root'
+        # scheduled tasks
+        - 'crontab -l'
+        - 'cat /etc/cron*'
+        - 'cat /etc/cron.allow'
+        - 'cat /etc/cron.deny'
+        - 'cat /etc/crontab'
+        # search for plain text user/passwords
+        - 'grep -i user *'
+        - 'grep -i pass *'
+        # networking
+        - 'ifconfig'
+        - 'cat /etc/network/interfaces'
+        - 'cat /etc/sysconfig/network'
+        - 'cat /etc/resolv.conf'
+        - 'cat /etc/sysconfig/network'
+        - 'cat /etc/networks'
+        - 'iptables -L'
+        - 'lsof -i'
+        - 'netstat -antup'
+        - 'netstat -antpx'
+        - 'netstat -tulpn'
+        - 'arp -e'
+        - 'route'
+        # sensitive files
+        - 'cat /etc/passwd'
+        - 'cat /etc/group'
+        - 'cat /etc/shadow'
+    timeframe: 30m
+    condition: keywords | count() by host > 6
+falsepositives:
+    - Troubleshooting on Linux Machines
+level: medium
+tags:
+    - attack.privilege_escalation
+    - attack.t1068


### PR DESCRIPTION
I created a new detection rule, which detects the preparation steps for privilege escalation under Linux. A comprehensive list of commands to enumerate a potential flaw can be found here:
https://blog.g0tmi1k.com/2011/08/basic-linux-privilege-escalation/

I wrote a blog article about it for more information:
https://patrick-bareiss.com/detect-privilege-escalation-preparation-in-linux-with-sigma/

The aggregation function count() is used, which is fine for this detection rule. A distinct count would be even better but I got parser errors running the | dc() by host > 6 .