### PR TITLE
Use configuration option "dateField" in xpack watcher 

### DIFF
--- a/tools/sigma/backends/elasticsearch.py
+++ b/tools/sigma/backends/elasticsearch.py
@@ -452,6 +452,7 @@ class XPackWatcherBackend(ElasticsearchQuerystringBackend, MultiRuleOutputMixin)
         tags = sigmaparser.parsedyaml.setdefault("tags", "")
         # Get time frame if exists
         interval = sigmaparser.parsedyaml["detection"].setdefault("timeframe", "30m")
+        dateField = self.sigmaconfig.config.get("dateField", "date")
         
         # creating condition
         indices = sigmaparser.get_logsource().index
@@ -673,7 +674,7 @@ class XPackWatcherBackend(ElasticsearchQuerystringBackend, MultiRuleOutputMixin)
                                             "filter":
                                                 {
                                                     "range":{
-                                                        "timestamp":{
+                                                        dateField:{
                                                             "gte":"now-%s/m"%self.filter_range #filter only for the last x minutes events
                                                             }
                                                         }


### PR DESCRIPTION
The es-dsl backend supports the configuration option "dateField" that determines the name of the field used for a specific time-range (a more detailled description: ref #402).
In this commit I add the same logic to the xpack-watcher backend.