### PR TITLE
Elastalert error, duplicate rule titles

### DIFF
--- a/rules/windows/builtin/win_pass_the_hash_2.yml
+++ b/rules/windows/builtin/win_pass_the_hash_2.yml
@@ -1,4 +1,4 @@
-title: Pass the Hash Activity
+title: Pass the Hash Activity 2
 id: 8eef149c-bd26-49f2-9e5a-9b00e3af499b
 status: production
 description: Detects the attack technique pass the hash which is used to move laterally inside the network

--- a/rules/windows/powershell/powershell_data_compressed.yml
+++ b/rules/windows/powershell/powershell_data_compressed.yml
@@ -1,4 +1,4 @@
-title: Data Compressed
+title: Data Compressed - Powershell
 id: 6dc5d284-69ea-42cf-9311-fb1c3932a69a
 status: experimental
 description: An adversary may compress data (e.g., sensitive documents) that is collected prior to exfiltration in order to make it portable and minimize the amount

--- a/rules/windows/process_creation/win_data_compressed_with_rar.yml
+++ b/rules/windows/process_creation/win_data_compressed_with_rar.yml
@@ -1,4 +1,4 @@
-title: Data Compressed
+title: Data Compressed - rar.exe
 id: 6f3e2987-db24-4c78-a860-b4f4095a7095
 status: experimental
 description: An adversary may compress data (e.g., sensitive documents) that is collected prior to exfiltration in order to make it portable and minimize the amount


### PR DESCRIPTION
Some duplicate rule titles are causing Elastalert to error on duplicate rule names.