### PR TITLE
LimaCharlie basic support for Proxy rule category.

### DIFF
--- a/tools/sigma/backends/limacharlie.py
+++ b/tools/sigma/backends/limacharlie.py
@@ -177,6 +177,22 @@ _allFieldMappings = {
         keywordField = None,
         postOpMapper = None
     ),
+    "/proxy/": SigmaLCConfig(
+        topLevelParams = {
+            "event": "HTTP_REQUEST",
+        },
+        preConditions = None,
+        fieldMappings = {
+            "c-uri|contains": "event/URL",
+            "c-uri": "event/URL",
+            "URL": "event/URL",
+            "cs-uri-query": "event/URL",
+            "cs-uri-stem": "event/URL",
+        },
+        isAllStringValues = False,
+        keywordField = None,
+        postOpMapper = None
+    ),
 }
 
 class LimaCharlieBackend(BaseBackend):


### PR DESCRIPTION
Adding support for basic proxy rules using the HTTP_REQUEST events from the Chrome LC Agent.