### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/contrib/sigma2elastalert.py
+++ b/contrib/sigma2elastalert.py
@@ -162,12 +162,12 @@ for file in glob.glob(args.ruledir + "/*"):
             output_elast_config = re.sub(entry, str(convert_args[entry]), output_elast_config)
         for entry in translate_func:
             output_elast_config = re.sub(entry, translate_func[entry], output_elast_config)
-        print "Converting file " + file
+        print("Converting file " + file)
         with open(os.path.join(args.outdir, "sigma-" + file.split("/")[-1]), "w") as f:
                 f.write(output_elast_config)
     except Exception as e:
         if args.debug:
             traceback.print_exc()
-        print "error " + str(file) + "----" + str(e)
+        print("error " + str(file) + "----" + str(e))
         pass
 


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.

[flake8](http://flake8.pycqa.org) testing of https://github.com/Neo23x0/sigma on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./contrib/sigma2sumologic.py:123:5: F821 undefined name 'parser_print_help'
    parser_print_help()
    ^
./contrib/sigma2sumologic.py:211:32: F821 undefined name 'r'
            f.write(json.dumps(r, indent=4, sort_keys=True) + " ERROR: %s\n\nQUERY: %s" % (e, sumo_query))
                               ^
./contrib/sigma2elastalert.py:165:32: E999 SyntaxError: invalid syntax
        print "Converting file " + file
                               ^
./tools/sigma/parser/collection.py:52:27: F821 undefined name 'SigmaCollectionParseError'
                    raise SigmaCollectionParseError("action 'repeat' is only applicable after first valid Sigma rule")
                          ^
1     E999 SyntaxError: invalid syntax
3     F821 undefined name 'parser_print_help'
4
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree