### PR TITLE
Add detection for recent Mimikatz versions

### DIFF
--- a/rules/windows/sysmon/sysmon_mimikatz_detection_lsass.yml
+++ b/rules/windows/sysmon/sysmon_mimikatz_detection_lsass.yml
@@ -1,8 +1,9 @@
 title: Mimikatz Detection LSASS Access
 status: experimental
-description: Detects process access to LSASS which is typical for Mimikatz (0x1000 PROCESS_QUERY_ LIMITED_INFORMATION, 0x0400 PROCESS_QUERY_ INFORMATION, 0x0010 PROCESS_VM_READ)
+description: Detects process access to LSASS which is typical for Mimikatz (0x1000 PROCESS_QUERY_ LIMITED_INFORMATION, 0x0400 PROCESS_QUERY_ INFORMATION "only old versions", 0x0010 PROCESS_VM_READ)
 references:
     - https://onedrive.live.com/view.aspx?resid=D026B4699190F1E6!2843&ithint=file%2cpptx&app=PowerPoint&authkey=!AMvCRTKB_V1J5ow
+    - https://cyberwardog.blogspot.com/2017/03/chronicles-of-threat-hunter-hunting-for_22.html
 tags:
     - attack.t1003
     - attack.s0002
@@ -14,7 +15,9 @@ detection:
     selection:
         EventID: 10
         TargetImage: 'C:\windows\system32\lsass.exe'
-        GrantedAccess: '0x1410'
+        GrantedAccess:
+            - '0x1410'      
+            - '0x1010'      
     condition: selection
 falsepositives:
     - unknown


### PR DESCRIPTION
GrantedAccess is 0x1010 not 0x1410 in recent versions of mimikatz.
This modification should address both