### PR TITLE
New C2 DNS Tunneling Sigma Detection Rule

### DIFF
--- a/rules/network/net_dns_c2_detection.yml
+++ b/rules/network/net_dns_c2_detection.yml
@@ -16,5 +16,4 @@ falsepositives:
     - Valid software, which uses dns for transferring data
 level: high
 tags:
-    - attack.c2
     - attack.t1043

--- a/rules/network/net_dns_c2_detection.yml
+++ b/rules/network/net_dns_c2_detection.yml
@@ -3,6 +3,7 @@ status: experimental
 description: Normally, there exists a limited amount of different dns queries for a single domain. If a huge number of dns queries were performed for a single domain, this can be an indicator that DNS is used for transferring data. 
 references:
     - https://zeltser.com/c2-dns-tunneling/
+    - https://patrick-bareiss.com/detect-c2-traffic-over-dns-using-sigma/
 author: Patrick Bareiss
 date: 2019/04/07
 logsource:

--- a/rules/network/net_dns_c2_detection.yml
+++ b/rules/network/net_dns_c2_detection.yml
@@ -1,0 +1,19 @@
+title: DNS C2 Detection
+status: experimental
+description: Normally, there exists a limited amount of different dns queries for a single domain. If a huge number of dns queries were performed for a single domain, this can be an indicator that DNS is used for transferring data. 
+references:
+    - https://zeltser.com/c2-dns-tunneling/
+author: Patrick Bareiss
+date: 2019/04/07
+logsource:
+    product: dns
+detection:
+    selection:
+        parent_domain: '*'
+    condition: selection | count(dns_query) by parent_domain > 1000
+falsepositives:
+    - Valid software, which uses dns for transferring data
+level: high
+tags:
+    - attack.c2
+    - attack.t1043

--- a/rules/network/net_dns_c2_detection.yml
+++ b/rules/network/net_dns_c2_detection.yml
@@ -1,6 +1,6 @@
-title: DNS C2 Detection
+title: Possible DNS Tunneling
 status: experimental
-description: Normally, there exists a limited amount of different dns queries for a single domain. If a huge number of dns queries were performed for a single domain, this can be an indicator that DNS is used for transferring data. 
+description: Normally, DNS logs contain a limited amount of different dns queries for a single domain. This rule detects a high amount of queries for a single domain, which can be an indicator that DNS is used to transfer data. 
 references:
     - https://zeltser.com/c2-dns-tunneling/
     - https://patrick-bareiss.com/detect-c2-traffic-over-dns-using-sigma/


### PR DESCRIPTION
I created a new Sigma detection rule, which should detect malicious C2 communication over DNS. The idea is to distinct count the number of dns query per parent domain. If this value is huge, it is an indicator that the dns queries are used to transfer data.