### PR TITLE
New Sigma Use Case: Masquerading

### DIFF
--- a/rules/linux/test_config.yml
+++ b/rules/linux/test_config.yml
@@ -1,4 +1,0 @@
-logsources:
-  linux_test:
-    product: linux
-    index: unix

--- a/rules/linux/test_config.yml
+++ b/rules/linux/test_config.yml
@@ -1,0 +1,4 @@
+logsources:
+  linux_test:
+    product: linux
+    index: unix

--- a/rules/windows/sysmon/sysmon_masquerading.yml
+++ b/rules/windows/sysmon/sysmon_masquerading.yml
@@ -1,0 +1,46 @@
+title: Masquerading
+status: experimental
+description: Malware often uses well-known windows process names for their malicious process name to avoid detection. This technique is called masquerading.
+references:
+    - https://github.com/Azure/Azure-Sentinel/blob/master/Hunting%20Queries/SecurityEvent/masquerading_files.txt
+    - https://niiconsulting.com/checkmate/2017/08/threat-hunting-for-masquerading-windows-processes/
+    - https://patrick-bareiss.com/detecting-masquerading-of-malware-with-sigma/
+tags:
+    - attack.defense_evasion
+    - attack.t1036
+author: Patrick Bareiss
+date: 2019/04/17
+logsource:
+    product: windows
+    service: sysmon
+detection:
+    selection:
+        EventCode: 1
+        Image:
+            - '*\rundll32.exe'
+            - '*\svchost.exe'
+            - '*\smss.exe'
+            - '*\csrss.exe'
+            - '*\wininit.exe'
+            - '*\services.exe'
+            - '*\lsass.exe'
+            - '*\lsm.exe'
+            - '*\winlogon.exe'
+            - '*\explorer.exe'
+            - '*\taskhost.exe'             
+    filter:
+        Image: 
+            - '*\Windows\System32\*'
+            - '*\Windows\Syswow64\*'
+    known_false_positives:
+        Image: 
+            - 'C:\Windows\Explorer.EXE'
+    condition: selection and not filter and not known_false_positives
+fields:
+    - User
+    - Image
+    - CommandLine
+falsepositives:
+    - unknown
+level: critical
+


### PR DESCRIPTION
Malware often uses well-known windows system process names in order to avoid detection through the user or application whitelisting based on file names. This is a Sigma Use Case detecting Masquerading of malware.

https://patrick-bareiss.com/detecting-masquerading-of-malware-with-sigma/