### PR TITLE
Updates sigmac and rules

### DIFF
--- a/rules/web/web_citrix_cve_2019_19781_exploit.yml
+++ b/rules/web/web_citrix_cve_2019_19781_exploit.yml
@@ -10,13 +10,13 @@ references:
 author: Arnim Rupp, Florian Roth
 status: experimental
 date: 2020/01/02
-modified: 2020/01/15
+modified: 2020/03/14
 logsource:
     category: webserver
     description: 'Make sure that your Netscaler appliance logs all kinds of attacks (test with http://your-citrix-gw.net/robots.txt). The directory traversal with ../ might not be needed on certain cloud instances or for authenticated users, so we also check for direct paths. All scripts in portal/scripts are exploitable except logout.pl.'
 detection:
     selection:
-        c-uri-path: 
+        c-uri: 
             - '*/../vpns/*'
             - '*/vpns/cfg/smb.conf'
             - '*/vpns/portal/scripts/*.pl*'

--- a/rules/web/web_cve_2018_2894_weblogic_exploit.yml
+++ b/rules/web/web_cve_2018_2894_weblogic_exploit.yml
@@ -3,6 +3,7 @@ id: 37e8369b-43bb-4bf8-83b6-6dd43bda2000
 description: Detects access to a webshell dropped into a keystore folder on the WebLogic server
 author: Florian Roth
 date: 2018/07/22
+modified: 2020/03/14
 status: experimental
 references:
     - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-2894
@@ -12,7 +13,7 @@ logsource:
     category: webserver
 detection:
     selection:
-        c-uri-path: 
+        c-uri: 
             - '*/config/keystore/*.js*'
     condition: selection
 fields:

--- a/rules/web/web_cve_2018_2894_weblogic_exploit.yml
+++ b/rules/web/web_cve_2018_2894_weblogic_exploit.yml
@@ -1,6 +1,6 @@
 title: Oracle WebLogic Exploit
 id: 37e8369b-43bb-4bf8-83b6-6dd43bda2000
-description: Detects access to a webshell droped into a keytore folder on the WebLogic server
+description: Detects access to a webshell dropped into a keystore folder on the WebLogic server
 author: Florian Roth
 date: 2018/07/22
 status: experimental

--- a/rules/web/web_multiple_suspicious_resp_codes_single_source.yml
+++ b/rules/web/web_multiple_suspicious_resp_codes_single_source.yml
@@ -3,11 +3,12 @@ id: 6fdfc796-06b3-46e8-af08-58f3505318af
 description: Detects possible exploitation activity or bugs in a web application
 author: Thomas Patzke
 date: 2017/02/19
+modified: 2020/03/14
 logsource:
     category: webserver
 detection:
     selection:
-        response:
+        sc-status:
           - 400
           - 401
           - 403

--- a/rules/web/web_pulsesecure_cve-2019-11510.yml
+++ b/rules/web/web_pulsesecure_cve-2019-11510.yml
@@ -5,11 +5,12 @@ references:
     - https://www.exploit-db.com/exploits/47297
 author: Florian Roth
 date: 2019/11/18
+modified: 2020/03/14
 logsource:
     category: webserver
 detection:
     selection:
-        c-uri-path: '*?/dana/html5acc/guacamole/*'
+        c-uri: '*?/dana/html5acc/guacamole/*'
     condition: selection
 fields:
     - client_ip

--- a/rules/windows/builtin/win_rare_schtasks_creations.yml
+++ b/rules/windows/builtin/win_rare_schtasks_creations.yml
@@ -1,7 +1,6 @@
 title: Rare Schtasks Creations
 id: b0d77106-7bb0-41fe-bd94-d1752164d066
-description: Detects rare scheduled tasks creations that only appear a few times per time frame and could reveal password dumpers, backdoor installs or other types
-    of malicious code
+description: Detects rare scheduled tasks creations that only appear a few times per time frame and could reveal password dumpers, backdoor installs or other types of malicious code
 status: experimental
 author: Florian Roth
 date: 2017/03/23

--- a/rules/windows/builtin/win_rare_service_installs.yml
+++ b/rules/windows/builtin/win_rare_service_installs.yml
@@ -1,7 +1,6 @@
 title: Rare Service Installs
 id: 66bfef30-22a5-4fcd-ad44-8d81e60922ae
-description: Detects rare service installs that only appear a few times per time frame and could reveal password dumpers, backdoor installs or other types of malicious
-    services
+description: Detects rare service installs that only appear a few times per time frame and could reveal password dumpers, backdoor installs or other types of malicious services
 status: experimental
 author: Florian Roth
 date: 2017/03/08

--- a/rules/windows/process_creation/win_susp_cli_escape.yml
+++ b/rules/windows/process_creation/win_susp_cli_escape.yml
@@ -10,6 +10,7 @@ references:
     - http://www.windowsinspired.com/understanding-the-command-line-string-and-arguments-received-by-a-windows-program/
 author: juju4
 date: 2018/12/11
+modified: 2020/03/14
 tags:
     - attack.defense_evasion
     - attack.t1140
@@ -20,8 +21,8 @@ detection:
     selection:
         CommandLine:
             # - <TAB>   # no TAB modifier in sigmac yet, so this matches <TAB> (or TAB in elasticsearch backends without DSL queries)
-            - ^h^t^t^p
-            - h"t"t"p
+            - '*h^t^t^p*'
+            - '*h"t"t"p*'
     condition: selection
 falsepositives:
     - False positives depend on scripts and administrative tools used in the monitored environment

--- a/tools/config/ecs-proxy.yml
+++ b/tools/config/ecs-proxy.yml
@@ -18,8 +18,12 @@ fieldmappings:
   c-uri-query: url.query
   c-uri-stem: url.original
   c-useragent: user_agent.original
+  cs-bytes: http.request.body.bytes
   cs-cookie: http.cookie
   cs-host: url.domain
   cs-method: http.request.method
+  cs-referrer: http.request.referrer
+  cs-version: http.version
   r-dns: url.domain
   sc-status: http.response.status_code
+  sc-bytes: http.response.body.bytes


### PR DESCRIPTION
- `ecs-proxy.yml` SIGMAC additions to match taxonomy
- fix spelling and typo in description
- better coverage and fixed character that would cause rule to not fire for `rules/windows/process_creation/win_susp_cli_escape.yml` 
- update 4 web rules to use `c-uri` instead of `c-uri-path` which a) taxonomy states to use and b) majority of rules are using `c-uri`
- http server response code to use taxonomy of `sc-status`