### PR TITLE
Restrict filter in system exe anomaly rule

### DIFF
--- a/rules/windows/process_creation/win_system_exe_anomaly.yml
+++ b/rules/windows/process_creation/win_system_exe_anomaly.yml
@@ -26,8 +26,8 @@ detection:
             - '*\conhost.exe'
     filter:
         Image:
-            - '*\System32\\*'
-            - '*\SysWow64\\*'
+            - 'C:\Windows\System32\\*'
+            - 'C:\Windows\SysWow64\\*'
     condition: selection and not filter
 falsepositives:
     - Exotic software


### PR DESCRIPTION
Restrict whitelist filter to exact system directories in where the binaries are located. Otherwise, an attacker only has to place his binaries inside a sub-folder called System32 or SysWow64 and would therefore bypass this valuable generic rule.

Is there a reason to use less restricted filters here?

This one like the other PRs is an output of my in-depth analysis of wildcards used in filters: https://github.com/Karneades/SigmaFilterCheck.