### PR TITLE
Update the NTLM downgrade registry paths

### DIFF
--- a/rules/windows/builtin/win_net_ntlm_downgrade.yml
+++ b/rules/windows/builtin/win_net_ntlm_downgrade.yml
@@ -23,8 +23,8 @@ detection:
         EventID: 13
         TargetObject: 
             - '*SYSTEM\\*ControlSet*\Control\Lsa\lmcompatibilitylevel'
-            - '*SYSTEM\\*ControlSet*\Control\Lsa\NtlmMinClientSec'
-            - '*SYSTEM\\*ControlSet*\Control\Lsa\RestrictSendingNTLMTraffic'
+            - '*SYSTEM\\*ControlSet*\Control\Lsa*\NtlmMinClientSec'
+            - '*SYSTEM\\*ControlSet*\Control\Lsa*\RestrictSendingNTLMTraffic'
 ---
 # Windows Security Eventlog: Process Creation with Full Command Line
 logsource:
@@ -34,7 +34,7 @@ logsource:
 detection:
     selection2:
         EventID: 4657
-        ObjectName: '\REGISTRY\MACHINE\SYSTEM\\*ControlSet*\Control\Lsa'
+        ObjectName: '\REGISTRY\MACHINE\SYSTEM\\*ControlSet*\Control\Lsa*'
         ObjectValueName: 
             - 'LmCompatibilityLevel'
             - 'NtlmMinClientSec'


### PR DESCRIPTION
Recent Windows versions rely on the ["MSV1_0" authentication package](https://docs.microsoft.com/en-us/windows/win32/secauthn/msv1-0-authentication-package). Tests have shown that NTLM downgrade attacks can be performed as detected by this rule although some of the registry keys are located in an `Lsa` subkey (`MSV1_0`). This commit introduces additional wildcards to handle these cases and ensure the previous ones are still included.

![Screenshot of the matched registry keys](https://user-images.githubusercontent.com/46688461/78687981-071ec880-78f5-11ea-90dc-63e99f57e9d8.png)

I have opted for wildcards as I was unsure whether the original use-case has been broken in a recent update or if it was erroneous from the start.