### PR TITLE
HELK SIGMAC fix name of network_initiated

### DIFF
--- a/tools/config/helk.yml
+++ b/tools/config/helk.yml
@@ -88,7 +88,7 @@ fieldmappings:
         EventID=7: module_loaded
     Imphash: hash_imphash
     Initiated:
-        EventID=3: network_initiated"
+        EventID=3: network_initiated
     IntegrityLevel:
         EventID=1: process_integrity_level
     ipAddress: dst_ip_addr


### PR DESCRIPTION
typo in network_initiated that included an ending `"`