### PR TITLE
Create apt_oceanlotus_registry.yml

### DIFF
--- a/rules/apt/apt_oceanlotus_registry.yml
+++ b/rules/apt/apt_oceanlotus_registry.yml
@@ -1,0 +1,27 @@
+title: OceanLotus Registry Activity
+status: experimental
+description: Detects registry keys created in OceanLotus (also known as APT32) attacks
+references:
+    - https://www.welivesecurity.com/2019/03/20/fake-or-fake-keeping-up-with-oceanlotus-decoys/
+tags:
+    - attack.t1112
+author: megan201296
+date: 2019/04/14
+logsource:
+    product: windows
+    service: sysmon
+detection:
+    selection:
+        EventID: 13
+        TargetObject: 
+            - '*\SOFTWARE\Classes\CLSID\{E08A0F4B-1F65-4D4D-9A09-BD4625B9C5A1}\Model' 
+            - '*\SOFTWARE\App\AppXbf13d4ea2945444d8b13e2121cb6b663\Application'
+            - '*\SOFTWARE\App\AppXbf13d4ea2945444d8b13e2121cb6b663\DefaultIcon'
+            - '*\SOFTWARE\App\AppX70162486c7554f7f80f481985d67586d\Application'
+            - '*\SOFTWARE\App\AppX70162486c7554f7f80f481985d67586d\DefaultIcon'
+            - '*\SOFTWARE\App\AppX37cc7fdccd644b4f85f4b22d5a3f105a\Application'
+            - '*\SOFTWARE\App\AppX37cc7fdccd644b4f85f4b22d5a3f105a\DefaultIcon'
+    condition: selection
+falsepositives:
+    - Unknown
+level: critical


### PR DESCRIPTION
Rule based on https://www.welivesecurity.com/2019/03/20/fake-or-fake-keeping-up-with-oceanlotus-decoys/. Based on OSINT, these keys are unique to the oceanlotus activity and not at all legitimate.