### PR TITLE
fix: bound keywords to field in WMI persistence rule

### DIFF
--- a/rules/windows/other/win_wmi_persistence.yml
+++ b/rules/windows/other/win_wmi_persistence.yml
@@ -16,9 +16,10 @@ detection:
     selection:
         EventID: 5861
     keywords:
-        - 'ActiveScriptEventConsumer'
-        - 'CommandLineEventConsumer'
-        - 'CommandLineTemplate'
+        Message:
+            - '*ActiveScriptEventConsumer*'
+            - '*CommandLineEventConsumer*'
+            - '*CommandLineTemplate*'
         # - 'Binding EventFilter'  # too many false positive with HP Health Driver
     selection2:
         EventID: 5859


### PR DESCRIPTION
See #501.