### PR TITLE
Modified winlogbeat config to adhere to winlogbeat 7 field names

### DIFF
--- a/tools/config/elk-winlogbeat-old.yml
+++ b/tools/config/elk-winlogbeat-old.yml
@@ -1,0 +1,114 @@
+title: Elastic Winlogbeat index pattern and field mapping
+order: 20
+backends:
+  - es-qs
+  - es-dsl
+  - kibana
+  - xpack-watcher
+  - elastalert
+  - elastalert-dsl
+logsources:
+  windows:
+    product: windows
+    index: winlogbeat-*
+  windows-application:
+    product: windows
+    service: application
+    conditions:
+      log_name: Application
+  windows-security:
+    product: windows
+    service: security
+    conditions:
+      log_name: Security
+  windows-sysmon:
+    product: windows
+    service: sysmon
+    conditions:
+      log_name: 'Microsoft-Windows-Sysmon/Operational'
+  windows-dns-server:
+    product: windows
+    service: dns-server
+    conditions:
+      log_name: 'DNS Server'
+  windows-driver-framework:
+    product: windows
+    service: driver-framework
+    conditions:
+      source: 'Microsoft-Windows-DriverFrameworks-UserMode/Operational'
+  windows-dhcp:
+    product: windows
+    service: dhcp
+    conditions:
+      source: 'Microsoft-Windows-DHCP-Server/Operational'
+defaultindex: winlogbeat-*
+# Extract all field names qith yq:
+# yq -r '.detection | del(.condition) | map(keys) | .[][]' $(find sigma/rules/windows -name '*.yml') | sort -u | grep -v ^EventID$ | sed 's/^\(.*\)/    \1: event_data.\1/g'
+# Keep EventID! Clean up the list afterwards!
+fieldmappings:
+    EventID: event_id
+    AccessMask: event_data.AccessMask
+    AccountName: event_data.AccountName
+    AllowedToDelegateTo: event_data.AllowedToDelegateTo
+    AttributeLDAPDisplayName: event_data.AttributeLDAPDisplayName
+    AuditPolicyChanges: event_data.AuditPolicyChanges
+    AuthenticationPackageName: event_data.AuthenticationPackageName
+    CallingProcessName: event_data.CallingProcessName
+    CallTrace: event_data.CallTrace
+    CommandLine: event_data.CommandLine
+    ComputerName: event_data.ComputerName
+    CurrentDirectory: event_data.CurrentDirectory
+    Description: event_data.Description
+    DestinationHostname: event_data.DestinationHostname
+    DestinationIp: event_data.DestinationIp
+    DestinationIsIpv6: event_data.DestinationIsIpv6
+    DestinationPort: event_data.DestinationPort
+    Details: event_data.Details
+    EngineVersion: event_data.EngineVersion
+    EventType: event_data.EventType
+    FailureCode: event_data.FailureCode
+    FileName: event_data.FileName
+    GrantedAccess: event_data.GrantedAccess
+    GroupName: event_data.GroupName
+    Hashes: event_data.Hashes
+    HiveName: event_data.HiveName
+    HostVersion: event_data.HostVersion
+    Image: event_data.Image
+    ImageLoaded: event_data.ImageLoaded
+    ImagePath: event_data.ImagePath
+    Imphash: event_data.Imphash
+    IpAddress: event_data.IpAddress
+    KeyLength: event_data.KeyLength
+    LogonProcessName: event_data.LogonProcessName
+    LogonType: event_data.LogonType
+    NewProcessName: event_data.NewProcessName
+    ObjectClass: event_data.ObjectClass
+    ObjectName: event_data.ObjectName
+    ObjectType: event_data.ObjectType
+    ObjectValueName: event_data.ObjectValueName
+    ParentCommandLine: event_data.ParentCommandLine
+    ParentProcessName: event_data.ParentProcessName
+    ParentImage: event_data.ParentImage
+    Path: event_data.Path
+    PipeName: event_data.PipeName
+    ProcessCommandLine: event_data.ProcessCommandLine
+    ProcessName: event_data.ProcessName
+    Properties: event_data.Properties
+    SecurityID: event_data.SecurityID
+    ServiceFileName: event_data.ServiceFileName
+    ServiceName: event_data.ServiceName
+    ShareName: event_data.ShareName
+    Signature: event_data.Signature
+    Source: event_data.Source
+    SourceImage: event_data.SourceImage
+    StartModule: event_data.StartModule
+    Status: event_data.Status
+    SubjectUserName: event_data.SubjectUserName
+    SubjectUserSid: event_data.SubjectUserSid
+    TargetFilename: event_data.TargetFilename
+    TargetImage: event_data.TargetImage
+    TargetObject: event_data.TargetObject
+    TicketEncryptionType: event_data.TicketEncryptionType
+    TicketOptions: event_data.TicketOptions
+    User: event_data.User
+    WorkstationName: event_data.WorkstationName

--- a/tools/config/elk-winlogbeat.yml
+++ b/tools/config/elk-winlogbeat.yml
@@ -15,100 +15,100 @@ logsources:
     product: windows
     service: application
     conditions:
-      log_name: Application
+      winlog.channel: Application
   windows-security:
     product: windows
     service: security
     conditions:
-      log_name: Security
+      winlog.channel: Security
   windows-sysmon:
     product: windows
     service: sysmon
     conditions:
-      log_name: 'Microsoft-Windows-Sysmon/Operational'
+      winlog.channel: 'Microsoft-Windows-Sysmon/Operational'
   windows-dns-server:
     product: windows
     service: dns-server
     conditions:
-      log_name: 'DNS Server'
+      winlog.channel: 'DNS Server'
   windows-driver-framework:
     product: windows
     service: driver-framework
     conditions:
-      source: 'Microsoft-Windows-DriverFrameworks-UserMode/Operational'
+      winlog.provider_name: 'Microsoft-Windows-DriverFrameworks-UserMode/Operational'
   windows-dhcp:
     product: windows
     service: dhcp
     conditions:
-      source: 'Microsoft-Windows-DHCP-Server/Operational'
+      winlog.provider_name: 'Microsoft-Windows-DHCP-Server/Operational'
 defaultindex: winlogbeat-*
 # Extract all field names qith yq:
-# yq -r '.detection | del(.condition) | map(keys) | .[][]' $(find sigma/rules/windows -name '*.yml') | sort -u | grep -v ^EventID$ | sed 's/^\(.*\)/    \1: event_data.\1/g'
+# yq -r '.detection | del(.condition) | map(keys) | .[][]' $(find sigma/rules/windows -name '*.yml') | sort -u | grep -v ^EventID$ | sed 's/^\(.*\)/    \1: winlog.event_data.\1/g'
 # Keep EventID! Clean up the list afterwards!
 fieldmappings:
-    EventID: event_id
-    AccessMask: event_data.AccessMask
-    AccountName: event_data.AccountName
-    AllowedToDelegateTo: event_data.AllowedToDelegateTo
-    AttributeLDAPDisplayName: event_data.AttributeLDAPDisplayName
-    AuditPolicyChanges: event_data.AuditPolicyChanges
-    AuthenticationPackageName: event_data.AuthenticationPackageName
-    CallingProcessName: event_data.CallingProcessName
-    CallTrace: event_data.CallTrace
-    CommandLine: event_data.CommandLine
-    ComputerName: event_data.ComputerName
-    CurrentDirectory: event_data.CurrentDirectory
-    Description: event_data.Description
-    DestinationHostname: event_data.DestinationHostname
-    DestinationIp: event_data.DestinationIp
-    DestinationIsIpv6: event_data.DestinationIsIpv6
-    DestinationPort: event_data.DestinationPort
-    Details: event_data.Details
-    EngineVersion: event_data.EngineVersion
-    EventType: event_data.EventType
-    FailureCode: event_data.FailureCode
-    FileName: event_data.FileName
-    GrantedAccess: event_data.GrantedAccess
-    GroupName: event_data.GroupName
-    Hashes: event_data.Hashes
-    HiveName: event_data.HiveName
-    HostVersion: event_data.HostVersion
-    Image: event_data.Image
-    ImageLoaded: event_data.ImageLoaded
-    ImagePath: event_data.ImagePath
-    Imphash: event_data.Imphash
-    IpAddress: event_data.IpAddress
-    KeyLength: event_data.KeyLength
-    LogonProcessName: event_data.LogonProcessName
-    LogonType: event_data.LogonType
-    NewProcessName: event_data.NewProcessName
-    ObjectClass: event_data.ObjectClass
-    ObjectName: event_data.ObjectName
-    ObjectType: event_data.ObjectType
-    ObjectValueName: event_data.ObjectValueName
-    ParentCommandLine: event_data.ParentCommandLine
-    ParentProcessName: event_data.ParentProcessName
-    ParentImage: event_data.ParentImage
-    Path: event_data.Path
-    PipeName: event_data.PipeName
-    ProcessCommandLine: event_data.ProcessCommandLine
-    ProcessName: event_data.ProcessName
-    Properties: event_data.Properties
-    SecurityID: event_data.SecurityID
-    ServiceFileName: event_data.ServiceFileName
-    ServiceName: event_data.ServiceName
-    ShareName: event_data.ShareName
-    Signature: event_data.Signature
-    Source: event_data.Source
-    SourceImage: event_data.SourceImage
-    StartModule: event_data.StartModule
-    Status: event_data.Status
-    SubjectUserName: event_data.SubjectUserName
-    SubjectUserSid: event_data.SubjectUserSid
-    TargetFilename: event_data.TargetFilename
-    TargetImage: event_data.TargetImage
-    TargetObject: event_data.TargetObject
-    TicketEncryptionType: event_data.TicketEncryptionType
-    TicketOptions: event_data.TicketOptions
-    User: event_data.User
-    WorkstationName: event_data.WorkstationName
+    EventID: winlog.event_id
+    AccessMask: winlog.event_data.AccessMask
+    AccountName: winlog.event_data.AccountName
+    AllowedToDelegateTo: winlog.event_data.AllowedToDelegateTo
+    AttributeLDAPDisplayName: winlog.event_data.AttributeLDAPDisplayName
+    AuditPolicyChanges: winlog.event_data.AuditPolicyChanges
+    AuthenticationPackageName: winlog.event_data.AuthenticationPackageName
+    CallingProcessName: winlog.event_data.CallingProcessName
+    CallTrace: winlog.event_data.CallTrace
+    CommandLine: winlog.event_data.CommandLine
+    ComputerName: winlog.ComputerName
+    CurrentDirectory: winlog.event_data.CurrentDirectory
+    Description: winlog.event_data.Description
+    DestinationHostname: winlog.event_data.DestinationHostname
+    DestinationIp: winlog.event_data.DestinationIp
+    DestinationIsIpv6: winlog.event_data.DestinationIsIpv6
+    DestinationPort: winlog.event_data.DestinationPort
+    Details: winlog.event_data.Details
+    EngineVersion: winlog.event_data.EngineVersion
+    EventType: winlog.event_data.EventType
+    FailureCode: winlog.event_data.FailureCode
+    FileName: winlog.event_data.FileName
+    GrantedAccess: winlog.event_data.GrantedAccess
+    GroupName: winlog.event_data.GroupName
+    Hashes: winlog.event_data.Hashes
+    HiveName: winlog.event_data.HiveName
+    HostVersion: winlog.event_data.HostVersion
+    Image: winlog.event_data.Image
+    ImageLoaded: winlog.event_data.ImageLoaded
+    ImagePath: winlog.event_data.ImagePath
+    Imphash: winlog.event_data.Imphash
+    IpAddress: winlog.event_data.IpAddress
+    KeyLength: winlog.event_data.KeyLength
+    LogonProcessName: winlog.event_data.LogonProcessName
+    LogonType: winlog.event_data.LogonType
+    NewProcessName: winlog.event_data.NewProcessName
+    ObjectClass: winlog.event_data.ObjectClass
+    ObjectName: winlog.event_data.ObjectName
+    ObjectType: winlog.event_data.ObjectType
+    ObjectValueName: winlog.event_data.ObjectValueName
+    ParentCommandLine: winlog.event_data.ParentCommandLine
+    ParentProcessName: winlog.event_data.ParentProcessName
+    ParentImage: winlog.event_data.ParentImage
+    Path: winlog.event_data.Path
+    PipeName: winlog.event_data.PipeName
+    ProcessCommandLine: winlog.event_data.ProcessCommandLine
+    ProcessName: winlog.event_data.ProcessName
+    Properties: winlog.event_data.Properties
+    SecurityID: winlog.event_data.SecurityID
+    ServiceFileName: winlog.event_data.ServiceFileName
+    ServiceName: winlog.event_data.ServiceName
+    ShareName: winlog.event_data.ShareName
+    Signature: winlog.event_data.Signature
+    Source: winlog.event_data.Source
+    SourceImage: winlog.event_data.SourceImage
+    StartModule: winlog.event_data.StartModule
+    Status: winlog.event_data.Status
+    SubjectUserName: winlog.event_data.SubjectUserName
+    SubjectUserSid: winlog.event_data.SubjectUserSid
+    TargetFilename: winlog.event_data.TargetFilename
+    TargetImage: winlog.event_data.TargetImage
+    TargetObject: winlog.event_data.TargetObject
+    TicketEncryptionType: winlog.event_data.TicketEncryptionType
+    TicketOptions: winlog.event_data.TicketOptions
+    User: winlog.event_data.User
+    WorkstationName: winlog.event_data.WorkstationName


### PR DESCRIPTION
Fix #384 .

In this version I kept two version of the file, one old (pre-version 7 of winlogbeat) and one new (post version 7 of winlogbeat) version of the config file. Does it make sense? If it is the case, how should we name the files?

