### PR TITLE
Add Windows Registry Persistence COM Search Order Hijacking

### DIFF
--- a/rules/windows/sysmon/sysmon_registry_persistence_search_order.yml
+++ b/rules/windows/sysmon/sysmon_registry_persistence_search_order.yml
@@ -1,0 +1,29 @@
+title: Windows Registry Persistence COM Search Order Hijacking
+id: a0ff33d8-79e4-4cef-b4f3-9dc4133ccd12
+status: experimental
+description: Detects potential COM object hijacking leveraging the COM Search Order
+references:
+    - https://www.cyberbit.com/blog/endpoint-security/com-hijacking-windows-overlooked-security-vulnerability/
+author: Maxime Thiebaut (@0xThiebaut)
+date: 2020/04/14
+tags:
+    - attack.persistence
+    - attack.t1038
+logsource:
+    product: windows
+    service: sysmon
+detection:
+    selection: # Detect new COM servers in the user hive
+        EventID: 13
+        TargetObject: 'HKU\\*_Classes\CLSID\\*\InProcServer32\(Default)'
+    filter:
+        Details: # Exclude privileged directories and observed FPs
+            - '%%systemroot%%\system32\\*'
+            - '%%systemroot%%\SysWow64\\*'
+            - '*\AppData\Local\Microsoft\OneDrive\\*\FileCoAuthLib64.dll'
+            - '*\AppData\Local\Microsoft\OneDrive\\*\FileSyncShell64.dll'
+            - '*\AppData\Local\Microsoft\TeamsMeetingAddin\\*\Microsoft.Teams.AddinLoader.dll'
+    condition: selection and not filter
+falsepositives:
+    - Some installed utilities (i.e. OneDrive) may serve new COM objects at user-level
+level: medium


### PR DESCRIPTION
This rule detects new user hive COM servers whose targets are in a user-writable folder. Matches highlight possible traces of COM object hijacking leveraging the COM Search Order where user-defined settings supersede system-wide settings.

> User-specific COM objects can be registered by any process at medium integrity level and are only visible to the user that installs them. However, they take precedence over machine-wide objects in the COM subsystem. COM object hijacking is a technique in which malicious software can replace a benign system-wide COM object with a malicious user-specific object that gets loaded in its place.
>
> Source: [cyberbit.com](https://www.cyberbit.com/blog/endpoint-security/com-hijacking-windows-overlooked-security-vulnerability/)

![Malicious COM Servers](https://user-images.githubusercontent.com/46688461/79217963-f7046d00-7e4f-11ea-8be2-ad377d60cd18.png)
