### PR TITLE
wmiprvse subprocess: add fallback check on username instead of only l…

### DIFF
--- a/rules/windows/process_creation/win_wmiprvse_spawning_process.yml
+++ b/rules/windows/process_creation/win_wmiprvse_spawning_process.yml
@@ -17,7 +17,8 @@ detection:
     selection:
         ParentImage|endswith: '\WmiPrvSe.exe'
     filter:
-        LogonId: '0x3e7'
+        - LogonId: '0x3e7'  # LUID 999 for SYSTEM
+        - Username: 'NT AUTHORITY\SYSTEM'  # if we don't have LogonId data, fallback on username detection
     condition: selection and not filter
 falsepositives:
     - Unknown


### PR DESCRIPTION
…ogonid

if we don't have logonid data in the log, fallback on using username