### PR TITLE
FP in win_system_exe_anomaly.yml

### DIFF
--- a/rules/windows/process_creation/win_system_exe_anomaly.yml
+++ b/rules/windows/process_creation/win_system_exe_anomaly.yml
@@ -29,13 +29,14 @@ detection:
             - '*\lsm.exe'
             - '*\winlogon.exe'
             - '*\explorer.exe'
-            - '*\taskhost.exe' 
+            - '*\taskhost.exe'
     filter:
         Image:
             - 'C:\Windows\System32\\*'
             - 'C:\Windows\SysWow64\\*'
             - 'C:\Windows\explorer.exe'
             - 'C:\Windows\winsxs\\*'
+             - '\SystemRoot\System32\\*'
     condition: selection and not filter
 falsepositives:
     - Exotic software

--- a/rules/windows/process_creation/win_system_exe_anomaly.yml
+++ b/rules/windows/process_creation/win_system_exe_anomaly.yml
@@ -29,14 +29,14 @@ detection:
             - '*\lsm.exe'
             - '*\winlogon.exe'
             - '*\explorer.exe'
-            - '*\taskhost.exe'
+            - '*\taskhost.exe' 
     filter:
         Image:
             - 'C:\Windows\System32\\*'
             - 'C:\Windows\SysWow64\\*'
             - 'C:\Windows\explorer.exe'
             - 'C:\Windows\winsxs\\*'
-             - '\SystemRoot\System32\\*'
+            - '\SystemRoot\System32\\*'
     condition: selection and not filter
 falsepositives:
     - Exotic software


### PR DESCRIPTION
Following an event with @maximelb , we have noticed \SystemRoot\System32\ is missing from the valid paths. This fork is a fix adding it to the paths.

Also, fun fact.
The original rule is referencing to one of my tweets: https://twitter.com/GelosSnake/status/934900723426439170
Closing circles and good cyber karma to us all.


 