### PR TITLE
Add netsh to renamed binary rule

### DIFF
--- a/rules/windows/process_creation/win_renamed_binary.yml
+++ b/rules/windows/process_creation/win_renamed_binary.yml
@@ -2,7 +2,7 @@ title: Renamed Binary
 id: 36480ae1-a1cb-4eaa-a0d6-29801d7e9142
 status: experimental
 description: Detects the execution of a renamed binary often used by attackers or malware leveraging new Sysmon OriginalFileName datapoint.
-author: Matthew Green - @mgreen27, Ecco, James Pemberton / @4A616D6573, oscd.community (improvements)
+author: Matthew Green - @mgreen27, Ecco, James Pemberton / @4A616D6573, oscd.community (improvements), Andreas Hunkeler (@Karneades)
 date: 2019/06/15
 modified: 2019/11/11
 references:
@@ -37,6 +37,7 @@ detection:
             - 'wevtutil.exe'
             - 'net.exe'
             - 'net1.exe'
+            - 'netsh.exe'
     filter:
         Image|endswith:
             - '\cmd.exe'
@@ -58,6 +59,7 @@ detection:
             - '\wevtutil.exe'
             - '\net.exe'
             - '\net1.exe'
+            - '\netsh.exe'
     condition: selection and not filter
 falsepositives:
     - Custom applications use renamed binaries adding slight change to binary name. Typically this is easy to spot and add to whitelist


### PR DESCRIPTION
Besides this addition a rule for catching the binary description which is `Network Command Shell` and at the same time the image name is not `netsh.exe` could be added. But I'm not sure yet because of duplicate purpose with this one.