### PR TITLE
Minor fixes to several rules

### DIFF
--- a/rules/windows/builtin/win_susp_dhcp_config.yml
+++ b/rules/windows/builtin/win_susp_dhcp_config.yml
@@ -17,6 +17,7 @@ logsource:
 detection:
     selection:
         EventID: 1033
+        Source: Microsoft-Windows-DHCP-Server
     condition: selection
 falsepositives: 
     - Unknown

--- a/rules/windows/process_creation/win_etw_trace_evasion.yml
+++ b/rules/windows/process_creation/win_etw_trace_evasion.yml
@@ -1,6 +1,7 @@
 title: Disable of ETW Trace
 id: a238b5d0-ce2d-4414-a676-7a531b3d13d6
 description: Detects a command that clears or disables any ETW trace log which could indicate a logging evasion.
+status: experimental
 references:
     - https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/wevtutil
     - https://github.com/Neo23x0/sigma/blob/master/rules/windows/process_creation/win_mal_lockergoga.yml
@@ -25,3 +26,5 @@ detection:
     selection_disable_2:
         CommandLine: '* set-log* /e:false*'
     condition: selection_clear_1 or selection_clear_2 or selection_disable_1 or selection_disable_2
+falsepositives:
+    - Unknown

--- a/rules/windows/process_creation/win_powershell_amsi_bypass.yml
+++ b/rules/windows/process_creation/win_powershell_amsi_bypass.yml
@@ -22,6 +22,6 @@ detection:
         CommandLine:
             - '*amsiInitFailed*'
     condition: selection1 and selection2
-    falsepositives:
-        - Potential Admin Activity
+falsepositives:
+    - Potential Admin Activity
 level: high

--- a/rules/windows/process_creation/win_sysmon_driver_unload.yml
+++ b/rules/windows/process_creation/win_sysmon_driver_unload.yml
@@ -17,7 +17,8 @@ detection:
             - 'unload'
             - 'sys'
     condition: selection
-falsepositives: Unknown
+falsepositives: 
+    - Unknown
 level: high
 fields:
     - CommandLine

--- a/rules/windows/process_creation/win_system_exe_anomaly.yml
+++ b/rules/windows/process_creation/win_system_exe_anomaly.yml
@@ -29,10 +29,11 @@ detection:
             - '*\lsm.exe'
             - '*\winlogon.exe'
             - '*\explorer.exe'
-            - '*\taskhost.exe' 
+            - '*\taskhost.exe'
     filter:
         Image:
             - 'C:\Windows\System32\\*'
+            - 'C:\Windows\system32\\*'
             - 'C:\Windows\SysWow64\\*'
             - 'C:\Windows\SysWOW64\\*'
             - 'C:\Windows\explorer.exe'

--- a/rules/windows/sysmon/sysmon_wmi_module_load.yml
+++ b/rules/windows/sysmon/sysmon_wmi_module_load.yml
@@ -29,6 +29,7 @@ detection:
     filter:
         Image|endswith:
             - '\WmiPrvSe.exe'
+            - '\WmiPrvSE.exe'
             - '\WmiAPsrv.exe'
             - '\svchost.exe'
     condition: selection and not filter


### PR DESCRIPTION
- rules/windows/sysmon/sysmon_wmi_module_load.yml
  Added WmiPrvSE.exe to detection as the different casing was causing false positives
- rules/windows/process_creation/win_system_exe_anomaly.yml
  Added "C:\Windows\system32" (lowercase system32) to detection as it was causing false positives
  removed trailing whitesapce 
- rules/windows/builtin/win_susp_dhcp_config.yml
  Added missing source Microsoft-Windows-DHCP-Server to detection (similar to rules/windows/builtin/win_susp_dhcp_config_failed.yml)
  The change was done based on studying the reference in the rule and triggering false positive with Event ID 1033 from Microsoft-Windows-Security-SPP
- rules/windows/process_creation/win_etw_trace_evasion.yml
  Added missing status (set to experimental), added falsepositives
- rules/windows/process_creation/win_powershell_amsi_bypass.yml
  Fixed wrong indentation for falsepositives
- rules/windows/process_creation/win_sysmon_driver_unload.yml
  Fixed falsepositives format to array as is used in other rules