### PR TITLE
Update rules to follow the Sigma state specification

### DIFF
--- a/rules/windows/process_creation/win_susp_netsh_dll_persistence.yml
+++ b/rules/windows/process_creation/win_susp_netsh_dll_persistence.yml
@@ -1,7 +1,7 @@
 title: Suspicious Netsh DLL Persistence
 id: 56321594-9087-49d9-bf10-524fe8479452
 description: Detects persitence via netsh helper
-status: test
+status: testing
 references:
     - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1128/T1128.md
 tags:

--- a/tests/mapping-conditional-multi.yml
+++ b/tests/mapping-conditional-multi.yml
@@ -1,5 +1,5 @@
 title: Contional mapping with multiple targets
-status: test
+status: testing
 description: Logpoint configuration causes conditional mapping with multiple results
 author: Thomas Patzke
 logsource:


### PR DESCRIPTION
The [Sigma specification's status component](https://github.com/Neo23x0/sigma/wiki/Specification#status-optional) states the following:

> Declares the status of the rule:
>  - stable: the rule is considered as stable and may be used in production systems or dashboards.
>  - test: an almost stable rule that possibly could require some fine tuning.
>  - experimental: an experimental rule that could lead to false results or be noisy, but could also identify interesting events.

However the Sigma Rx YAML specification states the following:

> ```yaml
> status:
>     type: //any
>     of:
>         - type: //str
>           value: stable
>         - type: //str
>           value: testing
>         - type: //str
>           value: experimental
> ```

The specification confuses the `test` and `testing` state. This commit changes the `test` state into the `testing` state which is already used in the code-base:
 - [`sigma/sigma-schema.rx.yml`](https://github.com/Neo23x0/sigma/blob/a805d18bbae60d3e4f291c8a18304104ed2e71c7/sigma-schema.rx.yml#L49)
 - [`sigma/tools/sigma/filter.py`](https://github.com/Neo23x0/sigma/blob/f3c60a63099f80296c8750aaba667e98ac71a4f7/tools/sigma/filter.py#L26)
 - [`sigma/tools/sigmac`](https://github.com/Neo23x0/sigma/blob/4e42bebb3480720966a59528cd8482c6271e603c/tools/sigmac#L98)

**Although not modifiable through a PR, the specification should furthermore be updated to use the `testing` state.**