### PR TITLE
New Sigma rule detecting local user creation

### DIFF
--- a/rules/windows/builtin/win_user_creation.yml
+++ b/rules/windows/builtin/win_user_creation.yml
@@ -1,0 +1,24 @@
+title: Detects local user creation
+description: Detects local user creation on windows servers, which shouldn't happen in an Active Directory environment. Apply this Sigma Use Case on your windows server logs and not on your DC logs. 
+tags:
+    - attack.privilege_escalation
+    - attack.t1078
+references:
+    - https://patrick-bareiss.com/detecting-local-user-creation-in-ad-with-sigma/ 
+author: Patrick Bareiss
+logsource:
+    product: windows
+    service: security
+detection:
+    selection:
+        EventID: 4720
+    condition: selection
+fields:
+    - EventCode
+    - Account_Name
+    - Account_Domain
+falsepositives: 
+    - Domain Controller Logs
+level: high
+
+

--- a/rules/windows/builtin/win_user_creation.yml
+++ b/rules/windows/builtin/win_user_creation.yml
@@ -1,8 +1,9 @@
 title: Detects local user creation
 description: Detects local user creation on windows servers, which shouldn't happen in an Active Directory environment. Apply this Sigma Use Case on your windows server logs and not on your DC logs. 
+status: experimental
 tags:
-    - attack.privilege_escalation
-    - attack.t1078
+    - attack.persistence
+    - attack.t1136
 references:
     - https://patrick-bareiss.com/detecting-local-user-creation-in-ad-with-sigma/ 
 author: Patrick Bareiss


### PR DESCRIPTION
The creation of a new user creates a Windows Event Log of Type Security with the Event Code 4720. In an AD environment, only domain controller should create these Windows Event Logs. If these logs are seen from non domain controller, this is an indicator of compromise.

https://patrick-bareiss.com/detecting-local-user-creation-in-ad-with-sigma/