### PR TITLE
Sysmon rules cleanup and move to process_creation

### DIFF
--- a/rules/windows/process_creation/win_susp_taskmgr_parent.yml
+++ b/rules/windows/process_creation/win_susp_taskmgr_parent.yml
@@ -16,6 +16,7 @@ detection:
         Image:
             - '*\resmon.exe'
             - '*\mmc.exe'
+            - '*\taskmgr.exe'
     condition: selection and not filter
 fields:
     - Image


### PR DESCRIPTION
… privileges (show processes from all users --> UAC) and its parent is still the old taskmgr

happens on "old" systems (win7, win2008)