### PR TITLE
Include Github raw URLs in suspicious downloads detection rule

### DIFF
--- a/rules/windows/sysmon/sysmon_win_binary_susp_com.yml
+++ b/rules/windows/sysmon/sysmon_win_binary_susp_com.yml
@@ -18,6 +18,7 @@ detection:
         DestinationHostname: 
             - '*dl.dropboxusercontent.com'
             - '*.pastebin.com'
+            - '*.githubusercontent.com' # includes both gists and github repositories
         Image: 'C:\Windows\\*'
     condition: selection
 falsepositives:


### PR DESCRIPTION
Relevant when directly retrieving pentest tools from github, e.g. Powershell mafia & co