### PR TITLE
LimaCharlie Productionization

### DIFF
--- a/tools/sigma/backends/limacharlie.py
+++ b/tools/sigma/backends/limacharlie.py
@@ -292,11 +292,15 @@ class LimaCharlieBackend(BaseBackend):
             mappedFiltered = []
             for k in filtered:
                 op, newVal = self._valuePatternToLcOp(k)
-                mappedFiltered.append({
+                newOp = {
                     "op": op,
                     "path": self._fieldMappingInEffect["keywords"],
-                    "value": newVal,
-                })
+                }
+                if op == "matches":
+                    newOp["re"] = newVal
+                else:
+                    newOp["value"] = newVal
+                mappedFiltered.append(newOp)
             filtered = mappedFiltered
         if 1 == len(filtered):
             return filtered[0]

--- a/tools/sigma/backends/limacharlie.py
+++ b/tools/sigma/backends/limacharlie.py
@@ -416,7 +416,7 @@ class LimaCharlieBackend(BaseBackend):
         if tmpVal.startswith("*"):
             isStartsWithWildcard = True
             tmpVal = tmpVal[1:]
-        if tmpVal.endswith("*") and not tmpVal.endswith("\\*"):
+        if tmpVal.endswith("*") and not (tmpVal.endswith("\\*") and not tmpVal.endswith("\\\\*")):
             isEndsWithWildcard = True
             tmpVal = tmpVal[:-1]
 

--- a/tools/sigma/backends/limacharlie.py
+++ b/tools/sigma/backends/limacharlie.py
@@ -425,7 +425,13 @@ class LimaCharlieBackend(BaseBackend):
             tmpVal = tmpVal[1:]
         if tmpVal.endswith("*") and not (tmpVal.endswith("\\*") and not tmpVal.endswith("\\\\*")):
             isEndsWithWildcard = True
-            tmpVal = tmpVal[:-1]
+            if tmpVal.endswith("\\\\*"):
+                # An extra \ had to be there so it didn't escapte the
+                # *, but since we plan on removing the *, we can also
+                # remove one \.
+                tmpVal = tmpVal[:-2]
+            else:
+                tmpVal = tmpVal[:-1]
 
         # Check to see if there are any other wildcards. If there are
         # we cannot use our shortcuts.

--- a/tools/sigma/backends/limacharlie.py
+++ b/tools/sigma/backends/limacharlie.py
@@ -30,7 +30,7 @@ def _windowsEventLogFieldName(fieldName):
 
 def _mapProcessCreationOperations(node):
     # Here we fix some common pitfalls found in rules
-    # in a consistent fashion (already process to D&R rule).
+    # in a consistent fashion (already processed to D&R rule).
 
     # First fixup is looking for a specific path prefix
     # based on a specific drive letter. There are many cases
@@ -459,6 +459,7 @@ class LimaCharlieBackend(BaseBackend):
         # or into altered values to be functionally equivalent using
         # a few different LC D&R rule operators.
 
+        # No point evaluating non-strings.
         if not isinstance(val, str):
             return ("is", str(val) if self._isAllStringValues else val)
 
@@ -467,7 +468,9 @@ class LimaCharlieBackend(BaseBackend):
             return ("is", val)
 
         # Now we do a small optimization for the shortcut operators
-        # available in LC.
+        # available in LC. We try to see if the wildcards are around
+        # the main value, but NOT within. If that's the case we can
+        # use the "starts with", "ends with" or "contains" operators.
         isStartsWithWildcard = False
         isEndsWithWildcard = False
         tmpVal = val
@@ -554,11 +557,12 @@ class LimaCharlieBackend(BaseBackend):
         # This function ensures that the list of values passed
         # are proper D&R operations, if they are strings it indicates
         # they were requested as keyword matches. We only support
-        # keyword matches when specific in the config where we just
+        # keyword matches when specified in the config. We generally just
         # map them to the most common field in LC that makes sense.
         mapped = []
 
         for val in values:
+            # Non-keywords are just passed through.
             if not isinstance(val, str):
                 mapped.append(val)
                 continue

--- a/tools/sigma/backends/limacharlie.py
+++ b/tools/sigma/backends/limacharlie.py
@@ -334,7 +334,6 @@ class LimaCharlieBackend(BaseBackend):
                 else:
                     fieldname = self._fieldMappingInEffect[fieldname]
             except:
-                raise
                 raise NotImplementedError("Field name %s not supported by backend." % (fieldname,))
 
         # If fieldname returned is None, it's a special case where we


### PR DESCRIPTION
Many refactors to ready the backend to generate rules ready for production use in LimaCharlie.

This targets the Process Creation category of rules primarily since they translate to LC easily.

High level changes:

- Implemented a new conversion of wildcard-string to proper Operator use and regular expression. This implementation is a bit more messy than the previous one, but as far as we can tell it is now correct in all cases. The previous one generated many invalid sequences in existing rules. We will see how it goes but might do a PR later on to port it to the WDATP backend (where we took the old implementation) to fix it.

- Support "keyword" searches on more event types.

- Many fixes.