### PR TITLE
rules/windows/builtin/win_rdp_potential_cve-2019-0708.yml improved

### DIFF
--- a/rules/windows/builtin/win_rdp_potential_cve-2019-0708.yml
+++ b/rules/windows/builtin/win_rdp_potential_cve-2019-0708.yml
@@ -2,17 +2,23 @@ title: Potential RDP exploit CVE-2019-0708
 description: Detect suspicious error on protocol RDP, potential CVE-2019-0708
 references:
     - https://github.com/zerosum0x0/CVE-2019-0708
+    - https://github.com/Ekultek/BlueKeep
 tags:
     - attack.initial_access
+    - attack.lateral_movement
+    - attack.t1210
+    - attack.t1190
     - car.2013-07-002
 status: experimental
-author: Lionel PRAT, Christophe BROCAS
+author: "Lionel PRAT, Christophe BROCAS, @atc_project (improvements)"
 logsource:
     product: windows
     service: system
 detection:
     selection:
-        EventID: 56
+        EventID: 
+            - 56
+            - 50
         Source: TermDD
     condition: selection
 falsepositives:


### PR DESCRIPTION
Hello guys!

During execution of available PoCs we've discovered another event from TermDD provider (system channel) — Event ID 50. It was triggered with this [1] PoC. 
Conditions:

- Victim OS: Windows 7 Enterprise x32 (modern.io)
- RDP Settings: "Allow connections only from computers running Remote Desktop with Network Level Authentication (more secure)"
- Exploit: bluekeep_weaponized_dos.py [2]

<img width="870" alt="Screenshot 2019-07-12 05 44 59" src="https://user-images.githubusercontent.com/13090109/61344739-0c198480-a85b-11e9-8350-c1be2e7b27bd.png">

As you can see on the screenshot, DoS payload wasn't delivered, connection was dropped during initialisation.
This way we possibly could detect payload agnostic BlueKeep attack attempts.

[1] https://github.com/Ekultek/BlueKeep
[2] https://github.com/Ekultek/BlueKeep/blob/master/bluekeep_weaponized_dos.py
