### PR TITLE
fix: fixed reference list, otherwise it's not valid string list

### DIFF
--- a/rules/windows/process_creation/win_office_spawn_exe_from_users_directory.yml
+++ b/rules/windows/process_creation/win_office_spawn_exe_from_users_directory.yml
@@ -2,7 +2,7 @@ title: MS Office Product Spawning Exe in User Dir
 status: experimental
 description: Detects an executable in the users directory started from Microsoft Word, Excel, Powerpoint, Publisher or Visio
 references:
-    - sha256: 23160972c6ae07f740800fa28e421a81d7c0ca5d5cab95bc082b4a986fbac57c
+    - sha256=23160972c6ae07f740800fa28e421a81d7c0ca5d5cab95bc082b4a986fbac57c
     - https://blog.morphisec.com/fin7-not-finished-morphisec-spots-new-campaign 
 tags:
     - attack.execution


### PR DESCRIPTION
I'm unable to parse `rules/windows/process_creation/win_office_spawn_exe_from_users_directory.yml` because the reference list is not parsable as string list.

With Golang's YAML Unmarshaler I get the following error: 
```
yaml: unmarshal errors:  line 5: cannot unmarshal !!map into string
```
