### PR TITLE
fix: fixed reference list, otherwise it's not valid string list

### DIFF
--- a/rules/windows/process_creation/win_renamed_paexec.yml
+++ b/rules/windows/process_creation/win_renamed_paexec.yml
@@ -2,7 +2,7 @@ title: Execution of Renamed PaExec
 status: experimental
 description: Detects execution of renamed paexec via imphash and executable product string 
 references:
-    - sha256: 01a461ad68d11b5b5096f45eb54df9ba62c5af413fa9eb544eacb598373a26bc 
+    - sha256=01a461ad68d11b5b5096f45eb54df9ba62c5af413fa9eb544eacb598373a26bc 
     - https://summit.fireeye.com/content/dam/fireeye-www/summit/cds-2018/presentations/cds18-technical-s05-att&cking-fin7.pdf
 tags:
     - attack.defense_evasion


### PR DESCRIPTION
I'm unable to parse `rules/windows/process_creation/win_renamed_paexec.yml` because the reference list is not parsable as string list (see Pull Request [#334](https://github.com/Neo23x0/sigma/pull/334)).

With Golang's YAML Unmarshaler I get the following error:

```
yaml: unmarshal errors:  line 5: cannot unmarshal !!map into string
```