### PR TITLE
improve(rule): add Empire links and userland match

### DIFF
--- a/rules/windows/sysmon/sysmon_powersploit_schtasks.yml
+++ b/rules/windows/sysmon/sysmon_powersploit_schtasks.yml
@@ -1,9 +1,11 @@
-title: Default PowerSploit Schtasks Persistence 
+title: Default PowerSploit and Empire Schtasks Persistence
 status: experimental
-description: Detects the creation of a schtask via PowerSploit Default Configuration 
+description: Detects the creation of a schtask via PowerSploit or Empire Default Configuration.
 references:
     - https://github.com/0xdeadbeefJERKY/PowerSploit/blob/8690399ef70d2cad10213575ac67e8fa90ddf7c3/Persistence/Persistence.psm1
-author: Markus Neis
+    - https://github.com/EmpireProject/Empire/blob/master/lib/modules/powershell/persistence/userland/schtasks.py
+    - https://github.com/EmpireProject/Empire/blob/master/lib/modules/powershell/persistence/elevated/schtasks.py
+author: Markus Neis, @Karneades
 date: 2018/03/06
 logsource:
     product: windows
@@ -13,10 +15,10 @@ detection:
         ParentImage:
             - '*\Powershell.exe'
         CommandLine:
-            - '*\schtasks.exe*/Create*/RU*system*/SC*ONLOGON*'
-            - '*\schtasks.exe*/Create*/RU*system*/SC*DAILY*'
-            - '*\schtasks.exe*/Create*/RU*system*/SC*ONIDLE*'
-            - '*\schtasks.exe*/Create*/RU*system*/SC*HOURLY*'
+            - '*schtasks*/Create*/SC *ONLOGON*/TN *Updater*/TR *powershell*'
+            - '*schtasks*/Create*/SC *DAILY*/TN *Updater*/TR *powershell*'
+            - '*schtasks*/Create*/SC *ONIDLE*/TN *Updater*/TR *powershell*'
+            - '*schtasks*/Create*/SC *Updater*/TN *Updater*/TR *powershell*'
     condition: selection
 tags:
     - attack.execution


### PR DESCRIPTION
Add default task name and powershell task command to match what the rule name says: detects default config.

We could also remove the "updater" name, to be more flexibel to catch a custom task name. It shouldn't give a lot FPs.