### PR TITLE
Added Sticky Bits

### DIFF
--- a/rules/linux/lnx_shell_priv_esc_prep.yml
+++ b/rules/linux/lnx_shell_priv_esc_prep.yml
@@ -58,6 +58,11 @@ detection:
         - 'cat /etc/passwd'
         - 'cat /etc/group'
         - 'cat /etc/shadow'
+        # sticky bits
+        - 'find / -perm -u=s'
+        - 'find / -perm -u=s'
+        - 'find / -perm -4000'
+        - 'find / -perm -2000'
     timeframe: 30m
     condition: keywords | count() by host > 6
 falsepositives:


### PR DESCRIPTION
Attackers may search for files with the sticky bit enabled in order to execute files with the owner's or group's permissions.  With some binaries, this can lead to privilege escalation.