### PR TITLE
Add new VAST backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ tools/sigmac -t splunk -c ~/my-splunk-mapping.yml -c tools/config/generic/window
 * [RSA NetWitness](https://www.rsa.com/en-us/products/threat-detection-response)
 * [PowerShell](https://docs.microsoft.com/en-us/powershell/scripting/getting-started/getting-started-with-windows-powershell?view=powershell-6)
 * [Grep](https://www.gnu.org/software/grep/manual/grep.html) with Perl-compatible regular expression support
+* [VAST](https://github.com/tenzir/vast)
 
 Current work-in-progress
 * [Splunk Data Models](https://docs.splunk.com/Documentation/Splunk/7.1.0/Knowledge/Aboutdatamodels)

--- a/tools/sigma/backends/vast.py
+++ b/tools/sigma/backends/vast.py
@@ -1,0 +1,68 @@
+# Output backends for sigmac
+# Copyright 2019 Matthias Vallentin <matthias@tenzir.com>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import re
+import ipaddress
+from sigma.parser.modifiers.type import SigmaRegularExpressionModifier
+
+from .base import SingleTextQueryBackend
+
+def parse_vast_data(value):
+    """Attempts to parse a value from a Sigma rule as a VAST data instance."""
+    # Parsers that do not alter the original value
+    identity_parsers = [
+        ipaddress.ip_address,
+        int
+    ]
+    for parser in identity_parsers:
+        try:
+            if parser(value) is not None:
+                return value
+        except ValueError:
+            pass
+    return None
+
+class VASTQuerystringBackend(SingleTextQueryBackend):
+    """Converts Sigma rule into a VAST query string. Only searches, no aggregations."""
+    identifier = "vast"
+    active = True
+    config_required = False
+    reEscape = re.compile("([+\\-!(){}\\[\\]^\"~:/]|(?<!\\\\)\\\\(?![*?\\\\])|&&|\\|\\|)")
+    reClear = None
+    andToken = " && "
+    orToken = " || "
+    notToken = "! "
+    subExpression = "(%s)"
+    listExpression = "{%s}"
+    listSeparator = ", "
+    nullExpression = "%s == nil"
+    notNullExpression = "%s != nil"
+    mapExpression = "%s == %s"
+    mapListsSpecialHandling = True
+    mapListValueExpression = "%s in %s"
+    valueExpression = "%s"
+    typedValueExpression = {
+        SigmaRegularExpressionModifier: "/%s/"
+    }
+
+    # Cleaning a value means trying to parse it as VAST data value. If we
+    # cannot parse the value successfully, we eventually consider the value as
+    # a string.
+    def cleanValue(self, value):
+        result = parse_vast_data(value)
+        if result is not None:
+            return result
+        return "\"%s\"" % value.replace("\'","\\\'")

--- a/tools/sigma/backends/vast.py
+++ b/tools/sigma/backends/vast.py
@@ -66,3 +66,11 @@ class VASTQuerystringBackend(SingleTextQueryBackend):
         if result is not None:
             return result
         return "\"%s\"" % value.replace("\'","\\\'")
+
+    # We must override this method because a map expression for a pattern
+    # differs from a normal equality lookup.
+    def generateMapItemTypedNode(self, fieldname, value):
+        predicate = self.mapExpression
+        if type(value) is SigmaRegularExpressionModifier:
+            predicate = "%s ~ %s"
+        return predicate % (fieldname, self.generateTypedValueNode(value))


### PR DESCRIPTION
This PR adds a new backend for the [VAST](https://github.com/tenzir/vast) network forensics platform.

Steps

- [x] Add basic VAST language support
- [x] Clarify type-specific operator adaption
- [ ] Increase coverage of VAST data parser
- [ ] Correctly translate [search identifier](https://github.com/Neo23x0/sigma/wiki/Specification#search-identifier) into VAST pattern
- [ ] Write unit tests 

There's a fundamental problem I am facing which I'd like to discuss. I would like to change the operator in `mapExpression` based on the type of the RHS (= value). Currently, I'm considering this workaround:

```python
    mapExpression = "%s == %s"

    ...
    
    # We must override this method because a map expression for a pattern
    # differs from a normal equality lookup.
    def generateMapItemTypedNode(self, fieldname, value):
        predicate = self.mapExpression
        if type(value) is SigmaRegularExpressionModifier:
            predicate = "%s in %s"
        return predicate % (fieldname, self.generateTypedValueNode(value))
```

Here, I'm changing the operator from `==` to `=` if the RHS is a pattern. Is there a better way to do this?