### PR TITLE
Fix a bad CommandLine search

### DIFF
--- a/rules/windows/process_creation/win_bootconf_mod.yml
+++ b/rules/windows/process_creation/win_bootconf_mod.yml
@@ -18,7 +18,7 @@ logsource:
 detection:
     selection1:
         Image|endswith: \bcdedit.exe
-        CommandLine: set
+        CommandLine|contains: set
     selection2:
         - CommandLine|contains|all:
             - bootstatuspolicy


### PR DESCRIPTION
The rule was not effective as it looked for non-compatible conditions.