### PR TITLE
Add AD User Enumeration

### DIFF
--- a/rules/windows/builtin/win_ad_user_enumeration.yml
+++ b/rules/windows/builtin/win_ad_user_enumeration.yml
@@ -1,0 +1,29 @@
+title: AD User Enumeration
+id: ab6bffca-beff-4baa-af11-6733f296d57a
+description: Detects access to a domain user from a non-machine account
+status: experimental
+date: 2020/03/30
+author: Maxime Thiebaut (@0xThiebaut)
+references:
+    - https://www.specterops.io/assets/resources/an_ace_up_the_sleeve.pdf
+    - http://www.stuffithoughtiknew.com/2019/02/detecting-bloodhound.html
+    - https://docs.microsoft.com/en-us/windows/win32/adschema/attributes-all # For further investigation of the accessed properties
+tags:
+    - attack.discovery
+    - attack.t1087
+logsource:
+    product: windows
+    service: security
+    definition: Requires the "Read all properties" permission on the user object to be audited for the "Everyone" principal
+detection:
+    selection:
+        EventID: 4662
+        ObjectType|contains: # Using contains as the data commonly is structured as "%{bf967aba-0de6-11d0-a285-00aa003049e2}"
+            - 'bf967aba-0de6-11d0-a285-00aa003049e2' # The user class (https://docs.microsoft.com/en-us/windows/win32/adschema/c-user)
+    filter:
+        - SubjectUserName|endswith: '$' # Exclude machine accounts
+        - SubjectUserName|startswith: 'MSOL_' # https://docs.microsoft.com/en-us/azure/active-directory/hybrid/reference-connect-accounts-permissions#ad-ds-connector-account
+    condition: selection and not filter
+falsepositives:
+    - Administrators configuring new users.
+level: medium


### PR DESCRIPTION
When the "Read all properties" permission of a user object is set to be audited in the AD, an event of ID 4662 (An operation was performed on an object) is triggered whenever a property is accessed.

This rule detects these events by flagging any non-machine `SubjectUserName` (i.e. another user) which accesses an object of the [`User` AD schema class](https://docs.microsoft.com/en-us/windows/win32/adschema/c-user).

Advantages of this rule include the detection of insider-enumeration through automated tools such as BloodHound or manually through the usage of the PowerShell ActiveDirectory module. Although this rule qualifies as a medium severity one, this event could be qualified as high/critical one if flagged on non-used canary user-accounts.

False positives may include administrators performing the initial configuration of new users.