### PR TITLE
More rules for AWS events

### DIFF
--- a/rules/cloud/aws_ec2_download_userdata.yml
+++ b/rules/cloud/aws_ec2_download_userdata.yml
@@ -5,20 +5,20 @@ author: faloker
 date: 2020/02/11
 description: Detects bulk downloading of User Data associated with AWS EC2 instances. Instance User Data may include installation scripts and hard-coded secrets for deployment.
 references:
-  - https://github.com/RhinoSecurityLabs/pacu/blob/master/modules/ec2__download_userdata/main.py#L24
+    - https://github.com/RhinoSecurityLabs/pacu/blob/master/modules/ec2__download_userdata/main.py#L24
 logsource:
-  service: cloudtrail
+    service: cloudtrail
 detection:
-  selection_source:
-    - eventSource: ec2.amazonaws.com
-  selection_requesttype:
-    - requestParameters.attribute: userData
-  selection_eventname:
-    - eventName: DescribeInstanceAttribute
-  timeframe: 30m
-  condition: all of them | count() > 10
+    selection_source:
+        - eventSource: ec2.amazonaws.com
+    selection_requesttype:
+        - requestParameters.attribute: userData
+    selection_eventname:
+        - eventName: DescribeInstanceAttribute
+    timeframe: 30m
+    condition: all of them | count() > 10
 level: medium
 falsepositives:
     - Assets management software like device42
 tags:
-  - attack.t1020
+    - attack.t1020

--- a/rules/cloud/aws_ec2_download_userdata.yml
+++ b/rules/cloud/aws_ec2_download_userdata.yml
@@ -1,4 +1,4 @@
-title: Downloading of User Data associated with AWS EC2 instances.
+title: AWS EC2 Download Userdata
 id: 26ff4080-194e-47e7-9889-ef7602efed0c
 status: experimental
 author: faloker

--- a/rules/cloud/aws_ec2_download_userdata.yml
+++ b/rules/cloud/aws_ec2_download_userdata.yml
@@ -1,0 +1,24 @@
+title: Downloading of User Data associated with AWS EC2 instances.
+id: 26ff4080-194e-47e7-9889-ef7602efed0c
+status: experimental
+author: faloker
+date: 2020/02/11
+description: Detects bulk downloading of User Data associated with AWS EC2 instances. Instance User Data may include installation scripts and hard-coded secrets for deployment.
+references:
+  - https://github.com/RhinoSecurityLabs/pacu/blob/master/modules/ec2__download_userdata/main.py#L24
+logsource:
+  service: cloudtrail
+detection:
+  selection_source:
+    - eventSource: ec2.amazonaws.com
+  selection_requesttype:
+    - requestParameters.attribute: userData
+  selection_eventname:
+    - eventName: DescribeInstanceAttribute
+  timeframe: 30m
+  condition: selection_source AND selection_eventname AND selection_requesttype | count() > 10
+level: medium
+falsepositives:
+    - Assets management software like device42
+tags:
+  - attack.t1020

--- a/rules/cloud/aws_ec2_download_userdata.yml
+++ b/rules/cloud/aws_ec2_download_userdata.yml
@@ -16,7 +16,7 @@ detection:
   selection_eventname:
     - eventName: DescribeInstanceAttribute
   timeframe: 30m
-  condition: selection_source AND selection_eventname AND selection_requesttype | count() > 10
+  condition: all of them | count() > 10
 level: medium
 falsepositives:
     - Assets management software like device42

--- a/rules/cloud/aws_ec2_startup_script_change.yml
+++ b/rules/cloud/aws_ec2_startup_script_change.yml
@@ -1,4 +1,4 @@
-title: Change of startup shell script for AWS EC2 instances.
+title: AWS EC2 Startup Shell Script Change
 id: 1ab3c5ed-5baf-417b-bb6b-78ca33f6c3df
 status: experimental
 author: faloker

--- a/rules/cloud/aws_ec2_startup_script_change.yml
+++ b/rules/cloud/aws_ec2_startup_script_change.yml
@@ -5,19 +5,19 @@ author: faloker
 date: 2020/02/12
 description: Detects changes to the EC2 instance startup script. The shell script will be executed as root/SYSTEM everytime the specific instances are booted up.
 references:
-  - https://github.com/RhinoSecurityLabs/pacu/blob/master/modules/ec2__startup_shell_script/main.py#L9
+    - https://github.com/RhinoSecurityLabs/pacu/blob/master/modules/ec2__startup_shell_script/main.py#L9
 logsource:
-  service: cloudtrail
+    service: cloudtrail
 detection:
-  selection_source:
-    - eventSource: ec2.amazonaws.com
-  selection_userdata:
-    - requestParameters.userData: "*"
-  selection_eventname:
-    - eventName: ModifyInstanceAttribute
-  condition: all of them
+    selection_source:
+        - eventSource: ec2.amazonaws.com
+    selection_userdata:
+        - requestParameters.userData: "*"
+    selection_eventname:
+        - eventName: ModifyInstanceAttribute
+    condition: all of them
 level: high
 falsepositives:
     - Valid changes to the startup script
 tags:
-  - attack.t1064
+    - attack.t1064

--- a/rules/cloud/aws_ec2_startup_script_change.yml
+++ b/rules/cloud/aws_ec2_startup_script_change.yml
@@ -1,0 +1,23 @@
+title: Change of startup shell script for AWS EC2 instances.
+id: 1ab3c5ed-5baf-417b-bb6b-78ca33f6c3df
+status: experimental
+author: faloker
+date: 2020/02/12
+description: Detects changes to the EC2 instance startup script. The shell script will be executed as root/SYSTEM everytime the specific instances are booted up.
+references:
+  - https://github.com/RhinoSecurityLabs/pacu/blob/master/modules/ec2__startup_shell_script/main.py#L9
+logsource:
+  service: cloudtrail
+detection:
+  selection_source:
+    - eventSource: ec2.amazonaws.com
+  selection_userdata:
+    - requestParameters.userData: "*"
+  selection_eventname:
+    - eventName: ModifyInstanceAttribute
+  condition: all of them
+level: high
+falsepositives:
+    - Valid changes to the startup script
+tags:
+  - attack.t1064

--- a/rules/cloud/aws_guardduty_disruption.yml
+++ b/rules/cloud/aws_guardduty_disruption.yml
@@ -1,0 +1,22 @@
+title: AWS GuardDuty Important Change
+id: 6e61ee20-ce00-4f8d-8aee-bedd8216f7e3
+status: experimental
+author: faloker
+date: 2020/02/11
+description: Detects updates of the GuardDuty list of trusted IPs, perhaps to disable security alerts against malicious IPs. 
+references:
+  - https://github.com/RhinoSecurityLabs/pacu/blob/master/modules/guardduty__whitelist_ip/main.py#L9
+logsource:
+  service: cloudtrail
+detection:
+  selection_source:
+    - eventSource: guardduty.amazonaws.com
+  events:
+    - eventName:
+        - CreateIPSet
+  condition: selection_source AND events
+level: medium
+falsepositives:
+    - Valid change in the GuardDuty (e.g. to ignore internal scanners)
+tags:
+  - attack.t1089

--- a/rules/cloud/aws_guardduty_disruption.yml
+++ b/rules/cloud/aws_guardduty_disruption.yml
@@ -11,11 +11,10 @@ logsource:
 detection:
   selection_source:
     - eventSource: guardduty.amazonaws.com
-  events:
-    - eventName:
-        - CreateIPSet
-  condition: selection_source AND events
-level: medium
+  selection_eventName:
+    - eventName: CreateIPSet
+  condition: all of them
+level: high
 falsepositives:
     - Valid change in the GuardDuty (e.g. to ignore internal scanners)
 tags:

--- a/rules/cloud/aws_guardduty_disruption.yml
+++ b/rules/cloud/aws_guardduty_disruption.yml
@@ -3,19 +3,19 @@ id: 6e61ee20-ce00-4f8d-8aee-bedd8216f7e3
 status: experimental
 author: faloker
 date: 2020/02/11
-description: Detects updates of the GuardDuty list of trusted IPs, perhaps to disable security alerts against malicious IPs. 
+description: Detects updates of the GuardDuty list of trusted IPs, perhaps to disable security alerts against malicious IPs.
 references:
-  - https://github.com/RhinoSecurityLabs/pacu/blob/master/modules/guardduty__whitelist_ip/main.py#L9
+    - https://github.com/RhinoSecurityLabs/pacu/blob/master/modules/guardduty__whitelist_ip/main.py#L9
 logsource:
-  service: cloudtrail
+    service: cloudtrail
 detection:
-  selection_source:
-    - eventSource: guardduty.amazonaws.com
-  selection_eventName:
-    - eventName: CreateIPSet
-  condition: all of them
+    selection_source:
+        - eventSource: guardduty.amazonaws.com
+    selection_eventName:
+        - eventName: CreateIPSet
+    condition: all of them
 level: high
 falsepositives:
     - Valid change in the GuardDuty (e.g. to ignore internal scanners)
 tags:
-  - attack.t1089
+    - attack.t1089

--- a/rules/cloud/aws_iam_backdoor_users_keys.yml
+++ b/rules/cloud/aws_iam_backdoor_users_keys.yml
@@ -1,0 +1,29 @@
+title: Creation of AWS API keys for users.
+id: 0a5177f4-6ca9-44c2-aacf-d3f3d8b6e4d2
+status: experimental
+author: faloker
+date: 2020/02/12
+description: Detects AWS API key creation for a user by another user. Backdoored users can be used to obtain persistence in the AWS environment. Also with this alert, you can detect a flow of AWS keys in your org.
+references:
+  - https://github.com/RhinoSecurityLabs/pacu/blob/master/modules/iam__backdoor_users_keys/main.py#L6
+logsource:
+  service: cloudtrail
+detection:
+  selection_source:
+    - eventSource: iam.amazonaws.com
+  selection_eventname:
+    - eventName: CreateAccessKey
+  filter:
+    userIdentity.arn|contains: responseElements.accessKey.userName
+  condition: all of selection* and not filter
+fields:
+  - userIdentity.arn
+  - responseElements.accessKey.userName
+  - errorCode
+  - errorMessage
+level: high
+falsepositives:
+    - Adding user keys to their own accounts (the filter cannot cover all possible variants of user naming)
+    - AWS API keys legitimate exchange workflows
+tags:
+  - attack.t1098

--- a/rules/cloud/aws_iam_backdoor_users_keys.yml
+++ b/rules/cloud/aws_iam_backdoor_users_keys.yml
@@ -5,25 +5,25 @@ author: faloker
 date: 2020/02/12
 description: Detects AWS API key creation for a user by another user. Backdoored users can be used to obtain persistence in the AWS environment. Also with this alert, you can detect a flow of AWS keys in your org.
 references:
-  - https://github.com/RhinoSecurityLabs/pacu/blob/master/modules/iam__backdoor_users_keys/main.py#L6
+    - https://github.com/RhinoSecurityLabs/pacu/blob/master/modules/iam__backdoor_users_keys/main.py#L6
 logsource:
-  service: cloudtrail
+    service: cloudtrail
 detection:
-  selection_source:
-    - eventSource: iam.amazonaws.com
-  selection_eventname:
-    - eventName: CreateAccessKey
-  filter:
-    userIdentity.arn|contains: responseElements.accessKey.userName
-  condition: all of selection* and not filter
+    selection_source:
+        - eventSource: iam.amazonaws.com
+    selection_eventname:
+        - eventName: CreateAccessKey
+    filter:
+        userIdentity.arn|contains: responseElements.accessKey.userName
+    condition: all of selection* and not filter
 fields:
-  - userIdentity.arn
-  - responseElements.accessKey.userName
-  - errorCode
-  - errorMessage
-level: high
+    - userIdentity.arn
+    - responseElements.accessKey.userName
+    - errorCode
+    - errorMessage
+level: medium
 falsepositives:
     - Adding user keys to their own accounts (the filter cannot cover all possible variants of user naming)
     - AWS API keys legitimate exchange workflows
 tags:
-  - attack.t1098
+    - attack.t1098

--- a/rules/cloud/aws_iam_backdoor_users_keys.yml
+++ b/rules/cloud/aws_iam_backdoor_users_keys.yml
@@ -1,4 +1,4 @@
-title: Creation of AWS API keys for users.
+title: AWS IAM Backdoor Users Keys
 id: 0a5177f4-6ca9-44c2-aacf-d3f3d8b6e4d2
 status: experimental
 author: faloker

--- a/rules/cloud/aws_rds_change_master_password.yml
+++ b/rules/cloud/aws_rds_change_master_password.yml
@@ -1,4 +1,4 @@
-title: Change RDS db instance master password.
+title: AWS RDS Master Password Change
 id: 8a63cdd4-6207-414a-85bc-7e032bd3c1a2
 status: experimental
 author: faloker

--- a/rules/cloud/aws_rds_change_master_password.yml
+++ b/rules/cloud/aws_rds_change_master_password.yml
@@ -1,0 +1,23 @@
+title: Change RDS db instance master password.
+id: 8a63cdd4-6207-414a-85bc-7e032bd3c1a2
+status: experimental
+author: faloker
+date: 2020/02/12
+description: Detects the change of database master password. It may be a part of data exfiltration.
+references:
+  - https://github.com/RhinoSecurityLabs/pacu/blob/master/modules/rds__explore_snapshots/main.py#L10
+logsource:
+  service: cloudtrail
+detection:
+  selection_source:
+    - eventSource: rds.amazonaws.com
+  selection_modified_values:
+    - responseElements.pendingModifiedValues.masterUserPassword: "*"
+  selection_eventname:
+    - eventName: ModifyDBInstance
+  condition: all of them
+level: medium
+falsepositives:
+    - Benign changes to a db instance
+tags:
+  - attack.t1020

--- a/rules/cloud/aws_rds_change_master_password.yml
+++ b/rules/cloud/aws_rds_change_master_password.yml
@@ -5,19 +5,19 @@ author: faloker
 date: 2020/02/12
 description: Detects the change of database master password. It may be a part of data exfiltration.
 references:
-  - https://github.com/RhinoSecurityLabs/pacu/blob/master/modules/rds__explore_snapshots/main.py#L10
+    - https://github.com/RhinoSecurityLabs/pacu/blob/master/modules/rds__explore_snapshots/main.py#L10
 logsource:
-  service: cloudtrail
+    service: cloudtrail
 detection:
-  selection_source:
-    - eventSource: rds.amazonaws.com
-  selection_modified_values:
-    - responseElements.pendingModifiedValues.masterUserPassword: "*"
-  selection_eventname:
-    - eventName: ModifyDBInstance
-  condition: all of them
+    selection_source:
+        - eventSource: rds.amazonaws.com
+    selection_modified_values:
+        - responseElements.pendingModifiedValues.masterUserPassword: "*"
+    selection_eventname:
+        - eventName: ModifyDBInstance
+    condition: all of them
 level: medium
 falsepositives:
     - Benign changes to a db instance
 tags:
-  - attack.t1020
+    - attack.t1020

--- a/rules/cloud/aws_rds_public_db_restore.yml
+++ b/rules/cloud/aws_rds_public_db_restore.yml
@@ -5,19 +5,19 @@ author: faloker
 date: 2020/02/12
 description: Detects the recovery of a new public database instance from a snapshot. It may be a part of data exfiltration.
 references:
-  - https://github.com/RhinoSecurityLabs/pacu/blob/master/modules/rds__explore_snapshots/main.py#L10
+    - https://github.com/RhinoSecurityLabs/pacu/blob/master/modules/rds__explore_snapshots/main.py#L10
 logsource:
-  service: cloudtrail
+    service: cloudtrail
 detection:
-  selection_source:
-    - eventSource: rds.amazonaws.com
-  selection_ispublic:
-    - responseElements.publiclyAccessible: "true"
-  selection_eventname:
-    - eventName: RestoreDBInstanceFromDBSnapshot
-  condition: all of them
+    selection_source:
+        - eventSource: rds.amazonaws.com
+    selection_ispublic:
+        - responseElements.publiclyAccessible: "true"
+    selection_eventname:
+        - eventName: RestoreDBInstanceFromDBSnapshot
+    condition: all of them
 level: high
 falsepositives:
     - unknown
 tags:
-  - attack.t1020
+    - attack.t1020

--- a/rules/cloud/aws_rds_public_db_restore.yml
+++ b/rules/cloud/aws_rds_public_db_restore.yml
@@ -1,4 +1,4 @@
-title: Restore RDS db instance from snapshot with public access.
+title: Restore Public AWS RDS Instance
 id: c3f265c7-ff03-4056-8ab2-d486227b4599
 status: experimental
 author: faloker

--- a/rules/cloud/aws_rds_public_db_restore.yml
+++ b/rules/cloud/aws_rds_public_db_restore.yml
@@ -1,0 +1,23 @@
+title: Restore RDS db instance from snapshot with public access.
+id: c3f265c7-ff03-4056-8ab2-d486227b4599
+status: experimental
+author: faloker
+date: 2020/02/12
+description: Detects the recovery of a new public database instance from a snapshot. It may be a part of data exfiltration.
+references:
+  - https://github.com/RhinoSecurityLabs/pacu/blob/master/modules/rds__explore_snapshots/main.py#L10
+logsource:
+  service: cloudtrail
+detection:
+  selection_source:
+    - eventSource: rds.amazonaws.com
+  selection_ispublic:
+    - responseElements.publiclyAccessible: "true"
+  selection_eventname:
+    - eventName: RestoreDBInstanceFromDBSnapshot
+  condition: all of them
+level: high
+falsepositives:
+    - unknown
+tags:
+  - attack.t1020


### PR DESCRIPTION
More rules for the AWS environment. 
These rules can be used to detect potential exploits by scripts and tools like [Pacu](https://github.com/RhinoSecurityLabs/pacu).
Each rule has a reference to a specific exploit available as part of Pacu.

New rules:
1. Downloading of User Data associated with AWS EC2 instances
1. Change of startup shell script for AWS EC2 instances
1. AWS GuardDuty disruption to avoid detection
1. Change the master password of an AWS RDS database instance
1. Backdoor of users AWS API keys
1. Restore AWS RDS db instance from a snapshot with public access