### PR TITLE
fix false positive on taskkill.exe not related to service stop at all

### DIFF
--- a/rules/windows/process_creation/win_service_stop.yml
+++ b/rules/windows/process_creation/win_service_stop.yml
@@ -13,7 +13,6 @@ logsource:
     product: windows
 detection:
     selection:
-      - Image|endswith: '\taskkill.exe'
       - Image|endswith:
             - '\sc.exe'
             - '\net.exe'


### PR DESCRIPTION
rule `win_service_stop `is about services being stopped
taskkill, on the other hand, can be called in a lot of contexts and generate a lot of false positives