### PR TITLE
Add source distribution for PyPi when building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ test-backend-es-qs:
 	tests/test-backend-es-qs.py
 
 build: tools/sigmac tools/merge_sigma tools/sigma/*.py tools/setup.py tools/setup.cfg
-	cd tools && python3 setup.py bdist_wheel
+	cd tools && python3 setup.py bdist_wheel sdist
 
 upload-test: build
 	twine upload --repository-url https://test.pypi.org/legacy/ tools/dist/*


### PR DESCRIPTION
Add sdist when building. This makes it easier to build packages from PyPi for example Debian PPA pkgs etc.
This will not affect anything else, just make the source distribution available in PyPi as a tar.gz archive.

If this gets merged, please bump the version and push to PyPi as well.