### PR TITLE
Widen the search as it gives too many false negatives

### DIFF
--- a/rules/windows/process_creation/win_susp_script_execution.yml
+++ b/rules/windows/process_creation/win_susp_script_execution.yml
@@ -12,14 +12,14 @@ logsource:
     product: windows
 detection:
     selection:
-        Image:
-            - '*\wscript.exe'
-            - '*\cscript.exe'
-        CommandLine:
-            - '*.jse'
-            - '*.vbe'
-            - '*.js'
-            - '*.vba'
+        Image|endswith:
+            - '\wscript.exe'
+            - '\cscript.exe'
+        CommandLine|contains:
+            - '.jse'
+            - '.vbe'
+            - '.js'
+            - '.vba'
     condition: selection
 fields:
     - CommandLine


### PR DESCRIPTION
This rule was giving too many false negatives, and could be easily bypassed, making it inefficient.
### It would detect
```psh
cscript.exe .\test.jse
```

### It would not detect
```psh
cscript.exe '.\test.jse'
cscript.exe .\test.jse \E:Jscript
cscript.exe .\test.jse [any option]
```

This PR aims at detecting all of the above.