### PR TITLE
rule: changed two proxy rules from uri-query to url

### DIFF
--- a/rules/proxy/proxy_chafer_malware.yml
+++ b/rules/proxy/proxy_chafer_malware.yml
@@ -9,7 +9,7 @@ logsource:
     category: proxy
 detection:
     selection:
-        URL: '*/asp.asp?ui=*'
+        c-uri: '*/asp.asp?ui=*'
     condition: selection
 fields:
     - ClientIP

--- a/rules/proxy/proxy_chafer_malware.yml
+++ b/rules/proxy/proxy_chafer_malware.yml
@@ -9,7 +9,7 @@ logsource:
     category: proxy
 detection:
     selection:
-        c-uri-query: '*/asp.asp?ui=*'
+        URL: '*/asp.asp?ui=*'
     condition: selection
 fields:
     - ClientIP

--- a/rules/proxy/proxy_ios_implant.yml
+++ b/rules/proxy/proxy_ios_implant.yml
@@ -10,7 +10,7 @@ logsource:
     category: proxy
 detection:
     selection:
-        c-uri-query: '*/list/suc?name=*'
+        URL: '*/list/suc?name=*'
     condition: selection
 fields:
     - ClientIP

--- a/rules/proxy/proxy_ios_implant.yml
+++ b/rules/proxy/proxy_ios_implant.yml
@@ -10,7 +10,7 @@ logsource:
     category: proxy
 detection:
     selection:
-        URL: '*/list/suc?name=*'
+        c-uri: '*/list/suc?name=*'
     condition: selection
 fields:
     - ClientIP


### PR DESCRIPTION
Hi all

These two rules used the URI Query Field for detection and checked against those two strings in this field:

- '*/asp.asp?ui=*'
- '*/list/suc?name=*'

But by definition the URI Query part starts at "?ui=*" respectively "?name=*". Therefore there would never be a match of this rule if the SIEM parses the URL correctly into a query and path part. I changed the detection field to "URL" to get a match.

Andi
