### PR TITLE
Fixed date typo - by the looks of the commit date the month/date were…

### DIFF
--- a/rules/windows/process_creation/win_task_folder_evasion.yml
+++ b/rules/windows/process_creation/win_task_folder_evasion.yml
@@ -5,7 +5,7 @@ description: The Tasks folder in system32 and syswow64 are globally writable pat
 references: 
     - https://twitter.com/subTee/status/1216465628946563073
     - https://gist.github.com/am0nsec/8378da08f848424e4ab0cc5b317fdd26
-date: 2020/13/01
+date: 2020/01/13
 author: Sreeman
 tags:
     - attack.t1064


### PR DESCRIPTION
… swapped.

Sorry - pedantic, but it was breaking some automation I was working on so just thought I'd fix it.