### PR TITLE
Create a rule for "suspicious activities"

### DIFF
--- a/rules/linux/auditd/lnx_auditd_susp_C2_commands.yml
+++ b/rules/linux/auditd/lnx_auditd_susp_C2_commands.yml
@@ -18,7 +18,7 @@ logsource:
     service: auditd
 detection:
     selection:
-        key :
+        key:
             - 'susp_activity'
     condition: selection
 falsepositives:

--- a/rules/linux/auditd/lnx_auditd_susp_C2_commands.yml
+++ b/rules/linux/auditd/lnx_auditd_susp_C2_commands.yml
@@ -1,12 +1,7 @@
 title: Suspicious C2 Activities
 id: f7158a64-6204-4d6d-868a-6e6378b467e0
 status: experimental
-description: Detects suspicious activities as declared by Florian Roth in its 'Best Practice Auditd Configuration'.
-    This includes the detection of the following commands; wget, curl, base64, nc, netcat, ncat, ssh, socat, wireshark, rawshark, rdesktop, nmap
-    These commands match a few techniques from the tactics "Command and Control", including not exhaustively the following; 
-    Application Layer Protocol (T1071)
-    Non-Application Layer Protocol (T1095)
-    Data Encoding (T1132)
+description: Detects suspicious activities as declared by Florian Roth in its 'Best Practice Auditd Configuration'. This includes the detection of the following commands; wget, curl, base64, nc, netcat, ncat, ssh, socat, wireshark, rawshark, rdesktop, nmap. These commands match a few techniques from the tactics "Command and Control", including not exhaustively the following; Application Layer Protocol (T1071), Non-Application Layer Protocol (T1095), Data Encoding (T1132)
 references:
     - 'https://github.com/Neo23x0/auditd'
 date: 2020/05/18

--- a/rules/linux/auditd/lnx_auditd_susp_C2_commands.yml
+++ b/rules/linux/auditd/lnx_auditd_susp_C2_commands.yml
@@ -1,0 +1,26 @@
+title: Suspicious C2 Activities
+id: f7158a64-6204-4d6d-868a-6e6378b467e0
+status: experimental
+description: Detects suspicious activities as declared by Florian Roth in its 'Best Practice Auditd Configuration'.
+    This includes the detection of the following commands; wget, curl, base64, nc, netcat, ncat, ssh, socat, wireshark, rawshark, rdesktop, nmap
+    These commands match a few techniques from the tactics "Command and Control", including not exhaustively the following; 
+    Application Layer Protocol (T1071)
+    Non-Application Layer Protocol (T1095)
+    Data Encoding (T1132)
+references:
+    - 'https://github.com/Neo23x0/auditd'
+date: 2020/05/18
+tags:
+    - attack.command_and_control
+author: Marie Euler
+logsource:
+    product: linux
+    service: auditd
+detection:
+    selection:
+        key :
+            - 'susp_activity'
+    condition: selection
+falsepositives:
+    - Admin or User activity
+level: medium


### PR DESCRIPTION
This rule detects all the suspicious activities declared in 'https://github.com/Neo23x0/auditd'.
It uses the keyword chosen in these rules. 
I am open to changing it in order to do the selection on the binaries names instead of the keyword.