### PR TITLE
Remove loose wildcard filter in powershell encoded cmd rule

### DIFF
--- a/rules/windows/process_creation/win_susp_powershell_enc_cmd.yml
+++ b/rules/windows/process_creation/win_susp_powershell_enc_cmd.yml
@@ -21,7 +21,4 @@ detection:
     falsepositive1:
         CommandLine: '* -ExecutionPolicy remotesigned *'
     condition: selection and not falsepositive1
-falsepositives:
-    - GRR powershell hacks
-    - PowerSponse Deployments
 level: high

--- a/rules/windows/process_creation/win_susp_powershell_enc_cmd.yml
+++ b/rules/windows/process_creation/win_susp_powershell_enc_cmd.yml
@@ -19,10 +19,8 @@ detection:
             - '* -encodedcommand JAB*'
             - '* BA^J e-'
     falsepositive1:
-        Image: '*\GRR\\*'
-    falsepositive2:
         CommandLine: '* -ExecutionPolicy remotesigned *'
-    condition: selection and not 1 of falsepositive*
+    condition: selection and not falsepositive1
 falsepositives:
     - GRR powershell hacks
     - PowerSponse Deployments


### PR DESCRIPTION
Remove easy to bypass CommandLine and environment-specific filter.