### PR TITLE
Create a new rule to detect "Create Account"

### DIFF
--- a/rules/linux/auditd/lnx_auditd_create_account.yml
+++ b/rules/linux/auditd/lnx_auditd_create_account.yml
@@ -1,0 +1,22 @@
+title: Creation Of An User Account
+id: 759d0d51-bc99-4b5e-9add-8f5b2c8e7512
+status: experimental
+description: Detects the creation of a new user account. According to MITRE ATT&CK, "such accounts may be used for persistence that do not require persistent remote access tools to be deployed on the system" 
+references:
+    - 'MITRE Attack technique T1136; Create Account '
+date: 2020/05/18
+tags:
+    - attack.T1136
+    - attack.persistence
+author: Marie Euler
+logsource:
+    product: linux
+    service: auditd
+detection:
+    selection:
+        type: 'SYSCALL'
+        exe: '*/useradd'
+    condition: selection
+falsepositives:
+    - Admin activity
+level: medium

--- a/rules/linux/auditd/lnx_auditd_create_account.yml
+++ b/rules/linux/auditd/lnx_auditd_create_account.yml
@@ -6,7 +6,7 @@ references:
     - 'MITRE Attack technique T1136; Create Account '
 date: 2020/05/18
 tags:
-    - attack.T1136
+    - attack.t1136
     - attack.persistence
 author: Marie Euler
 logsource:


### PR DESCRIPTION
This new rules detects the Mitre Att&ck technique "Create account" on Linux systems.