### PR TITLE
CVE 2020-0688 Exploit attempt rule

### DIFF
--- a/rules/web/web_exchange_cve_2020_0688_exploit.yml
+++ b/rules/web/web_exchange_cve_2020_0688_exploit.yml
@@ -1,0 +1,22 @@
+title: CVE-2020-0688 Exploitation attempt
+id: 7c64e577-d72e-4c3d-9d75-8de6d1f9146a
+status: experimental
+description: Detects CVE-2020-0688 Exploitation attempts
+references:
+  - https://github.com/Ridter/cve-2020-0688
+author: NVISO
+date: 2020/02/27
+tags:
+  - attack.t1210
+logsource:
+  category: webserver
+detection:
+  selection:
+    c-uri-path|contains|all:
+      - "/ecp/default.aspx"
+      - "__VIEWSTATEGENERATOR="
+      - "__VIEWSTATE="
+  condition: selection
+falsepositives:
+  - Unknown
+level: high

--- a/rules/web/web_exchange_cve_2020_0688_exploit.yml
+++ b/rules/web/web_exchange_cve_2020_0688_exploit.yml
@@ -1,4 +1,4 @@
-title: CVE-2020-0688 Exploitation attempt
+title: CVE-2020-0688 Exploitation Attempt
 id: 7c64e577-d72e-4c3d-9d75-8de6d1f9146a
 status: experimental
 description: Detects CVE-2020-0688 Exploitation attempts

--- a/rules/web/web_exchange_cve_2020_0688_exploit.yml
+++ b/rules/web/web_exchange_cve_2020_0688_exploit.yml
@@ -12,7 +12,7 @@ logsource:
   category: webserver
 detection:
   selection:
-    c-uri-path|contains|all:
+    c-uri|contains|all:
       - "/ecp/default.aspx"
       - "__VIEWSTATEGENERATOR="
       - "__VIEWSTATE="


### PR DESCRIPTION
New rule to detect exploitation of [CVE 2020-0688](https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2020-0688), based on the PoC at https://github.com/Ridter/cve-2020-0688