### PR TITLE
fix sysmon registry rules with HKLM/HKU format as used since 02/2017 in sysmon

### DIFF
--- a/rules/windows/process_creation/win_mal_adwind.yml
+++ b/rules/windows/process_creation/win_mal_adwind.yml
@@ -41,5 +41,5 @@ logsource:
 detection:
     selection:
         EventID: 13
-        TargetObject: \REGISTRY\MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Run*
+        TargetObject: HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Run*
         Details: '%AppData%\Roaming\Oracle\bin\\*'

--- a/rules/windows/sysmon/sysmon_apt_pandemic.yml
+++ b/rules/windows/sysmon/sysmon_apt_pandemic.yml
@@ -31,9 +31,7 @@ detection:
     selection1:
         EventID: 13
         TargetObject:
-            - '\REGISTRY\MACHINE\SYSTEM\CurrentControlSet\services\null\Instance*'
-            - '\REGISTRY\MACHINE\SYSTEM\ControlSet001\services\null\Instance*'
-            - '\REGISTRY\MACHINE\SYSTEM\ControlSet002\services\null\Instance*'
+            - 'HKLM\SYSTEM\CurrentControlSet\services\null\Instance*'
 ---
 logsource:
     category: process_creation

--- a/rules/windows/sysmon/sysmon_uac_bypass_eventvwr.yml
+++ b/rules/windows/sysmon/sysmon_uac_bypass_eventvwr.yml
@@ -13,7 +13,7 @@ logsource:
 detection:
     methregistry:
         EventID: 13
-        TargetObject: 'HKEY_USERS\\*\mscfile\shell\open\command'
+        TargetObject: 'HKU\\*\mscfile\shell\open\command'
     methprocess:
         EventID: 1 # Migration to process_creation requires multipart YAML
         ParentImage: '*\eventvwr.exe'

--- a/rules/windows/sysmon/sysmon_uac_bypass_sdclt.yml
+++ b/rules/windows/sysmon/sysmon_uac_bypass_sdclt.yml
@@ -12,7 +12,7 @@ logsource:
 detection:
     selection:
         EventID: 13
-        TargetObject: 'HKEY_USERS\\*\Classes\exefile\shell\runas\command\isolatedCommand'
+        TargetObject: 'HKU\\*\Classes\exefile\shell\runas\command\isolatedCommand'
     condition: selection
 tags:
     - attack.defense_evasion


### PR DESCRIPTION
(see sysmon changelog  here : https://github.com/Neo23x0/sysmon-version-history#v60
```
Release date: 17.02.2017
...
interprets and displays registry paths in their common format
...
```

https://github.com/SwiftOnSecurity/sysmon-config/blob/master/sysmonconfig-export.xml#L547
`Schema version 3.30 and higher change HKLM\="\REGISTRY\MACHINE\" and HKU\="\REGISTRY\USER\" and HKCR\="\REGISTRY\MACHINE\SOFTWARE\Classes\" and CurrentControlSet="ControlSet001"-->`