### PR TITLE
Update win_mal_ursnif.yml

### DIFF
--- a/rules/windows/malware/win_mal_ursnif.yml
+++ b/rules/windows/malware/win_mal_ursnif.yml
@@ -15,7 +15,7 @@ logsource:
 detection:
     selection:
         EventID: 13
-        TargetObject: 'HKU\Software\AppDataLow\Software\Microsoft\\*'
+        TargetObject: '*\Software\AppDataLow\Software\Microsoft\\*'
     condition: selection
 falsepositives:
     - Unknown


### PR DESCRIPTION
After @thomaspatzke changed to HKU, I did some reading. HKU is for HKEY_User, not HKEY_Current_User (what this threat is tied to. However, he was correct that HKCU does not exist as a prefix for sysmon (see the notes section under event id 13 here: https://github.com/SwiftOnSecurity/sysmon-config/blob/master/sysmonconfig-export.xml). Changed to ignore the key name, confirmed that the key is still uniique.