### PR TITLE
Win susp dhcp config failed fix

### DIFF
--- a/rules/windows/builtin/win_susp_dhcp_config_failed.yml
+++ b/rules/windows/builtin/win_susp_dhcp_config_failed.yml
@@ -9,7 +9,7 @@ date: 2017/05/15
 tags:
     - attack.defense_evasion
     - attack.t1073
-author: Dimitrios Slamaris
+author: "Dimitrios Slamaris, @atc_project (fix)"
 logsource:
     product: windows
     service: system

--- a/rules/windows/builtin/win_susp_dhcp_config_failed.yml
+++ b/rules/windows/builtin/win_susp_dhcp_config_failed.yml
@@ -12,7 +12,7 @@ tags:
 author: Dimitrios Slamaris
 logsource:
     product: windows
-    service: dhcp
+    service: system
 detection:
     selection:
         EventID: 


### PR DESCRIPTION
Hello guys!

We've been testing that rule and noticed a typo.

We believe that this is a typo, because in a similar [rule](https://github.com/Neo23x0/sigma/blob/a82ea0a02238952d3e7f50d18d0a291f222e4411/rules/windows/builtin/win_susp_dhcp_config.yml) from the same author service is `system` (which represents channel) and for all events listed in original rule (1031, 1032, 1034) channel is `system`, not `dhcp`:

You can find event samples in [original article](https://blog.3or.de/mimilib-dhcp-server-callout-dll-injection.html) from Dimitrios Slamaris @dim0x69 : 

<img width="708" alt="orig_article" src="https://user-images.githubusercontent.com/13090109/61347022-f2c90600-a863-11e9-8548-7940d43d5957.png">

(`System` provider mentioned in a corresponding field)

Here is a screenshot from [WELM project](https://github.com/nsacyber/Windows-Event-Log-Messages) dataset analysis:

<img width="1457" alt="welm_project" src="https://user-images.githubusercontent.com/13090109/61346500-b4cae280-a861-11e9-9650-9fcc5ff2c7da.png">

(`System` provider mentioned in the first column)