### PR TITLE
rule: Zeek Suspicious kerberos network traffic RC4

### DIFF
--- a/rules/network/zeek_susp_kerberos_rc4.yml
+++ b/rules/network/zeek_susp_kerberos_rc4.yml
@@ -1,0 +1,22 @@
+title: Suspicious kerberos network traffic RC4 ticket encryption
+id: 503fe26e-b5f2-4944-a126-eab405cc06e5
+status: experimental
+description: Detects kerberos TGS request using RC4 encryption which may be indicative of kerberoasting
+references:
+    - https://adsecurity.org/?p=3458
+tags:
+    - attack.credential_access
+    - attack.t1208
+logsource:
+    product: zeek
+    service: kerberos
+detection:
+    selection:
+        request_type: 'TGS'
+        cipher: 'rc4-hmac'
+    computer_acct:
+        service: '$*'
+    condition: selection and computer_acct
+falsepositives:
+    - normal enterprise SPN requests activity
+level: medium

--- a/rules/network/zeek_susp_kerberos_rc4.yml
+++ b/rules/network/zeek_susp_kerberos_rc4.yml
@@ -16,7 +16,7 @@ detection:
         cipher: 'rc4-hmac'
     computer_acct:
         service: '$*'
-    condition: selection and computer_acct
+    condition: selection and not computer_acct
 falsepositives:
     - normal enterprise SPN requests activity
 level: medium

--- a/rules/network/zeek_susp_kerberos_rc4.yml
+++ b/rules/network/zeek_susp_kerberos_rc4.yml
@@ -1,6 +1,7 @@
-title: Suspicious kerberos network traffic RC4 ticket encryption
+title: Kerberos Network Traffic RC4 Ticket Encryption
 id: 503fe26e-b5f2-4944-a126-eab405cc06e5
 status: experimental
+date: 2020/02/12
 description: Detects kerberos TGS request using RC4 encryption which may be indicative of kerberoasting
 references:
     - https://adsecurity.org/?p=3458

--- a/tools/config/splunk-zeek.yml
+++ b/tools/config/splunk-zeek.yml
@@ -1,0 +1,41 @@
+logsources:
+  zeek-conn:
+    product: zeek
+    service: conn
+    conditions:
+      sourcetype: 'bro:conn:json'
+  zeek-dns:
+    product: zeek
+    service: dns
+    conditions:
+      sourcetype: 'bro:dns:json'
+  zeek-files:
+    product: zeek
+    service: files
+    conditions:
+      sourcetype: 'bro:files:json'
+  zeek-kerberos:
+    product: zeek
+    service: kerberos
+    conditions:
+      sourcetype: 'bro:kerberos:json'
+  zeek-http:
+    product: zeek
+    service: http
+    conditions:
+      sourcetype: 'bro:http:json'
+  zeek-rdp:
+    product: zeek
+    service: rdp
+    conditions:
+      sourcetype: 'bro:rdp:json'
+  zeek-ssl:
+    product: zeek
+    service: ssl
+    conditions:
+      sourcetype: 'bro:ssl:json'
+  zeek-x509:
+    product: zeek
+    service: x509
+    conditions:
+      sourcetype: 'bro:x509:json'


### PR DESCRIPTION
Added a rule to detect Kerberos TGS requests with rc4-hmac encryption in Zeek logs.  As well as a log source config for Zeek logs in Splunk.

rules/network/zeek_susp_kerberos_rc4.yml
tools/config/splunk-zeek.yml