### PR TITLE
Remove "condition" from global rule in CVE-2020-1048.

### DIFF
--- a/rules/windows/sysmon/sysmon_cve-2020-1048.yml
+++ b/rules/windows/sysmon/sysmon_cve-2020-1048.yml
@@ -11,8 +11,6 @@ references:
 tags:
     - attack.persistence
     - attack.execution
-detection:
-    condition: 1 of them
 falsepositives:
     - New printer port install on host
 level: high


### PR DESCRIPTION
The condition field in this rule was in the global section which overwrote the condition in sub-rules and generated FPs. For example, once Sigma read the rule, the bottom sub-rule's "condition" was overwritten with "1 of them".

Fixes #767 