### PR TITLE
Fixed commandline to detect any shim install from any location

### DIFF
--- a/rules/windows/process_creation/win_sdbinst_shim_persistence.yml
+++ b/rules/windows/process_creation/win_sdbinst_shim_persistence.yml
@@ -1,13 +1,12 @@
 title: Possible Shim Database Persistence via sdbinst.exe
 status: experimental
-description: Detects execution of sdbinst writing to default shim database path C:\Windows\AppPatch\*
+description: Detects installation of a new shim using sdbinst.exe. A shim can be used to load malicious DLLs into applications.
 references:
     - https://www.fireeye.com/blog/threat-research/2017/05/fin7-shim-databases-persistence.html
 tags:
     - attack.persistence
     - attack.t1138
 author: Markus Neis
-date: 2018/08/03
 logsource:
     category: process_creation
     product: windows
@@ -16,7 +15,7 @@ detection:
         Image:
             - '*\sdbinst.exe'
         CommandLine:
-            - '*\AppPatch\\*}.sdb*'
+            - '*.sdb*'
     condition: selection
 falsepositives:
     - Unknown


### PR DESCRIPTION
A shim database can be loaded from any path, not just AppPatch. I updated the rule to trigger on any sdb installation. `sdbinst.exe` should be rare enough in most environments to trigger on its execution alone, but I'm keeping the file to stay on the safe side.