### PR TITLE
additional gallium ttp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ ENV/
 # vi(m)
 *.swp
 settings.json
+
+# VisualStudio
+.vs/

--- a/rules/windows/process_creation/win_apt_gallium.yml
+++ b/rules/windows/process_creation/win_apt_gallium.yml
@@ -4,7 +4,7 @@ id: 440a56bf-7873-4439-940a-1c8a671073c2
 status: experimental
 description: Detects artefacts associated with activity group GALLIUM - Microsoft Threat Intelligence Center indicators released in December 2019.
 author: Tim Burrell
-date: 2020/01/02
+date: 2020/02/07
 references:
     - https://www.microsoft.com/security/blog/2019/12/12/gallium-targeting-global-telecom/
     - https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-R2-and-2012/dn800669(v=ws.11)
@@ -17,7 +17,7 @@ level: high
 ---
 logsource:
     category: process_creation
-    product: windows
+    product: sysmon
 detection:
     exec_selection:
         sha1:
@@ -48,7 +48,7 @@ logsource:
 detection:
     c2_selection:
         EventID: 257
-        QNAME:
+        QNAME: 
             - 'asyspy256.ddns.net'
             - 'hotkillmail9sddcc.ddns.net'
             - 'rosaf112.ddns.net'
@@ -57,3 +57,16 @@ detection:
             - 'dffwescwer4325.myftp.biz'
             - 'cvdfhjh1231.ddns.net'
     condition: c2_selection
+---
+logsource:
+    category: process_creation
+    product: sysmon
+detection:
+    legitimate_process_path:
+        Image|contains:
+            - ':\Program Files(x86)\'
+            - ':\Program Files\'
+    legitimate_executable:
+        sha1:
+            - 'e570585edc69f9074cb5e8a790708336bd45ca0f'
+    condition: legitimate_executable and not legitimate_process_path

--- a/rules/windows/process_creation/win_apt_gallium.yml
+++ b/rules/windows/process_creation/win_apt_gallium.yml
@@ -16,8 +16,8 @@ falsepositives:
 level: high
 ---
 logsource:
+    product: windows
     category: process_creation
-    product: sysmon
 detection:
     exec_selection:
         sha1:
@@ -59,8 +59,8 @@ detection:
     condition: c2_selection
 ---
 logsource:
+    product: windows
     category: process_creation
-    product: sysmon
 detection:
     legitimate_process_path:
         Image|contains:


### PR DESCRIPTION
sha1 process creation only makes sense for sysmon.
Add gallium ttp related to softether vpn binary located under an unusual file path.