### PR TITLE
Update win_susp_netsh_dll_persistence.yml

### DIFF
--- a/rules/windows/process_creation/win_susp_netsh_dll_persistence.yml
+++ b/rules/windows/process_creation/win_susp_netsh_dll_persistence.yml
@@ -7,6 +7,7 @@ references:
 tags:
     - attack.persistence
     - attack.t1060
+    - attack.t1128
 date: 2019/10/25
 modified: 2019/10/25
 author: Victor Sergeev, oscd.community
@@ -26,5 +27,5 @@ fields:
     - CommandLine
     - ParentCommandLine
 falsepositives:
-    - Unkown
+    - Unknown
 level: high

--- a/rules/windows/process_creation/win_susp_netsh_dll_persistence.yml
+++ b/rules/windows/process_creation/win_susp_netsh_dll_persistence.yml
@@ -6,7 +6,6 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1060/T1060.yaml
 tags:
     - attack.persistence
-    - attack.t1060
     - attack.t1128
 date: 2019/10/25
 modified: 2019/10/25

--- a/rules/windows/process_creation/win_susp_netsh_dll_persistence.yml
+++ b/rules/windows/process_creation/win_susp_netsh_dll_persistence.yml
@@ -3,7 +3,7 @@ id: 56321594-9087-49d9-bf10-524fe8479452
 description: Detects persitence via netsh helper
 status: test
 references:
-    - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1060/T1060.yaml
+    - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1128/T1128.md
 tags:
     - attack.persistence
     - attack.t1128


### PR DESCRIPTION
Fix typo and update to include proper MITRE technique [T1128](https://attack.mitre.org/techniques/T1128/)