### PR TITLE
remove false positives with cmd as child of services.exe (not specifi…

### DIFF
--- a/rules/windows/builtin/win_meterpreter_or_cobaltstrike_getsystem_service_installation.yml
+++ b/rules/windows/builtin/win_meterpreter_or_cobaltstrike_getsystem_service_installation.yml
@@ -2,9 +2,9 @@ action: global
 title: Meterpreter or Cobalt Strike Getsystem Service Installation
 id: 843544a7-56e0-4dcc-a44f-5cc266dd97d6
 description: Detects the use of getsystem Meterpreter/Cobalt Strike command by detecting a specific service installation
-author: Teymur Kheirkhabarov
+author: Teymur Kheirkhabarov, Ecco
 date: 2019/10/26
-modified: 2019/11/11
+modified: 2020/05/15
 references:
     - https://speakerdeck.com/heirhabarov/hunting-for-privilege-escalation-in-windows-environment
     - https://blog.cobaltstrike.com/2014/04/02/what-happens-when-i-type-getsystem/
@@ -13,9 +13,6 @@ tags:
     - attack.t1134
 detection:
     selection:
-        - ServiceFileName|contains:
-            - 'cmd'
-            - 'comspec'
         # meterpreter getsystem technique 1: cmd.exe /c echo 559891bb017 > \\.\pipe\5e120a
         - ServiceFileName|contains|all:
             - 'cmd'

--- a/rules/windows/process_creation/win_meterpreter_or_cobaltstrike_getsystem_service_start.yml
+++ b/rules/windows/process_creation/win_meterpreter_or_cobaltstrike_getsystem_service_start.yml
@@ -1,9 +1,9 @@
 title: Meterpreter or Cobalt Strike Getsystem Service Start
 id: 15619216-e993-4721-b590-4c520615a67d
 description: Detects the use of getsystem Meterpreter/Cobalt Strike command by detecting a specific service starting
-author: Teymur Kheirkhabarov
+author: Teymur Kheirkhabarov, Ecco
 date: 2019/10/26
-modified: 2019/11/11
+modified: 2020/05/15
 references:
     - https://speakerdeck.com/heirhabarov/hunting-for-privilege-escalation-in-windows-environment
     - https://blog.cobaltstrike.com/2014/04/02/what-happens-when-i-type-getsystem/
@@ -17,9 +17,6 @@ detection:
     selection_1:
         ParentImage|endswith: '\services.exe'
     selection_2:    
-        - CommandLine|contains:
-            - 'cmd'
-            - 'comspec'
         # meterpreter getsystem technique 1: cmd.exe /c echo 559891bb017 > \\.\pipe\5e120a
         - CommandLine|contains|all:
             - 'cmd'


### PR DESCRIPTION
…cally related to meterpreter/cobaltstrike)

cmd and comspec were in the original rule but unused and were kept as is in the current rule