### PR TITLE
fix CVE 2020-1048 rule

### DIFF
--- a/rules/windows/sysmon/sysmon_cve-2020-1048.yml
+++ b/rules/windows/sysmon/sysmon_cve-2020-1048.yml
@@ -1,5 +1,5 @@
 action: global
-title: Suspicious PrinterPorts Created
+title: Suspicious PrinterPorts Created (CVE-2020-1048)
 id: 7ec912f2-5175-4868-b811-ec13ad0f8567
 status: experimental
 description: Detects new registry printer port was created or powershell command add new printer port which point to suspicious file
@@ -26,7 +26,10 @@ detection:
             - 12
             - 13 
         TargetObject|startswith: 'HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Ports'
-        EventType: CreateKey
+        EventType:
+            - SetValue
+            - DeleteValue
+            - CreateValue
         TargetObject|contains:
             - '.dll'
             - '.exe'


### PR DESCRIPTION
after testing, correct event type is either SetValue or DeleteValue (didn't see CreateValue being used with the PoC but doesn't hurt to set it here)
CreateKey is used when opening the key to list values underneath it