### PR TITLE
Add "Suspicious desktop.ini Action" rule

### DIFF
--- a/rules/windows/sysmon/sysmon_susp_desktop_ini.yml
+++ b/rules/windows/sysmon/sysmon_susp_desktop_ini.yml
@@ -23,5 +23,5 @@ detection:
         TargetFilename|endswith: '\desktop.ini'
     condition: selection and not filter
 falsepositives:
-  - Operations performed through Windows SCCM or equivalent
+    - Operations performed through Windows SCCM or equivalent
 level: medium

--- a/rules/windows/sysmon/sysmon_susp_desktop_ini.yml
+++ b/rules/windows/sysmon/sysmon_susp_desktop_ini.yml
@@ -1,0 +1,27 @@
+title: Suspicious desktop.ini Action
+id: 81315b50-6b60-4d8f-9928-3466e1022515
+status: experimental
+description: Detects unusual processes accessing desktop.ini, which can be leveraged to alter how Explorer displays a folder's content (i.e. renaming files) without changing them on disk.
+references:
+    - https://isc.sans.edu/forums/diary/Desktopini+as+a+postexploitation+tool/25912/
+author: Maxime Thiebaut (@0xThiebaut)
+date: 2020/03/19
+tags:
+    - attack.persistence
+    - attack.t1023
+logsource:
+    product: windows
+    service: sysmon
+detection:
+    filter:
+        Image:
+            - 'C:\Windows\explorer.exe'
+            - 'C:\Windows\System32\msiexec.exe'
+            - 'C:\Windows\System32\mmc.exe'
+    selection:
+        EventID: 11
+        TargetFilename|endswith: '\desktop.ini'
+    condition: selection and not filter
+falsepositives:
+  - Operations performed through Windows SCCM or equivalent
+level: medium


### PR DESCRIPTION
Detects unusual processes accessing `desktop.ini`, which can be leveraged to alter how Explorer displays a folder's content (i.e. renaming files) without changing them on disk.

Reference: https://isc.sans.edu/forums/diary/Desktopini+as+a+postexploitation+tool/25912/