### PR TITLE
Add Covenant default named pipe

### DIFF
--- a/rules/windows/sysmon/sysmon_mal_namedpipes.yml
+++ b/rules/windows/sysmon/sysmon_mal_namedpipes.yml
@@ -30,6 +30,7 @@ detection:
          - '\NamePipe_MoreWindows'  # Cloud Hopper Annex B https://www.pwc.co.uk/cyber-security/pdf/cloud-hopper-annex-b-final.pdf, US-CERT Alert - RedLeaves https://www.us-cert.gov/ncas/alerts/TA17-117A
          - '\pcheap_reuse'  # Pipe used by Equation Group malware 77486bb828dba77099785feda0ca1d4f33ad0d39b672190079c508b3feb21fb0
          - '\msagent_*'  # CS default named pipes https://github.com/Neo23x0/sigma/issues/253
+         - '\gruntsvc' # Covenant default named pipe
          # - '\status_*'  # CS default named pipes https://github.com/Neo23x0/sigma/issues/253
    condition: selection
 tags:


### PR DESCRIPTION
Covenant (https://github.com/cobbr/Covenant) can use named pipes for peer to peer communication.
The default named pipe name is "\gruntsvc".
References: https://posts.specterops.io/designing-peer-to-peer-command-and-control-ad2c61740456