### PR TITLE
es-rule backend options for index-patterns and time interval

### DIFF
--- a/tools/sigma/backends/elasticsearch.py
+++ b/tools/sigma/backends/elasticsearch.py
@@ -997,6 +997,10 @@ class ElastalertBackendQs(ElastalertBackend, ElasticsearchQuerystringBackend):
 class ElasticSearchRuleBackend(ElasticsearchQuerystringBackend):
     identifier = "es-rule"
     active = True
+    options = ElasticsearchQuerystringBackend.options + (
+            ("index_patterns", "apm-*-transaction,auditbeat-*,endgame-*,filebeat-*,packetbeat-*,winlogbeat-*", "Rule execution index patterns", "index_patterns"),
+            ("execution_interval", "5m", "Rule execution interval", "interval"),
+            )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -1106,15 +1110,8 @@ class ElasticSearchRuleBackend(ElasticsearchQuerystringBackend):
             "filters": [],
             "from": "now-360s",
             "immutable": False,
-            "index": [
-                "apm-*-transaction*",
-                "auditbeat-*",
-                "endgame-*",
-                "filebeat-*",
-                "packetbeat-*",
-                "winlogbeat-*"
-            ],
-            "interval": "5m",
+            "index": self.index_patterns.split(','),
+            "interval": self.interval,
             "rule_id": rule_id,
             "language": "lucene",
             "output_index": ".siem-signals-default",


### PR DESCRIPTION
Hi, 

I added two custom backend-options for es-rule backend. 

`index_patterns` allows you to specify on which patterns should the rule be executed. 

The reason behind this is that executing the rule on unnecessary indices may cause significant search overhead. Also some people have multi-tenant clusters and this will allow them to generate sigma rules for different Kibana spaces with different SIEM patterns (although that may require to add also output index option). Original values are moved to default settings for the options.

`execution_interval` allows you to simply change the execution interval of the rule.

Example input (backend-config.yml):
```
index_patterns: "winlogbeat-*,auditbeat-*"
execution_interval: "10m
```

Example output:
```
./sigmac --target es-rule --config ./config/winlogbeat-modules-enabled.yml  --backend-config ./config/backend_config.yml ../rules/windows/sysmon/sysmon_cactustorch.yml
 
{"description": "Detects remote thread creation from CACTUSTORCH as described in references.", "enabled": true, "false_positives": ["unknown"], "filters": [], "from": "now-360s", "immutable": false, "index": ["winlogbeat-*", "auditbeat-*"], "interval": "10m", "rule_id": "cactustorch_remote_thread_creation", "language": "lucene", "output_index": ".siem-signals-default", "max_signals": 100, "risk_score": 48, "name": "CACTUSTORCH Remote Thread Creation", "query": "(winlog.channel:\"Microsoft\\-Windows\\-Sysmon\\/Operational\" AND winlog.event_id:\"8\" AND process.executable.keyword:(*\\\\System32\\\\cscript.exe OR *\\\\System32\\\\wscript.exe OR *\\\\System32\\\\mshta.exe OR *\\\\winword.exe OR *\\\\excel.exe) AND winlog.event_data.TargetImage.keyword:*\\\\SysWOW64\\\\* AND NOT _exists_:winlog.event_data.StartModule)", "references": ["https://twitter.com/SBousseaden/status/1090588499517079552", "https://github.com/mdsecactivebreach/CACTUSTORCH"], "meta": {"from": "1m"}, "severity": "high", "tags": ["attack.execution", "attack.t1055", "attack.t1064"], "to": "now", "type": "query", "threat": [{"tactic": {"id": "TA0002", "reference": "https://attack.mitre.org/tactics/TA0002", "name": "Execution"}, "framework": "MITRE ATT&CK", "technique": [{"id": "T1064", "name": "Scripting", "reference": "https://attack.mitre.org/techniques/T1064"}]}], "version": 1}
```