### PR TITLE
Eliminate title collision

### DIFF
--- a/rules/windows/process_creation/win_apt_bear_activity_gtr19.yml
+++ b/rules/windows/process_creation/win_apt_bear_activity_gtr19.yml
@@ -1,4 +1,4 @@
-title: Judgement Panda Exfil Activity
+title: Judgement Panda Credential Access Activity
 id: b83f5166-9237-4b5e-9cd4-7b5d52f4d8ee
 description: Detects Russian group activity as described in Global Threat Report 2019 by Crowdstrike
 references:


### PR DESCRIPTION
Fixing the problem described in HELK here: https://github.com/Cyb3rWard0g/HELK/issues/442 where when running sigmac to generate elastalert rules, this rule has a title collision with another rule in the same directory and causes elastalert to fail to start.