### PR TITLE
Support OR queries for Elasticsearch 6 and above

### DIFF
--- a/tools/sigma/backends/elasticsearch.py
+++ b/tools/sigma/backends/elasticsearch.py
@@ -81,7 +81,7 @@ class ElasticsearchQuerystringBackend(ElasticsearchWildcardHandlingMixin, Single
     notToken = "NOT "
     subExpression = "(%s)"
     listExpression = "(%s)"
-    listSeparator = " "
+    listSeparator = " OR "
     valueExpression = "%s"
     nullExpression = "NOT _exists_:%s"
     notNullExpression = "_exists_:%s"


### PR DESCRIPTION
## Issue description

From https://docs.graylog.org/en/3.0/pages/upgrade/graylog-2.5.html

> Before Elasticsearch 6, queries for keyword fields were split by whitespaces and combined with OR operators resulting, for example, in type:(ssh login) and type:(ssh OR login) being equivalent. This is no longer the case in Elasticsearch 6 and now those queries are different: the former looking for the ssh login value, the second for either ssh or login values.

This is an issue with the queries generated by sigma. For instance, the following rule:

```yml
detection:
  selection:
    EventID:
    - 4624
    - 4625

  condition: selection
```

.. translates into

```bash
$ ./tools/sigmac -t es-qs test.rule -c config.yaml
EventID:("4624" "4625")
```

Which for ES 5.x is functionally equivalent to `if (EventID == '4624' || EventID == '4625')`, but for ES 6.x+ is equivalent to `if (EventID == '"4624" "4625"')`

## How to reproduce

Run a similar query against a ES 5.6 cluster => matches

Run a similar query against a ES 6.8 cluster => 0 match

## Fix suggestions

The fix is straightforward and should be enough. The same is already done in the ArcSight backend: https://github.com/Neo23x0/sigma/blob/master/tools/sigma/backends/arcsight.py#L30

Results:

```
$ ./tools/sigmac -t es-qs test.rule -c config.yaml
EventID:("4624" OR "4625")
```

Example with a negated result:

```
$ cat test.rule
title: Sample rule
logsource: {product: windows, service: security}
detection:
  selection:
    EventID: [4624, 4625]

  condition: not selection

$ ./tools/sigmac -t es-qs test.rule -c config.yaml
(NOT (EventID:("4624" OR "4625")))
``` 

I confirmed that both work on ES 6.8.1 and 5.6.10