### PR TITLE
Update win_susp_svchost rule

### DIFF
--- a/rules/windows/process_creation/win_susp_svchost.yml
+++ b/rules/windows/process_creation/win_susp_svchost.yml
@@ -17,6 +17,7 @@ detection:
             - '*\services.exe'
             - '*\MsMpEng.exe'
             - '*\Mrt.exe'
+            - '*\rpcnet.exe'
     condition: selection and not filter
 fields:
     - CommandLine


### PR DESCRIPTION
Adding rpcnet.exe as ParentImage for legit spawn of svchost.