### PR TITLE
Add rule for CVE-2019-0708

### DIFF
--- a/rules/windows/builtin/win_rdp_potential_cve-2019-0708.yml
+++ b/rules/windows/builtin/win_rdp_potential_cve-2019-0708.yml
@@ -15,6 +15,6 @@ detection:
         Source: TermDD
     condition: selection
 falsepositives:
-    - Unknown
-level: critical
+    - Bad connections or network interruptions
+level: high
 

--- a/rules/windows/builtin/win_rdp_potential_cve-2019-0708.yml
+++ b/rules/windows/builtin/win_rdp_potential_cve-2019-0708.yml
@@ -1,0 +1,20 @@
+title: Potential RDP exploit CVE-2019-0708
+description: Detect suspicious error on protocol RDP, potential CVE-2019-0708
+references:
+    - https://github.com/zerosum0x0/CVE-2019-0708
+tags:
+    - attack.initial_access
+status: experimental
+author: Lionel PRAT, Christophe BROCAS
+logsource:
+    product: windows
+    service: system
+detection:
+    selection:
+        EventID: 56
+        Source: TermDD
+    condition: selection
+falsepositives:
+    - Unknown
+level: critical
+


### PR DESCRIPTION
Hi,
It's rule for detect potential exploit of CVE-2019-0708 in event windows. Rule is based on event created (http://www.eventid.net/display-eventid-56-source-TermDD-eventno-9421-phase-1.htm)  when use scan CVE-2019-0708 (https://github.com/zerosum0x0/CVE-2019-0708).

Sincerly.
Lionel & Christophe