### PR TITLE
Improve MMC rules: fix generic rule and add new rule for shell spawning

### DIFF
--- a/rules/windows/process_creation/win_mmc_spawn_shell.yml
+++ b/rules/windows/process_creation/win_mmc_spawn_shell.yml
@@ -1,0 +1,30 @@
+title: MMC Spawning Windows Shell
+status: experimental
+description: Detects a Windows command line executable started from MMC.
+author: Karneades, Swisscom CSIRT
+tags:
+    - attack.lateral_movement
+    - attack.t1175
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        EventID: 1
+        ParentImage: '*\mmc.exe'
+        Image:
+            - '*\cmd.exe'
+            - '*\powershell.exe'
+            - '*\wscript.exe'
+            - '*\cscript.exe'
+            - '*\sh.exe'
+            - '*\bash.exe'
+            - '*\reg.exe'
+            - '*\regsvr32.exe'
+            - '*\BITSADMIN*'
+    condition: selection
+fields:
+    - CommandLine
+    - Image
+    - ParentCommandLine
+level: high

--- a/rules/windows/process_creation/win_mmc_spawn_shell.yml
+++ b/rules/windows/process_creation/win_mmc_spawn_shell.yml
@@ -10,7 +10,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventID: 1
         ParentImage: '*\mmc.exe'
         Image:
             - '*\cmd.exe'

--- a/rules/windows/process_creation/win_susp_mmc_source.yml
+++ b/rules/windows/process_creation/win_susp_mmc_source.yml
@@ -1,6 +1,6 @@
 title: Processes created by MMC
 status: experimental
-description: Processes started by MMC could be a sign of lateral movement using MMC application COM object
+description: Processes started by MMC could be a sign of lateral movement.
 references:
     - https://enigma0x3.net/2017/01/05/lateral-movement-using-the-mmc20-application-com-object/
 tags:
@@ -13,13 +13,13 @@ logsource:
 detection:
     selection:
         ParentImage: '*\mmc.exe'
-        Image: '*\cmd.exe'
     exclusion:
-        CommandLine: '*\RunCmd.cmd'
+        Image: 
+            - 'C:\Windows\System32\mmc.exe'
+            - 'C:\Windows\System32\certreq.exe'
     condition: selection and not exclusion
 fields:
+    - Image
     - CommandLine
     - ParentCommandLine
-falsepositives:
-    - unknown
 level: medium

--- a/rules/windows/process_creation/win_susp_mmc_source.yml
+++ b/rules/windows/process_creation/win_susp_mmc_source.yml
@@ -16,10 +16,15 @@ detection:
     exclusion:
         Image: 
             - 'C:\Windows\System32\mmc.exe'
+            - 'C:\Windows\SysWOW64\mmc.exe'
+            - 'C:\Windows\System32\vmconnect.exe'
             - 'C:\Windows\System32\certreq.exe'
+            - 'C:\Windows\System32\DeviceProperties.exe'
+            - 'C:\Windows\explorer.exe'
     condition: selection and not exclusion
 fields:
     - Image
+    - ParentImage
     - CommandLine
     - ParentCommandLine
 level: medium


### PR DESCRIPTION
Fix generic process dedection rule: remove cmd.exe filter to match what title says: detect all processes created by MMC.

Add (analog to [win_mshta_spawn_shell.yml](https://github.com/Neo23x0/sigma/blob/master/rules/windows/process_creation/win_mshta_spawn_shell.yml) a dedicated rule for dedecting MMC spawning a shell. And it covers the (removed) cmd part from the existing rule [win_susp_mmc_source.yml](https://github.com/Neo23x0/sigma/blob/master/rules/windows/process_creation/win_susp_mmc_source.yml).