### PR TITLE
Adding LimaCharlie support for OriginalFileName field.

### DIFF
--- a/tools/sigma/backends/limacharlie.py
+++ b/tools/sigma/backends/limacharlie.py
@@ -81,9 +81,7 @@ _allFieldMappings = {
             "ParentImage": "event/PARENT/FILE_PATH",
             "ParentCommandLine": "event/PARENT/COMMAND_LINE",
             "User": "event/USER_NAME",
-            # This field is redundant in LC, it seems to always be used with Image
-            # so we will ignore it.
-            "OriginalFileName": lambda fn, fv: ("event/FILE_PATH", "*" + fv),
+            "OriginalFileName": "event/INTERNAL_NAME",
             # Custom field names coming from somewhere unknown.
             "NewProcessName": "event/FILE_PATH",
             "ProcessCommandLine": "event/COMMAND_LINE",

--- a/tools/sigma/backends/limacharlie.py
+++ b/tools/sigma/backends/limacharlie.py
@@ -81,7 +81,7 @@ _allFieldMappings = {
             "ParentImage": "event/PARENT/FILE_PATH",
             "ParentCommandLine": "event/PARENT/COMMAND_LINE",
             "User": "event/USER_NAME",
-            "OriginalFileName": "event/INTERNAL_NAME",
+            "OriginalFileName": "event/ORIGINAL_FILE_NAME",
             # Custom field names coming from somewhere unknown.
             "NewProcessName": "event/FILE_PATH",
             "ProcessCommandLine": "event/COMMAND_LINE",


### PR DESCRIPTION
LimaCharlie is adding a new `event/ORIGINAL_FILE_NAME` field which maps to the OriginalFileName in various Sigma rules.