### PR TITLE
Added new rule for Azorult malware

### DIFF
--- a/rules/windows/malware/mal_azorult_reg_creation.yml
+++ b/rules/windows/malware/mal_azorult_reg_creation.yml
@@ -1,0 +1,28 @@
+title: Azorult Registry
+id: 
+description: Detects the presence of a registry key created during Azorult execution
+status: experimental
+references:
+tags:
+    - attack.execution
+    - attack.t1112
+author: Trent Liffick
+date: 2020/05/08
+logsource:
+    product: windows
+    service: sysmon
+detection:
+  selection:
+    EventID:
+      - 12
+      - 13
+    TargetObject:
+      - '*\SYSTEM\*\services\LocalNETService'
+  condition: selection
+fields:
+    - Image
+    - TargetObject
+    - TargetDetails
+falsepositives:
+  - unknown
+level: medium

--- a/rules/windows/malware/mal_azorult_reg_creation.yml
+++ b/rules/windows/malware/mal_azorult_reg_creation.yml
@@ -17,7 +17,7 @@ detection:
       - 12
       - 13
     TargetObject:
-      - '*\SYSTEM\*\services\LocalNETService'
+      - '*\SYSTEM\*\services\localNETService'
   condition: selection
 fields:
     - Image

--- a/rules/windows/malware/mal_azorult_reg_creation.yml
+++ b/rules/windows/malware/mal_azorult_reg_creation.yml
@@ -1,5 +1,4 @@
 title: Azorult Registry
-id: 
 description: Detects the presence of a registry key created during Azorult execution
 status: experimental
 references:


### PR DESCRIPTION
Added a new rule to detect the registry key creation commonly seen with Azorult malware