### PR TITLE
Added Sticky Bits

### DIFF
--- a/rules/linux/lnx_shell_priv_esc_prep.yml
+++ b/rules/linux/lnx_shell_priv_esc_prep.yml
@@ -58,6 +58,11 @@ detection:
         - 'cat /etc/passwd'
         - 'cat /etc/group'
         - 'cat /etc/shadow'
+        # sticky bits
+        - 'find / -perm -u=s'
+        - 'find / -perm -g=s'
+        - 'find / -perm -4000'
+        - 'find / -perm -2000
     timeframe: 30m
     condition: keywords | count() by host > 6
 falsepositives:

--- a/rules/linux/lnx_shell_priv_esc_prep.yml
+++ b/rules/linux/lnx_shell_priv_esc_prep.yml
@@ -62,7 +62,7 @@ detection:
         - 'find / -perm -u=s'
         - 'find / -perm -g=s'
         - 'find / -perm -4000'
-        - 'find / -perm -2000
+        - 'find / -perm -2000'
     timeframe: 30m
     condition: keywords | count() by host > 6
 falsepositives:


### PR DESCRIPTION
Attackers may look to exploit binaries with the sticky bits enabled.  By being able to run a binary as a different user or group, they may be able to run separate commands as an elevated user.