### PR TITLE
added rule Detects Executions on Behalf of Web Server

### DIFF
--- a/rules/linux/auditd/lnx_auditd_susp_exe_webserver.yml
+++ b/rules/linux/auditd/lnx_auditd_susp_exe_webserver.yml
@@ -2,7 +2,12 @@ title: Detects Executions on Behalf of Web Server
 status: experimental
 description: Purpose of this rule is to detect post exploitation techniques by monitoring of shell commands on behalf of Web Server like Apache and Nginx. Web Server is usually running as user UID=33 without assigned tty.
 references:
-    - 'Internal Research - mostly derived from observing web shell artefacts'
+    - 'Internal Research - mostly derived from observing web shell artefacts. https://github.com/petermat/sigma-rules-contribution/blob/master/lnx_auditd_susp_exe_webserver.md'
+tags:
+    - attack.s0003
+    - attack.t1100
+    - attack.persistence
+    - attack.privilege_escalation
 date: 2019/05/02
 author: Peter Matkovski
 logsource:

--- a/rules/linux/auditd/lnx_auditd_susp_exe_webserver.yml
+++ b/rules/linux/auditd/lnx_auditd_susp_exe_webserver.yml
@@ -1,0 +1,22 @@
+title: Detects Executions on Behalf of Web Server
+status: experimental
+description: Purpose of this rule is to detect post exploitation techniques by monitoring of shell commands on behalf of Web Server like Apache and Nginx. Web Server is usually running as user UID=33 without assigned tty.
+references:
+    - 'Internal Research - mostly derived from observing web shell artefacts'
+date: 2019/05/02
+author: Peter Matkovski
+logsource:
+    product: linux
+    service: auditd
+detection:
+    cmd:
+        - type: 'SYSCALL'
+          success: 'yes'
+          uid: '33'
+          tty: '(none)'
+          comm: 'sh'
+          exe: '/bin/dash'
+    condition: cmd
+falsepositives:
+    - Crazy Web Applications 
+level: medium


### PR DESCRIPTION
Purpose of this rule is to detect post-exploitation techniques by monitoring of shell commands on behalf of Web Server like Apache and Nginx. Web Server is usually running as user UID=33 without assigned tty.

**Mitre Attack Classification**
ID: [T1100](https://attack.mitre.org/techniques/T1100/)
Tactic: Persistence, Privilege Escalation
Platform:  Linux, macOS
System Requirements:  Adversary access to Web server with vulnerability or account to upload and serve the Web shell file.
Effective Permissions:  SYSTEM, User
Data Sources:  Process monitoring

More info
* [Detection of PHP Web Shells with Access log, WAF and Audit Deamon](https://medium.com/@p.matkovski/detection-of-php-web-shells-with-access-log-waf-and-audit-deamon-e798d4c95ec)
* [Detection of PHP Web Shells with SIGMA](https://medium.com/@p.matkovski/detection-of-php-web-shells-with-sigma-475de8386d2b)