### PR TITLE
sysmon registry events fix

### DIFF
--- a/rules/windows/sysmon/sysmon_apt_oceanlotus_registry.yml
+++ b/rules/windows/sysmon/sysmon_apt_oceanlotus_registry.yml
@@ -15,13 +15,21 @@ detection:
     selection:
         EventID: 13
         TargetObject: 
-            - '*\SOFTWARE\Classes\CLSID\{E08A0F4B-1F65-4D4D-9A09-BD4625B9C5A1}\Model' 
+            - 'HKCR\CLSID\{E08A0F4B-1F65-4D4D-9A09-BD4625B9C5A1}\Model'
+            - 'HKU\\*_Classes\CLSID\{E08A0F4B-1F65-4D4D-9A09-BD4625B9C5A1}\Model'
+              # covers HKU\* and HKLM..
             - '*\SOFTWARE\App\AppXbf13d4ea2945444d8b13e2121cb6b663\Application'
             - '*\SOFTWARE\App\AppXbf13d4ea2945444d8b13e2121cb6b663\DefaultIcon'
             - '*\SOFTWARE\App\AppX70162486c7554f7f80f481985d67586d\Application'
             - '*\SOFTWARE\App\AppX70162486c7554f7f80f481985d67586d\DefaultIcon'
             - '*\SOFTWARE\App\AppX37cc7fdccd644b4f85f4b22d5a3f105a\Application'
             - '*\SOFTWARE\App\AppX37cc7fdccd644b4f85f4b22d5a3f105a\DefaultIcon'
+            # HKCU\SOFTWARE\Classes\AppXc52346ec40fb4061ad96be0e6cb7d16a\
+            - 'HKU\\*_Classes\AppXc52346ec40fb4061ad96be0e6cb7d16a\\*'
+            # HKCU\SOFTWARE\Classes\AppX3bbba44c6cae4d9695755183472171e2\
+            - 'HKU\\*_Classes\AppX3bbba44c6cae4d9695755183472171e2\\*'
+            # HKCU\SOFTWARE\Classes\CLSID\{E3517E26-8E93-458D-A6DF-8030BC80528B}\
+            - 'HKU\\*_Classes\CLSID\{E3517E26-8E93-458D-A6DF-8030BC80528B}\\*'
     condition: selection
 falsepositives:
     - Unknown

--- a/rules/windows/sysmon/sysmon_disable_security_events_logging_adding_reg_key_minint.yml
+++ b/rules/windows/sysmon/sysmon_disable_security_events_logging_adding_reg_key_minint.yml
@@ -16,11 +16,10 @@ logsource:
 detection:
     selection:
       - EventID: 12 # key create
-        TargetObject|contains: '\SYSTEM\'
-        TargetObject|endswith: '\Control\MiniNt'
+        # Sysmon gives us HKLM\SYSTEM\CurrentControlSet\.. if ControlSetXX is the selected one
+        TargetObject: 'HKLM\SYSTEM\CurrentControlSet\Control\MiniNt'
       - EventID: 14  # key rename
-        NewName|contains: '\SYSTEM\'
-        NewName|endswith: '\Control\MiniNt'
+        NewName: 'HKLM\SYSTEM\CurrentControlSet\Control\MiniNt'
     condition: selection
 fields:
     - EventID

--- a/rules/windows/sysmon/sysmon_new_dll_added_to_appcertdlls_registry_key.yml
+++ b/rules/windows/sysmon/sysmon_new_dll_added_to_appcertdlls_registry_key.yml
@@ -20,11 +20,10 @@ detection:
       - EventID: 
             - 12  # key create
             - 13  # value set
-        TargetObject|contains: '\SYSTEM\'
-        TargetObject|endswith: '\Control\Session Manager\AppCertDlls'
+        # Sysmon gives us HKLM\SYSTEM\CurrentControlSet\.. if ControlSetXX is the selected one
+        TargetObject: 'HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\AppCertDlls'
       - EventID: 14  # key rename
-        NewName|contains: '\SYSTEM\'
-        NewName|endswith: '\Control\Session Manager\AppCertDlls'
+        NewName: 'HKLM\SYSTEM\CurentControlSet\Control\Session Manager\AppCertDlls'
     condition: selection
 fields:
     - EventID

--- a/rules/windows/sysmon/sysmon_new_dll_added_to_appinit_dlls_registry_key.yml
+++ b/rules/windows/sysmon/sysmon_new_dll_added_to_appinit_dlls_registry_key.yml
@@ -19,11 +19,13 @@ detection:
       - EventID: 
             - 12 # key create
             - 13 # value set
-        TargetObject|contains: '\SOFTWARE\'
-        TargetObject|endswith: '\Windows\AppInit_Dlls'
+        TargetObject:
+                - '*\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Windows\AppInit_Dlls'
+                - '*\SOFTWARE\Wow6432Node\Microsoft\Windows NT\CurrentVersion\Windows\AppInit_Dlls'
       - EventID: 14 # key rename
-        NewName|contains: '\SOFTWARE\'
-        NewName|endswith: '\Windows\AppInit_Dlls'
+        NewName:
+                - '*\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Windows\AppInit_Dlls'
+                - '*\SOFTWARE\Wow6432Node\Microsoft\Windows NT\CurrentVersion\Windows\AppInit_Dlls'
     condition: selection
 fields:
     - EventID

--- a/rules/windows/sysmon/sysmon_registry_persistence_key_linking.yml
+++ b/rules/windows/sysmon/sysmon_registry_persistence_key_linking.yml
@@ -16,9 +16,7 @@ logsource:
 detection:
     selection:
         EventID: 12
-        TargetObject|startswith: 'HKU\'
-        TargetObject|contains: '_Classes\CLSID\'
-        TargetObject|endswith: '\TreatAs'
+        TargetObject: 'HKU\\*_Classes\CLSID\\*\TreatAs'
     condition: selection
 falsepositives:
     - Maybe some system utilities in rare cases use linking keys for backward compability

--- a/rules/windows/sysmon/sysmon_susp_reg_persist_explorer_run.yml
+++ b/rules/windows/sysmon/sysmon_susp_reg_persist_explorer_run.yml
@@ -1,7 +1,7 @@
 title: Registry Persistence via Explorer Run Key
 id: b7916c2a-fa2f-4795-9477-32b731f70f11
 status: experimental
-description: Detects a possible persistence mechanism using RUN key for Windows Explorer and poiting to a suspicious folder
+description: Detects a possible persistence mechanism using RUN key for Windows Explorer and pointing to a suspicious folder
 author: Florian Roth
 date: 2018/07/18
 references:

--- a/rules/windows/sysmon/sysmon_suspicious_keyboard_layout_load.yml
+++ b/rules/windows/sysmon/sysmon_suspicious_keyboard_layout_load.yml
@@ -18,7 +18,7 @@ detection:
         TargetObject: 
             - '*\Keyboard Layout\Preload\*'
             - '*\Keyboard Layout\Substitutes\*'
-        Details: 
+        Details|contains:
             - 00000429  # Persian (Iran)
             - 00050429  # Persian (Iran)
             - 0000042a  # Vietnamese

--- a/rules/windows/sysmon/sysmon_uac_bypass_sdclt.yml
+++ b/rules/windows/sysmon/sysmon_uac_bypass_sdclt.yml
@@ -12,7 +12,8 @@ logsource:
 detection:
     selection:
         EventID: 13
-        TargetObject: 'HKU\\*\Classes\exefile\shell\runas\command\isolatedCommand'
+        # usrclass.dat is mounted on HKU\USERSID_Classes\...
+        TargetObject: 'HKU\\*_Classes\exefile\shell\runas\command\isolatedCommand'
     condition: selection
 tags:
     - attack.defense_evasion


### PR DESCRIPTION
- fix some rules with data as received by Sysmon and not it appears in hives or reports
- performance fix (patch rules with `startswith` `contains` and `endswith` with only 1 check, might have better performance in backend SIEMs)