### PR TITLE
fix: bound windows event log rules to message field

### DIFF
--- a/rules/windows/builtin/win_alert_active_directory_user_control.yml
+++ b/rules/windows/builtin/win_alert_active_directory_user_control.yml
@@ -14,7 +14,8 @@ detection:
     selection:
         EventID: 4704
     keywords:
-        - 'SeEnableDelegationPrivilege'
+        Message:
+            - '*SeEnableDelegationPrivilege*'
     condition: all of them
 falsepositives: 
     - Unknown

--- a/rules/windows/builtin/win_alert_enable_weak_encryption.yml
+++ b/rules/windows/builtin/win_alert_enable_weak_encryption.yml
@@ -15,11 +15,13 @@ detection:
     selection:
         EventID: 4738
     keywords:
-        - 'DES'
-        - 'Preauth'
-        - 'Encrypted'
+        Message:
+        - '*DES*'
+        - '*Preauth*'
+        - '*Encrypted*'
     filters:
-        - 'Enabled'
+        Message:
+            - '*Enabled*'
     condition: selection and keywords and filters
 falsepositives: 
     - Unknown

--- a/rules/windows/builtin/win_alert_mimikatz_keywords.yml
+++ b/rules/windows/builtin/win_alert_mimikatz_keywords.yml
@@ -14,6 +14,7 @@ logsource:
     product: windows
 detection:
     keywords:
+        Message:
         - "* mimikatz *"
         - "* mimilib *"
         - "* <3 eo.oe *"

--- a/rules/windows/builtin/win_av_relevant_match.yml
+++ b/rules/windows/builtin/win_av_relevant_match.yml
@@ -6,29 +6,31 @@ logsource:
     service: application
 detection:
     keywords:
-        - HTool
-        - Hacktool
-        - ASP/Backdoor
-        - JSP/Backdoor
-        - PHP/Backdoor
-        - Backdoor.ASP
-        - Backdoor.JSP
-        - Backdoor.PHP
-        - Webshell
-        - Portscan
-        - Mimikatz
-        - WinCred
-        - PlugX
-        - Korplug
-        - Pwdump
-        - Chopper
-        - WmiExec
-        - Xscan
-        - Clearlog
-        - ASPXSpy
+        Message:
+            - "*HTool*"
+            - "*Hacktool*"
+            - "*ASP/Backdoor*"
+            - "*JSP/Backdoor*"
+            - "*PHP/Backdoor*"
+            - "*Backdoor.ASP*"
+            - "*Backdoor.JSP*"
+            - "*Backdoor.PHP*"
+            - "*Webshell*"
+            - "*Portscan*"
+            - "*Mimikatz*"
+            - "*WinCred*"
+            - "*PlugX*"
+            - "*Korplug*"
+            - "*Pwdump*"
+            - "*Chopper*"
+            - "*WmiExec*"
+            - "*Xscan*"
+            - "*Clearlog*"
+            - "*ASPXSpy*"
     filters:
-        - Keygen
-        - Crack
+        Message:
+            - "*Keygen*"
+            - "*Crack*"
     condition: keywords and not 1 of filters
 falsepositives:
     - Some software piracy tools (key generators, cracks) are classified as hack tools

--- a/rules/windows/builtin/win_mal_creddumper.yml
+++ b/rules/windows/builtin/win_mal_creddumper.yml
@@ -15,9 +15,10 @@ detection:
         EventID: 
           - 7045
     keywords:
-      - 'WCE SERVICE'
-      - 'WCESERVICE'
-      - 'DumpSvc'
+        Message:
+          - '*WCE SERVICE*'
+          - '*WCESERVICE*'
+          - '*DumpSvc*'
     quarkspwdump:
         EventID: 16
         HiveName: '*\AppData\Local\Temp\SAM*.dmp'

--- a/rules/windows/builtin/win_susp_msmpeng_crash.yml
+++ b/rules/windows/builtin/win_susp_msmpeng_crash.yml
@@ -21,8 +21,9 @@ detection:
         Source: 'Windows Error Reporting'
         EventID: 1001
     keywords:
-        - 'MsMpEng.exe'
-        - 'mpengine.dll'
+        Message:
+            - '*MsMpEng.exe*'
+            - '*mpengine.dll*'
     condition: 1 of selection* and all of keywords
 falsepositives:
     - MsMpEng.exe can crash when C:\ is full

--- a/rules/windows/builtin/win_susp_sam_dump.yml
+++ b/rules/windows/builtin/win_susp_sam_dump.yml
@@ -13,7 +13,8 @@ detection:
     selection:
         EventID: 16
     keywords:
-        - '*\AppData\Local\Temp\SAM-*.dmp *'
+        Message:
+            - '*\AppData\Local\Temp\SAM-*.dmp *'
     condition: all of them
 falsepositives:
     - Penetration testing


### PR DESCRIPTION
See #501.

Fixed rules
- rules/windows/builtin/win_susp_msmpeng_crash.yml
- rules/windows/builtin/win_alert_active_directory_user_control.yml
- rules/windows/builtin/win_av_relevant_match.yml
- rules/windows/builtin/win_mal_creddumper.yml
- rules/windows/builtin/win_susp_sam_dump.yml
- rules/windows/builtin/win_alert_mimikatz_keywords.yml
- rules/windows/builtin/win_alert_enable_weak_encryption.yml