### PR TITLE
Adding Backend for LimaCharlie D&R rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ test-sigmac:
 	coverage run -a --include=$(COVSCOPE) tools/sigmac -rvdI -t powershell -c tools/config/powershell.yml -Ocsv rules/ > /dev/null
 	coverage run -a --include=$(COVSCOPE) tools/sigmac -rvdI -t arcsight -c tools/config/arcsight.yml rules/ > /dev/null
 	coverage run -a --include=$(COVSCOPE) tools/sigmac -rvdI -t qradar -c tools/config/qradar.yml rules/ > /dev/null
+	coverage run -a --include=$(COVSCOPE) tools/sigmac -rvdI -t limacharlie -c tools/config/limacharlie.yml rules/ > /dev/null
 	coverage run -a --include=$(COVSCOPE) tools/sigmac -rvdI -t qualys -c tools/config/qualys.yml rules/ > /dev/null
 	coverage run -a --include=$(COVSCOPE) tools/sigmac -rvdI -t netwitness -c tools/config/netwitness.yml rules/ > /dev/null
 	coverage run -a --include=$(COVSCOPE) tools/sigmac -rvdI -t sumologic -O rulecomment -c tools/config/sumologic.yml rules/ > /dev/null

--- a/tools/config/limacharlie.yml
+++ b/tools/config/limacharlie.yml
@@ -5,11 +5,3 @@ order: 20
 logsources:
   windows:
     product: windows
-
-  netflow:
-    product: netflow
-    index: flows
-
-  flow:
-   category: flow
-   index: flows

--- a/tools/config/limacharlie.yml
+++ b/tools/config/limacharlie.yml
@@ -1,0 +1,15 @@
+title: LimaCharlie
+backends:
+  - limacharlie
+order: 20
+logsources:
+  windows:
+    product: windows
+
+  netflow:
+    product: netflow
+    index: flows
+
+  flow:
+   category: flow
+   index: flows

--- a/tools/config/limacharlie.yml
+++ b/tools/config/limacharlie.yml
@@ -5,3 +5,7 @@ order: 20
 logsources:
   windows:
     product: windows
+  linux:
+    product: linux
+  netflow:
+    product: netflow

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -60,6 +60,7 @@ setup(
             'config/winlogbeat-modules-enabled.yml',
             'config/winlogbeat.yml',
             'config/winlogbeat-old.yml',
+            'config/limacharlie.yml',
             ]),
         ('etc/sigma/generic', [
             'config/generic/sysmon.yml',

--- a/tools/sigma/backends/limacharlie.py
+++ b/tools/sigma/backends/limacharlie.py
@@ -174,7 +174,7 @@ class LimaCharlieBackend(BaseBackend):
             raise TypeError("Backend does not support map values of type " + str(type(value)))
 
     def generateValueNode(self, node):
-        return self.valueExpression % (str(node),)
+        return node
 
     def generateNULLValueNode(self, node):
         generated = self.generateNode(node.item)

--- a/tools/sigma/backends/limacharlie.py
+++ b/tools/sigma/backends/limacharlie.py
@@ -192,7 +192,9 @@ class LimaCharlieBackend(BaseBackend):
     def generateNOTNode(self, node):
         generated = self.generateNode(node.item)
         if generated is not None:
-            generated[ 'not' ] = True
+            if not isinstance(generated, dict):
+                raise NotImplementedError("Not operator not available on non-dict nodes.")
+            generated['not'] = True
             return generated
         else:
             return None

--- a/tools/sigma/backends/limacharlie.py
+++ b/tools/sigma/backends/limacharlie.py
@@ -24,21 +24,24 @@ from sigma.parser.modifiers.type import SigmaRegularExpressionModifier
 # on the log source and category.
 # Top level is product.
 # Second level is category.
-# Third level is a tuple (pre-condition, field mappings).
+# Thirs level is service.
+# Fourth level is a tuple (pre-condition, field mappings).
 _allFieldMappings = {
     "windows": {
-        "process_creation": ({
-            "op": "is windows",
-            "events": [
-                "NEW_PROCESS",
-                "EXISTING_PROCESS",
-            ]
-        },{
-            "CommandLine": "event/COMMAND_LINE",
-            "Image": "event/FILE_PATH",
-            "ParentImage": "event/PARENT/FILE_PATH",
-            "ParentCommandLine": "event/PARENT/COMMAND_LINE",
-        })
+        "process_creation": {
+            "*": ({
+                "op": "is windows",
+                "events": [
+                    "NEW_PROCESS",
+                    "EXISTING_PROCESS",
+                ]
+            }, {
+                "CommandLine": "event/COMMAND_LINE",
+                "Image": "event/FILE_PATH",
+                "ParentImage": "event/PARENT/FILE_PATH",
+                "ParentCommandLine": "event/PARENT/COMMAND_LINE",
+            })
+        }
     }
 }
 
@@ -58,14 +61,12 @@ class LimaCharlieBackend(BaseBackend):
             product = ls_rule['product']
         except KeyError:
             product = None
+        try:
+            service = ls_rule['service']
+        except KeyError:
+            service = "*"
 
-        # We don't use service at the moment.
-        # try:
-        #     service = ls_rule['service']
-        # except KeyError:
-        #     service = None
-
-        preCond, mappings = _allFieldMappings.get(product, {}).get(category, tuple([None, None]))
+        preCond, mappings = _allFieldMappings.get(product, {}).get(category, {}).get(service, tuple([None, None]))
         if mappings is None:
             raise NotImplementedError("Log source %s/%s not supported by backend." % (product, category))
 

--- a/tools/sigma/backends/limacharlie.py
+++ b/tools/sigma/backends/limacharlie.py
@@ -95,7 +95,7 @@ class LimaCharlieBackend(BaseBackend):
         service = ""
 
         mappingKey = "%s/%s/%s" % (product, category, service)
-        topFilter, preCond, mappings, isAllStringValues = _allFieldMappings.get(mappingKey, tuple([None, None, None]))
+        topFilter, preCond, mappings, isAllStringValues = _allFieldMappings.get(mappingKey, tuple([None, None, None, None]))
         if mappings is None:
             raise NotImplementedError("Log source %s/%s/%s not supported by backend." % (product, category, service))
 

--- a/tools/sigma/backends/limacharlie.py
+++ b/tools/sigma/backends/limacharlie.py
@@ -79,6 +79,14 @@ _allFieldMappings = {
         "op": "is linux",
     }, {
         "keywords": "event/COMMAND_LINE",
+        "exe": "event/FILE_PATH",
+        "type": None,
+    }, False, True),
+    "netflow//": ({
+        "event": "NETWORK_CONNECTIONS",
+    }, None, {
+        "destination.port": "event/NETWORK_ACTIVITY/DESTINATION/PORT",
+        "source.port": "event/NETWORK_ACTIVITY/SOURCE/PORT",
     }, False, True)
 }
 
@@ -111,7 +119,7 @@ class LimaCharlieBackend(BaseBackend):
         service = ""
 
         mappingKey = "%s/%s/%s" % (product, category, service)
-        topFilter, preCond, mappings, isAllStringValues, isKeywordsSupported = _allFieldMappings.get(mappingKey, tuple([None, None, None, None]))
+        topFilter, preCond, mappings, isAllStringValues, isKeywordsSupported = _allFieldMappings.get(mappingKey, tuple([None, None, None, None, None]))
         if mappings is None:
             raise NotImplementedError("Log source %s/%s/%s not supported by backend." % (product, category, service))
 

--- a/tools/sigma/backends/limacharlie.py
+++ b/tools/sigma/backends/limacharlie.py
@@ -56,6 +56,8 @@ _allFieldMappings = {
         # Custom field names coming from somewhere unknown.
         "NewProcessName": "event/FILE_PATH",
         "ProcessCommandLine": "event/COMMAND_LINE",
+        # Another one-off command line.
+        "Command": "event/COMMAND_LINE",
     }, False, False),
     "windows//": ({
         "target": "log",
@@ -71,6 +73,18 @@ _allFieldMappings = {
         "query": "event/DOMAIN_NAME",
     }, False, False),
     "linux//": ({
+        "events": [
+            "NEW_PROCESS",
+            "EXISTING_PROCESS",
+        ]
+    }, {
+        "op": "is linux",
+    }, {
+        "keywords": "event/COMMAND_LINE",
+        "exe": "event/FILE_PATH",
+        "type": None,
+    }, False, True),
+    "unix//": ({
         "events": [
             "NEW_PROCESS",
             "EXISTING_PROCESS",

--- a/tools/sigma/backends/limacharlie.py
+++ b/tools/sigma/backends/limacharlie.py
@@ -1,0 +1,220 @@
+# LimaCharlie backend for sigmac created by LimaCharlie.io
+# Copyright 2019 Refraction Point, Inc
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import re
+import yaml
+from .base import BaseBackend
+from sigma.parser.modifiers.base import SigmaTypeModifier
+from sigma.parser.modifiers.type import SigmaRegularExpressionModifier
+
+# We support many different log sources so we keep different mapping depending
+# on the log source and category.
+# Top level is product.
+# Second level is category.
+# Third level is a tuple (pre-condition, field mappings).
+_allFieldMappings = {
+    "windows": {
+        "process_creation": ({
+            "op": "is windows",
+            "events": [
+                "NEW_PROCESS",
+                "EXISTING_PROCESS",
+            ]
+        },{
+            "CommandLine": "event/COMMAND_LINE",
+            "Image": "event/FILE_PATH",
+            "ParentImage": "event/PARENT/FILE_PATH",
+            "ParentCommandLine": "event/PARENT/COMMAND_LINE",
+        })
+    }
+}
+
+class LimaCharlieBackend(BaseBackend):
+    """Converts Sigma rule into LimaCharlie D&R rules. Contributed by LimaCharlie. https://limacharlie.io"""
+    identifier = "limacharlie"
+    active = True
+
+    def generate(self, sigmaparser):
+        # Take the log source information and figure out which set of mappings to use.
+        ls_rule = sigmaparser.parsedyaml['logsource']
+        try:
+            category = ls_rule['category']
+        except KeyError:
+            category = None
+        try:
+            product = ls_rule['product']
+        except KeyError:
+            product = None
+
+        # We don't use service at the moment.
+        # try:
+        #     service = ls_rule['service']
+        # except KeyError:
+        #     service = None
+
+        preCond, mappings = _allFieldMappings.get(product, {}).get(category, tuple([None, None]))
+        if mappings is None:
+            raise NotImplementedError("Log source %s/%s not supported by backend." % (product, category))
+
+        self._fieldMappingInEffect = mappings
+        self._preCondition = preCond
+
+        return super().generate(sigmaparser)
+
+    def generateQuery(self, parsed):
+        result = self.generateNode(parsed.parsedSearch)
+        if self._preCondition is not None:
+            result = {
+                "op": "and",
+                "rules": [
+                    self._preCondition,
+                    result,
+                ]
+            }
+        return yaml.safe_dump(result)
+
+    def generateANDNode(self, node):
+        generated = [ self.generateNode(val) for val in node ]
+        filtered = [ g for g in generated if g is not None ]
+        if filtered:
+            return {
+                "op": "and",
+                "rules": filtered,
+            }
+        else:
+            return None
+
+    def generateORNode(self, node):
+        generated = [ self.generateNode(val) for val in node ]
+        filtered = [ g for g in generated if g is not None ]
+        if filtered:
+            return {
+                "op": "or",
+                "rules": filtered,
+            }
+        else:
+            return None
+
+    def generateNOTNode(self, node):
+        generated = self.generateNode(node.item)
+        if generated is not None:
+            generated[ 'not' ] = True
+            return generated
+        else:
+            return None
+
+    def generateSubexpressionNode(self, node):
+        generated = self.generateNode(node.items)
+        if generated:
+            return generated
+        else:
+            return None
+
+    def generateListNode(self, node):
+        return [self.generateNode(value) for value in node]
+
+    def generateMapItemNode(self, node):
+        fieldname, value = node
+
+        fieldname = self._fieldMappingInEffect.get(fieldname, None)
+        if fieldname is None:
+            raise NotImplementedError("Field name %s not supported by backend." % (fieldname,))
+
+        if isinstance(value, (int, str)):
+            op, newVal = self._valuePatternToLcOp(value)
+            return {
+                "op": op,
+                "path": fieldname,
+                "value": newVal,
+            }
+        elif isinstance(value, list):
+            subOps = []
+            for v in value:
+                op, newVal = self._valuePatternToLcOp(v)
+                subOps.append({
+                    "op": op,
+                    "path": fieldname,
+                    "value": newVal,
+                })
+            if 1 == len(subOps):
+                return subOps[0]
+            return {
+                "op": "or",
+                "rules": subOps
+            }
+        elif isinstance(value, SigmaTypeModifier):
+            if isinstance(value, SigmaRegularExpressionModifier):
+                return {
+                    "op": "matches",
+                    "path": fieldname,
+                    "re": re.compile(value),
+                }
+            else:
+                raise TypeError("Backend does not support TypeModifier: %s" % (str(type(value))))
+        elif value is None:
+            return {
+                "op": "exists",
+                "not": True,
+                "path": fieldname,
+            }
+        else:
+            raise TypeError("Backend does not support map values of type " + str(type(value)))
+
+    def generateValueNode(self, node):
+        return self.valueExpression % (str(node),)
+
+    def generateNULLValueNode(self, node):
+        generated = self.generateNode(node.item)
+        if generated is not None:
+            generated[ "op" ] = "exists"
+            generated[ "not" ] = True
+            return generated
+        else:
+            return None
+
+    def generateNotNULLValueNode(self, node):
+        generated = self.generateNode(node.item)
+        if generated is not None:
+            generated[ "op" ] = "exists"
+            generated[ "not" ] = False
+            return generated
+        else:
+            return None
+
+    def _valuePatternToLcOp(self, val):
+        if not isinstance(val, str):
+            return ("is", val)
+        # The following logic is taken from the WDATP backend to translate
+        # the basic wildcard format into proper regular expression.
+        if "*" in val[1:-1]:
+            # Contains a wildcard within, must be translated.
+            # TODO: getting a W605 from the \g escape, this may be broken.
+            val = re.sub('([".^$]|\\\\(?![*?]))', '\\\\\g<1>', val)
+            val = re.sub('\\*', '.*', val)
+            val = re.sub('\\?', '.', val)
+            return ("matches", val)
+        # value possibly only starts and/or ends with *, use prefix/postfix match
+        # TODO: this is actually not correct since the string could end with
+        # a \* expression which would mean it's NOT a wildcard. We'll gloss over
+        # it for now to get something out but it should eventually be fixed
+        # so that it's accurate in all corner cases.
+        if val.endswith("*") and val.startswith("*"):
+            return ("contains", val[1:-1])
+        elif val.endswith("*"):
+            return ("starts with", val[:-1])
+        elif val.startswith("*"):
+            return ("ends with", val[1:])
+        return ("is", val)

--- a/tools/sigma/backends/limacharlie.py
+++ b/tools/sigma/backends/limacharlie.py
@@ -185,6 +185,8 @@ class LimaCharlieBackend(BaseBackend):
         generated = [self.generateNode(val) for val in node]
         filtered = [g for g in generated if g is not None]
         if filtered:
+            if isinstance(filtered[0], str):
+                raise NotImplementedError("Full-text keyboard searches not supported.")
             if 1 == len(filtered):
                 return filtered[0]
             return {

--- a/tools/sigma/backends/limacharlie.py
+++ b/tools/sigma/backends/limacharlie.py
@@ -228,19 +228,19 @@ class LimaCharlieBackend(BaseBackend):
 
         # Add a lot of the metadata available to the report.
         if ruleConfig.get("tags", None) is not None:
-            respondComponents[0].setdefault("metatdata", {})["tags"] = ruleConfig["tags"]
+            respondComponents[0].setdefault("metadata", {})["tags"] = ruleConfig["tags"]
 
         if ruleConfig.get("description", None) is not None:
-            respondComponents[0].setdefault("metatdata", {})["description"] = ruleConfig["description"]
+            respondComponents[0].setdefault("metadata", {})["description"] = ruleConfig["description"]
 
         if ruleConfig.get("references", None) is not None:
-            respondComponents[0].setdefault("metatdata", {})["references"] = ruleConfig["references"]
+            respondComponents[0].setdefault("metadata", {})["references"] = ruleConfig["references"]
 
         if ruleConfig.get("level", None) is not None:
-            respondComponents[0].setdefault("metatdata", {})["level"] = ruleConfig["level"]
+            respondComponents[0].setdefault("metadata", {})["level"] = ruleConfig["level"]
 
         if ruleConfig.get("author", None) is not None:
-            respondComponents[0].setdefault("metatdata", {})["author"] = ruleConfig["author"]
+            respondComponents[0].setdefault("metadata", {})["author"] = ruleConfig["author"]
 
         # Assemble it all as a single, complete D&R rule.
         return yaml.safe_dump({

--- a/tools/sigma/backends/limacharlie.py
+++ b/tools/sigma/backends/limacharlie.py
@@ -27,22 +27,18 @@ from sigma.parser.modifiers.type import SigmaRegularExpressionModifier
 # Thirs level is service.
 # Fourth level is a tuple (pre-condition, field mappings).
 _allFieldMappings = {
-    "windows": {
-        "process_creation": {
-            "*": ({
-                "op": "is windows",
-                "events": [
-                    "NEW_PROCESS",
-                    "EXISTING_PROCESS",
-                ]
-            }, {
-                "CommandLine": "event/COMMAND_LINE",
-                "Image": "event/FILE_PATH",
-                "ParentImage": "event/PARENT/FILE_PATH",
-                "ParentCommandLine": "event/PARENT/COMMAND_LINE",
-            })
-        }
-    }
+    "windows/process_creation/": ({
+        "op": "is windows",
+        "events": [
+            "NEW_PROCESS",
+            "EXISTING_PROCESS",
+        ]
+    }, {
+        "CommandLine": "event/COMMAND_LINE",
+        "Image": "event/FILE_PATH",
+        "ParentImage": "event/PARENT/FILE_PATH",
+        "ParentCommandLine": "event/PARENT/COMMAND_LINE",
+    }),
 }
 
 class LimaCharlieBackend(BaseBackend):
@@ -64,9 +60,10 @@ class LimaCharlieBackend(BaseBackend):
         try:
             service = ls_rule['service']
         except KeyError:
-            service = "*"
+            service = ""
 
-        preCond, mappings = _allFieldMappings.get(product, {}).get(category, {}).get(service, tuple([None, None]))
+        mappingKey = "%s/%s/%s" % (product, category, service)
+        preCond, mappings = _allFieldMappings.get(mappingKey, tuple([None, None]))
         if mappings is None:
             raise NotImplementedError("Log source %s/%s not supported by backend." % (product, category))
 


### PR DESCRIPTION
This adds a new backend to convert rules to LimaCharlie.io [D&R rules](https://doc.limacharlie.io/en/master/dr/).

The D&R rules are like AWS lambda applied to data from endpoint (either native LC events, or External Logs like Windows Event Logs).

This changes a bit the meta of a Sigma backend. Instead of generating a search query for a more-or-less generic log viewer, it generates "D&R rules" for specific event types in LC.

It means we support multiple Sigma rule "products", and for each ones we attempt to convert the various selector values into the specific LC event type and the specific relevant LC fields (all LC events are JSON).

The drawback of all this is that it means we can't use the current Sigma config file model (as far as I can tell, but I may be wrong) because of the wide number of "products" as well as more complex transforms needed to get a valid LC D&R rule.

To be able to make this work, we instead define a mapping of product/category/service => `SigmaLCConfig` named tuple that defines characteristics of the transformation for the product. We tried to keep the Sigma approach as much as possible.