### PR TITLE
Fix Win10 FP Out of the Box

### DIFF
--- a/rules/windows/process_creation/win_proc_wrong_parent.yml
+++ b/rules/windows/process_creation/win_proc_wrong_parent.yml
@@ -31,6 +31,7 @@ detection:
         ParentImage:
             - '*\System32\\*'
             - '*\SysWOW64\\*'
+            - '*\ProgramData\Microsoft\Windows Defender\Platform\\*'
     filter_null:
         ParentImage: null
     condition: selection and not filter and not filter_null


### PR DESCRIPTION
Seeing a FP from the parent process directory rule on Windows 10.
This adds that exception.

Sample source event:
```
{
  "HASH": "7fd065bac18c5278777ae44908101cdfed72d26fa741367f0ad4d02020787ab6",
  "PARENT": {
    "PROCESS_ID": 3008,
    "FILE_IS_SIGNED": 1,
    "USER_NAME": "NT AUTHORITY\\SYSTEM",
    "FILE_PATH": "\\Device\\HarddiskVolume3\\ProgramData\\Microsoft\\Windows Defender\\Platform\\4.18.1910.4-0\\MsMpEng.exe",
    "PARENT_PROCESS_ID": 800
  },
  "COMMAND_LINE": "\"c:\\windows\\system32\\\\svchost.exe\"",
  "PROCESS_ID": 3108,
  "FILE_IS_SIGNED": 1,
  "USER_NAME": "NT AUTHORITY\\SYSTEM",
  "FILE_PATH": "c:\\windows\\system32\\svchost.exe",
  "PARENT_PROCESS_ID": 3008
}
```