### PR TITLE
Update proxy_raw_paste_service_access.yml

### DIFF
--- a/rules/proxy/proxy_raw_paste_service_access.yml
+++ b/rules/proxy/proxy_raw_paste_service_access.yml
@@ -17,6 +17,7 @@ detection:
           - '.paste.ee/r/'
           - '.pastebin.com/raw/'
           - '.hastebin.com/raw/'
+          - '.ghostbin.co/paste/.+/raw/'
     condition: selection
 fields:
     - ClientIP

--- a/rules/proxy/proxy_raw_paste_service_access.yml
+++ b/rules/proxy/proxy_raw_paste_service_access.yml
@@ -17,7 +17,7 @@ detection:
           - '.paste.ee/r/'
           - '.pastebin.com/raw/'
           - '.hastebin.com/raw/'
-          - '.ghostbin.co/paste/.+/raw/'
+          - '.ghostbin.co/paste/*/raw/'
     condition: selection
 fields:
     - ClientIP


### PR DESCRIPTION
Add another paste provider website, ghostbin.co to the list. Note that saved pastes generate pseudo random 5 character strings before being suffixed with `/raw` at the end of the URL. e.g. `https://ghostbin.co/paste/y4e9a/raw`

Thus, I've added a regex match between /paste and /raw. I'm unsure if this is supported, I skimmed the Sigma specification wiki but didn't see anything other than that contains adds '*' to end and beginning of each selection. If this regex isn't going to work then I'd imagine we just have to remove the `.+/raw/` from the URI.