### PR TITLE
powershell false positives

### DIFF
--- a/rules/windows/powershell/powershell_malicious_commandlets.yml
+++ b/rules/windows/powershell/powershell_malicious_commandlets.yml
@@ -108,7 +108,9 @@ detection:
         - Invoke-ReverseDNSLookup
         - Invoke-SMBScanner
         - Invoke-Mimikittenz
-    condition: keywords
+    false_positives:
+        - Get-SystemDriveInfo  # http://bheltborg.dk/Windows/WinSxS/amd64_microsoft-windows-maintenancediagnostic_31bf3856ad364e35_10.0.10240.16384_none_91ef7543a4514b5e/CL_Utility.ps1
+    condition: keywords and not false_positives
 falsepositives:
     - Penetration testing
 level: high

--- a/rules/windows/sysmon/sysmon_renamed_powershell.yml
+++ b/rules/windows/sysmon/sysmon_renamed_powershell.yml
@@ -16,6 +16,7 @@ detection:
         Company: 'Microsoft Corporation'
     filter:
         Image: '*\powershell.exe'
+        Image: '*\powershell_ise.exe'
     condition: selection and not filter
 falsepositives:
     - Unknown


### PR DESCRIPTION
rules about `renamed powershell `exist twice :

` rules/windows/sysmon/sysmon_renamed_powershell.yml`
`rules/windows/process_creation/win_powershell_renamed_ps.yml`

alert level also differs in rules:
in sysmon: **critical**
 in process_creation : **high**

1 of the 2 rules could  be deleted?


fix on `powershell_malicious_commandlets.yml  `is about `Get-SystemDriveInfo`which matches `Get-System`