### PR TITLE
fix missing condition when unique plus timeframe

### DIFF
--- a/tools/sigma/backends/elasticsearch.py
+++ b/tools/sigma/backends/elasticsearch.py
@@ -245,7 +245,9 @@ class ElasticsearchDSLBackend(RulenameCommentMixin, ElasticsearchWildcardHandlin
             dateField = self.sigmaconfig.config['dateField']
         if self.interval:
             if 'bool' not in self.queries[-1]['query']['constant_score']['filter']:
+                saved_simple_query = self.queries[-1]['query']['constant_score']['filter']
                 self.queries[-1]['query']['constant_score']['filter'] = {'bool': {'must': []}}
+                self.queries[-1]['query']['constant_score']['filter']['bool']['must'].append(saved_simple_query)
             if 'must' not in self.queries[-1]['query']['constant_score']['filter']['bool']:
                 self.queries[-1]['query']['constant_score']['filter']['bool']['must'] = []
 
@@ -748,7 +750,7 @@ class ElastalertBackend(MultiRuleOutputMixin, ElasticsearchQuerystringBackend):
                     if idx == agg.aggfunc:
                         funcname = name
                         break
-                raise NotImplementedError("%s : The '%s' aggregation operator is not yet implemented for this backend"%(self.title, funcname)) 
+                raise NotImplementedError("%s : The '%s' aggregation operator is not yet implemented for this backend"%(self.title, funcname))
 
     def convertLevel(self, level):
     	return {

--- a/tools/sigma/backends/elasticsearch.py
+++ b/tools/sigma/backends/elasticsearch.py
@@ -247,7 +247,8 @@ class ElasticsearchDSLBackend(RulenameCommentMixin, ElasticsearchWildcardHandlin
             if 'bool' not in self.queries[-1]['query']['constant_score']['filter']:
                 saved_simple_query = self.queries[-1]['query']['constant_score']['filter']
                 self.queries[-1]['query']['constant_score']['filter'] = {'bool': {'must': []}}
-                self.queries[-1]['query']['constant_score']['filter']['bool']['must'].append(saved_simple_query)
+                if len(saved_simple_query.keys()) > 0:
+                    self.queries[-1]['query']['constant_score']['filter']['bool']['must'].append(saved_simple_query)
             if 'must' not in self.queries[-1]['query']['constant_score']['filter']['bool']:
                 self.queries[-1]['query']['constant_score']['filter']['bool']['must'] = []
 


### PR DESCRIPTION
When only one `condition` exists `filter` doesn't use a `must` array.

When `timeframe` exists, it tries to push the condition in a `must` array and create it first if it doesn't exists replacing the single condition.

## Current behaviour

```
$ tools/sigmac --target es-dsl --config tools/config/elk-winlogbeat.yml rules/windows/builtin/win_rare_service_installs.yml
{
  "query": {
    "constant_score": {
      "filter": {
        "bool": {
          "must": [
            {
              "range": {
                "date": {
                  "gte": "now-7d"
                }
              }
            }
          ]
        }
      }
    }
  },
  "aggs": {
    "event_data.ServiceFileName_count": {
      "terms": {
        "field": "event_data.ServiceFileName"
      },
      "aggs": {
        "limit": {
          "bucket_selector": {
            "buckets_path": {
              "count": "_count"
            },
            "script": "params.count < 5"
          }
        }
      }
    }
  }
}
```

`EventID: 7045` disappeared

## Expected behaviour

```
$ tools/sigmac --target es-dsl --config tools/config/elk-winlogbeat.yml rules/windows/builtin/win_rare_service_installs.yml
{
  "query": {
    "constant_score": {
      "filter": {
        "bool": {
          "must": [
            {
              "match_phrase": {
                "event_id": "7045"
              }
            },
            {
              "range": {
                "date": {
                  "gte": "now-7d"
                }
              }
            }
          ]
        }
      }
    }
  },
  "aggs": {
    "event_data.ServiceFileName_count": {
      "terms": {
        "field": "event_data.ServiceFileName"
      },
      "aggs": {
        "limit": {
          "bucket_selector": {
            "buckets_path": {
              "count": "_count"
            },
            "script": "params.count < 5"
          }
        }
      }
    }
  }
}
```