### PR TITLE
use c-uri instead of c-uri-path

### DIFF
--- a/rules/web/web_citrix_cve_2019_19781_exploit.yml
+++ b/rules/web/web_citrix_cve_2019_19781_exploit.yml
@@ -10,13 +10,13 @@ references:
 author: Arnim Rupp, Florian Roth
 status: experimental
 date: 2020/01/02
-modified: 2020/01/15
+modified: 2020/02/27
 logsource:
     category: webserver
     description: 'Make sure that your Netscaler appliance logs all kinds of attacks (test with http://your-citrix-gw.net/robots.txt). The directory traversal with ../ might not be needed on certain cloud instances or for authenticated users, so we also check for direct paths. All scripts in portal/scripts are exploitable except logout.pl.'
 detection:
     selection:
-        c-uri-path: 
+        c-uri:
             - '*/../vpns/*'
             - '*/vpns/cfg/smb.conf'
             - '*/vpns/portal/scripts/*.pl*'

--- a/rules/web/web_cve_2018_2894_weblogic_exploit.yml
+++ b/rules/web/web_cve_2018_2894_weblogic_exploit.yml
@@ -3,6 +3,7 @@ id: 37e8369b-43bb-4bf8-83b6-6dd43bda2000
 description: Detects access to a webshell droped into a keytore folder on the WebLogic server
 author: Florian Roth
 date: 2018/07/22
+modified: 2020/02/27
 status: experimental
 references:
     - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-2894
@@ -12,7 +13,7 @@ logsource:
     category: webserver
 detection:
     selection:
-        c-uri-path: 
+        c-uri:
             - '*/config/keystore/*.js*'
     condition: selection
 fields:

--- a/rules/web/web_pulsesecure_cve-2019-11510.yml
+++ b/rules/web/web_pulsesecure_cve-2019-11510.yml
@@ -5,11 +5,12 @@ references:
     - https://www.exploit-db.com/exploits/47297
 author: Florian Roth
 date: 2019/11/18
+modified: 2020/02/27
 logsource:
     category: webserver
 detection:
     selection:
-        c-uri-path: '*?/dana/html5acc/guacamole/*'
+        c-uri: '*?/dana/html5acc/guacamole/*'
     condition: selection
 fields:
     - client_ip


### PR DESCRIPTION
update URI/URL rules to use `c-uri` instead of `c-uri-path`. a) `c-uri-path` has no sigmac's and b) is a bit more ambiguous and c) will allow new network data sources (zeek/corelight and suricata) consistent compatibility