### PR TITLE
Win susp add sid history improvement

### DIFF
--- a/rules/windows/builtin/win_susp_add_sid_history.yml
+++ b/rules/windows/builtin/win_susp_add_sid_history.yml
@@ -19,7 +19,9 @@ detection:
     selection2:
         EventID: 4738
     selection3:
-        SidHistory: '-'
+        SidHistory: 
+            - '-'
+            - '%%1793'
     condition: selection1 or (selection2 and not selection3)
 falsepositives:
     - Migration of an account into a new domain

--- a/rules/windows/builtin/win_susp_add_sid_history.yml
+++ b/rules/windows/builtin/win_susp_add_sid_history.yml
@@ -3,19 +3,24 @@ status: stable
 description: An attacker can use the SID history attribute to gain additional privileges.
 references:
     - https://adsecurity.org/?p=1772
-author: Thomas Patzke
+author: "Thomas Patzke, @atc_project (improvements)"
 tags:
+    - attack.persistence               # https://adsecurity.org/?p=1772
     - attack.privilege_escalation
     - attack.t1178
 logsource:
     product: windows
     service: security
 detection:
-    selection:
+    selection1:
         EventID:
             - 4765
             - 4766
-    condition: selection
+    selection2:
+        EventID: 4738
+    selection3:
+        SidHistory: '-'
+    condition: selection1 or (selection2 and not selection3)
 falsepositives:
     - Migration of an account into a new domain
 level: medium


### PR DESCRIPTION
Hello guys!

We've improved this rule simulating malicious behaviour and analysing available artifacts. 
For some reason we couldn't trigger Event IDs 4765 and 4766, now we are under investigation about that case. 

But during modification of SIDHistory we've notices another event — 4738, and it has quite specific field which could be used for that kind of changes detection — `SidHistory`. 

When SID History is added, it just provide list of SID's in SidHistory attribute:

<img width="801" alt="add_to_sidhistory" src="https://user-images.githubusercontent.com/13090109/61340546-74f90080-a84b-11e9-8e28-062c930574d1.png">

In case of cleaning SIDHistory OS generates 4738 event with "%%1793" value ("value not set") in SIDHistory field:

<img width="661" alt="clear_sid_history" src="https://user-images.githubusercontent.com/13090109/61340557-84784980-a84b-11e9-9d29-9a8d52db4e48.png">

In case of other events (like password update) OS generates 4738 events with "-" value in SIDHistory field:

<img width="966" alt="password_change" src="https://user-images.githubusercontent.com/13090109/61340564-8a6e2a80-a84b-11e9-95aa-1f4339360706.png">

xml events attached:

[xml_logs.log](https://github.com/Neo23x0/sigma/files/3399684/xml_logs.log)

