### PR TITLE
Added logsources for generic sigma rules to spark config, renamed spa…

### DIFF
--- a/tools/config/thor.yml
+++ b/tools/config/thor.yml
@@ -1,5 +1,28 @@
-order: 20
+# this configuration differs from other configurations and can not be used
+# with the sigmac tool. This configuration is used by the ioc scanners THOR and SPARK.
 logsources:
+  # log source configurations for generic sigma rules
+  process_creation_1:
+    category: process_creation
+    product: windows
+    conditions:
+      EventID: 1
+    rewrite:
+      product: windows
+      service: sysmon
+  process_creation_2:
+    category: process_creation
+    product: windows
+    conditions:
+      EventID: 4688
+    rewrite:
+      product: windows
+      service: security
+    fieldmappings:
+      Image: NewProcessName
+      ParentImage: ParentProcessName
+      CommandLine: ProcessCommandLine
+  # target system configurations
   windows-application:
     product: windows
     service: application
@@ -35,11 +58,6 @@ logsources:
     service: wmi
     sources: 
       - 'WinEventLog:Microsoft-Windows-WMI-Activity/Operational'
-  windows-dhcp:
-    product: windows
-    service: dhcp
-    sources: 
-      - 'WinEventLog:Microsoft-Windows-DHCP-Server/Operational'
   apache:
     category: webserver
     sources:
@@ -51,10 +69,14 @@ logsources:
     service: auth
     sources:
       - 'File:/var/log/auth.log'
-      - 'File:/var/log/auth.log.?' # auth.log.1, auth.log.2, ...
+      - 'File:/var/log/auth.log.?'
   linux-syslog:
     product: linux
     service: syslog
     sources:
       - 'File:/var/log/syslog'
-      - 'File:/var/log/syslog.?' # syslog.1, syslog.2 ...
+      - 'File:/var/log/syslog.?'
+  logfiles:
+    category: logfile
+    sources:
+      - 'File:*.log'

--- a/tools/config/thor.yml
+++ b/tools/config/thor.yml
@@ -58,6 +58,11 @@ logsources:
     service: wmi
     sources: 
       - 'WinEventLog:Microsoft-Windows-WMI-Activity/Operational'
+  windows-dhcp:
+    product: windows
+    service: dhcp
+    sources: 
+      - 'WinEventLog:Microsoft-Windows-DHCP-Server/Operational'
   apache:
     category: webserver
     sources:

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -51,7 +51,7 @@ setup(
             'config/elk-defaultindex-logstash.yml',
             'config/elk-linux.yml',
             'config/logpoint-windows-all.yml',
-            'config/spark.yml',
+            'config/thor.yml',
             'config/elk-winlogbeat.yml',
             'config/elk-defaultindex-filebeat.yml',
             'config/splunk-windows-all.yml',


### PR DESCRIPTION
SPARK requires and updated spark.yml to support the new "log source configurations" for generic sigma rules, e.g. `category: process_creation`. THOR will support Sigma in the future, too, that's why I favor to rename the config from spark.yml to thor.yml.