### PR TITLE
Add default path for explorer to filter in exe anomaly rule

### DIFF
--- a/rules/windows/process_creation/win_system_exe_anomaly.yml
+++ b/rules/windows/process_creation/win_system_exe_anomaly.yml
@@ -33,6 +33,7 @@ detection:
         Image:
             - 'C:\Windows\System32\\*'
             - 'C:\Windows\SysWow64\\*'
+            - 'C:\Windows\explorer.exe'
     condition: selection and not filter
 falsepositives:
     - Exotic software


### PR DESCRIPTION
While merging https://github.com/Neo23x0/sigma/pull/321 the filter explorer's default path got lost and that generates a lot of events :)