### PR TITLE
fix: bound keywords to field in PS cred prompt rule

### DIFF
--- a/rules/windows/powershell/powershell_prompt_credentials.yml
+++ b/rules/windows/powershell/powershell_prompt_credentials.yml
@@ -17,7 +17,8 @@ detection:
     selection:
         EventID: 4104
     keyword:
-        - 'PromptForCredential'
+        Message:
+            - '*PromptForCredential*'
     condition: all of them
 falsepositives:
     - Unknown


### PR DESCRIPTION
See #501.