### PR TITLE
Update win_susp_net_execution.yml

### DIFF
--- a/rules/windows/process_creation/win_susp_net_execution.yml
+++ b/rules/windows/process_creation/win_susp_net_execution.yml
@@ -3,11 +3,17 @@ status: experimental
 description: Detects execution of Net.exe, whether suspicious or benign.
 references:
     - https://pentest.blog/windows-privilege-escalation-methods-for-pentesters/
-author: Michael Haag, Mark Woan (improvements)
+    - https://eqllib.readthedocs.io/en/latest/analytics/4d2e7fc1-af0b-4915-89aa-03d25ba7805e.html
+    - https://eqllib.readthedocs.io/en/latest/analytics/e61f557c-a9d0-4c25-ab5b-bbc46bb24deb.html
+author: Michael Haag, Mark Woan (improvements), James Pemberton / @4A616D6573 / oscd.community (improvements)
 tags:
     - attack.s0039
+    - attack.t1027
+    - attack.t1049
+    - attack.t1135
     - attack.lateral_movement
     - attack.discovery
+    - attack.defense.evasion
 logsource:
     category: process_creation
     product: windows
@@ -16,6 +22,11 @@ detection:
         Image:
             - '*\net.exe'
             - '*\net1.exe'
+    filename:
+        OriginalFileName:
+            - 'net.exe'
+            - 'net1.exe'
+    cmdline:
         CommandLine:
             - '* group*'
             - '* localgroup*'
@@ -25,7 +36,7 @@ detection:
             - '* accounts*'
             - '* use*'
             - '* stop *'
-    condition: selection
+    condition: selection or filename and cmdline
 fields:
     - CommandLine
     - ParentCommandLine

--- a/rules/windows/process_creation/win_susp_net_execution.yml
+++ b/rules/windows/process_creation/win_susp_net_execution.yml
@@ -15,7 +15,7 @@ tags:
     - attack.t1135
     - attack.lateral_movement
     - attack.discovery
-    - attack.defense.evasion
+    - attack.defense_evasion
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_susp_net_execution.yml
+++ b/rules/windows/process_creation/win_susp_net_execution.yml
@@ -5,11 +5,13 @@ references:
     - https://pentest.blog/windows-privilege-escalation-methods-for-pentesters/
     - https://eqllib.readthedocs.io/en/latest/analytics/4d2e7fc1-af0b-4915-89aa-03d25ba7805e.html
     - https://eqllib.readthedocs.io/en/latest/analytics/e61f557c-a9d0-4c25-ab5b-bbc46bb24deb.html
+    - https://eqllib.readthedocs.io/en/latest/analytics/9b3dd402-891c-4c4d-a662-28947168ce61.html
 author: Michael Haag, Mark Woan (improvements), James Pemberton / @4A616D6573 / oscd.community (improvements)
 tags:
     - attack.s0039
     - attack.t1027
     - attack.t1049
+    - attack.t1077
     - attack.t1135
     - attack.lateral_movement
     - attack.discovery

--- a/rules/windows/process_creation/win_susp_net_execution.yml
+++ b/rules/windows/process_creation/win_susp_net_execution.yml
@@ -24,10 +24,6 @@ detection:
         Image:
             - '*\net.exe'
             - '*\net1.exe'
-    filename:
-        OriginalFileName:
-            - 'net.exe'
-            - 'net1.exe'
     cmdline:
         CommandLine:
             - '* group*'
@@ -38,7 +34,7 @@ detection:
             - '* accounts*'
             - '* use*'
             - '* stop *'
-    condition: selection or filename and cmdline
+    condition: selection and cmdline
 fields:
     - CommandLine
     - ParentCommandLine


### PR DESCRIPTION
Added:

1. Additional tags for techniques as defined by Atomic Blue.
2. Detection for OriginalFileName as net.exe can easily be renamed.

Part of oscd.community effort.