### PR TITLE
Correct parenthesization for NOT expressions in the ES-QS backend

### DIFF
--- a/tools/sigma/backends/elasticsearch.py
+++ b/tools/sigma/backends/elasticsearch.py
@@ -94,6 +94,11 @@ class ElasticsearchQuerystringBackend(ElasticsearchWildcardHandlingMixin, Single
             else:
                 return "\"%s\"" % result
 
+    def generateNOTNode(self, node):
+        expression = super().generateNode(node.item)
+        if expression:
+            return "(%s%s)" % (self.notToken, expression)
+
 class ElasticsearchDSLBackend(RulenameCommentMixin, ElasticsearchWildcardHandlingMixin, BaseBackend):
     """ElasticSearch DSL backend"""
     identifier = 'es-dsl'


### PR DESCRIPTION
## Problem

It looks like the parenthesization generated by the ES-QS backend is insufficient when the query contains multiple expressions.

### Source

https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html

> The familiar boolean operators AND, OR and NOT (also written &&, || and !) are also supported but beware that they do not honor the usual precedence rules, so parentheses should be used whenever multiple operators are used together

### Reproduce

Use the rule:

```yaml
title: Sample rule
tags: []
logsource:
    product: windows
    service: sysmon
detection:
    process_creation:
        EventID: 1
    excluded_paths:
        Image:
        - 'C:\\\\Windows*'
    ms_utils:
        Image:
        - 'C:\\\\Windows\\\\System32\\\\WindowsPowerShell\\\\v1.0\\\\powershell.exe'
    condition: process_creation and (ms_utils or not excluded_paths)
level: low
```

The generated ES query string is:

```
$ ./tools/sigmac -t es-qs ./sample.sigma
(EventID:"1" AND (Image:("C\:\\\\Windows\\\\System32\\\\WindowsPowerShell\\\\v1.0\\\\powershell.exe") OR NOT (Image.keyword:(C\:\\\\Windows*))))
```

Which does not seem to work because of missing parenthesis around the `NOT` expression.

## Patch

Add parenthesis around the `NOT` expressions.

Before the patch:

```
$ ./tools/sigmac -t es-qs ./sample.sigma
(EventID:"1" AND (Image:("C\:\\\\Windows\\\\System32\\\\WindowsPowerShell\\\\v1.0\\\\powershell.exe") OR NOT (Image.keyword:(C\:\\\\Windows*))))
```

After the patch:

```
(EventID:"1" AND (Image:("C\:\\\\Windows\\\\System32\\\\WindowsPowerShell\\\\v1.0\\\\powershell.exe") OR (NOT (Image.keyword:(C\:\\\\Windows*)))))
```
