### PR TITLE
Rule: restore initial behaviour matching single word with spaces on each side

### DIFF
--- a/rules/windows/process_creation/win_susp_eventlog_clear.yml
+++ b/rules/windows/process_creation/win_susp_eventlog_clear.yml
@@ -20,19 +20,19 @@ detection:
         Image|endswith: '\wevtutil.exe'
     selection_wevtutil_command:
         CommandLine|contains:  
-            - 'clear-log' # clears specified log 
-            - 'cl'        # short version of 'clear-log'
-            - 'set-log'   # modifies config of specified log. could be uset to set it to a tiny size
-            - 'sl'        # short version of 'set-log'
+            - ' clear-log ' # clears specified log
+            - ' cl '        # short version of 'clear-log'
+            - ' set-log '   # modifies config of specified log. could be uset to set it to a tiny size
+            - ' sl '        # short version of 'set-log'
     selection_other_ps:
         Image|endswith: '\powershell.exe'
         CommandLine|contains: 
-            - 'Clear-EventLog'
-            - 'Remove-EventLog'
-            - 'Limit-EventLog'
+            - ' Clear-EventLog '
+            - ' Remove-EventLog '
+            - ' Limit-EventLog '
     selection_other_wmic:
         Image|endswith: '\wmic.exe'
-        CommandLine|contains: 'ClearEventLog'
+        CommandLine|contains: ' ClearEventLog '
     condition: 1 of selection_other_* or (selection_wevtutil_binary and selection_wevtutil_command)
 falsepositives:
     - Admin activity

--- a/rules/windows/process_creation/win_susp_fsutil_usage.yml
+++ b/rules/windows/process_creation/win_susp_fsutil_usage.yml
@@ -22,8 +22,8 @@ detection:
         OriginalFileName: 'fsutil.exe'
     selection:
         CommandLine|contains: 
-            - 'deletejournal'  # usn deletejournal ==> generally ransomware or attacker
-            - 'createjournal'  # usn createjournal ==> can modify config to set it to a tiny size
+            - ' deletejournal '  # usn deletejournal ==> generally ransomware or attacker
+            - ' createjournal '  # usn createjournal ==> can modify config to set it to a tiny size
     condition: (1 of binary_*) and selection
 falsepositives:
     - Admin activity


### PR DESCRIPTION
rule was initially `'* cl *'`
with the current  status, it matches on `'*cl*'` (without space around cl)
restore it to its original behaviour

here's a false positive that matched the wrong rule as there is 'cl' in ClickToRun :
`wevtutil.exe im "C:\ProgramData\Microsoft\ClickToRun\....`

More generally, there seem to be quite some rules that got rewritten with `"|contains" ` and just the pattern` 'XX'` in quotes whereas it initially was `'* XX *'` with spaces
The "new" rules will, IMHO, generate a lot more false positives and would need to be patched accordingly