### PR TITLE
ELASTALERT: Set realert_time equal to buffer_time

### DIFF
--- a/rules/windows/sysmon/sysmon_mimikatz_detection_lsass.yml
+++ b/rules/windows/sysmon/sysmon_mimikatz_detection_lsass.yml
@@ -1,6 +1,6 @@
 title: Mimikatz Detection LSASS Access
 status: experimental
-description: Detects process access to LSASS which is typical for Mimikatz (0x1000 PROCESS_QUERY_ LIMITED_INFORMATION, 0x0400 PROCESS_QUERY_ INFORMATION, 0x0010 PROCESS_VM_READ)
+description: Detects process access to LSASS which is typical for Mimikatz (0x1000 PROCESS_QUERY_ LIMITED_INFORMATION, 0x0010 PROCESS_VM_READ)
 references:
     - https://onedrive.live.com/view.aspx?resid=D026B4699190F1E6!2843&ithint=file%2cpptx&app=PowerPoint&authkey=!AMvCRTKB_V1J5ow
 tags:
@@ -14,7 +14,7 @@ detection:
     selection:
         EventID: 10
         TargetImage: 'C:\windows\system32\lsass.exe'
-        GrantedAccess: '0x1410'
+        GrantedAccess: '0x1010'
     condition: selection
 falsepositives:
     - unknown


### PR DESCRIPTION
I am relatively new to setting up SIGMA Alerts and not sure if this is the best option.  However, by not setting this with HELK, rules with buffer_time would trigger every minute for the entire duration of the buffer_time.

If this is a silly idea, feel free to reject wasn't sure of the best way to get ahold of people to ask about this.