### PR TITLE
replace --target-list with --lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ tools/sigmac -t splunk -c ~/my-splunk-mapping.yml -c tools/config/generic/window
 Current work-in-progress
 * [Splunk Data Models](https://docs.splunk.com/Documentation/Splunk/7.1.0/Knowledge/Aboutdatamodels)
 
-New targets are continuously developed. You can get a list of supported targets with `sigmac --target-list` or `sigmac -l`.
+New targets are continuously developed. You can get a list of supported targets with `sigmac --lists` or `sigmac -l`.
 
 ### Requirements
 


### PR DESCRIPTION
The description in the readme is outdated

````
sigmac --target-list
usage: sigmac [-h] [--recurse] [--filter FILTER]
              [--target {kibana,ala-rule,splunk,ala,splunkxml,fieldlist,graylog,es-rule,qualys,arcsight-esm,mdatp,netwitness,arcsight,elastalert-dsl,sql,carbonblack,xpack-watcher,limacharlie,qradar,logiq,powershell,grep,ee-outliers,elastalert,es-qs,es-dsl,logpoint,sumologic}]
              [--lists] [--config CONFIG] [--output OUTPUT]
              [--backend-option BACKEND_OPTION]
              [--backend-config BACKEND_CONFIG] [--defer-abort]
              [--ignore-backend-errors] [--verbose] [--debug]
              [inputs [inputs ...]]
sigmac: error: unrecognized arguments: --target-list

````