### PR TITLE
Changes to sysmon_cve-2020-1048

### DIFF
--- a/rules/windows/sysmon/sysmon_cve-2020-1048.yml
+++ b/rules/windows/sysmon/sysmon_cve-2020-1048.yml
@@ -2,9 +2,9 @@ title: Suspicious New Printer Ports in Registry (CVE-2020-1048)
 id: 7ec912f2-5175-4868-b811-ec13ad0f8567
 status: experimental
 description: Detects a new and suspicious printer port creation in Registry that could be an attempt to exploit CVE-2020-1048
-author: EagleEye Team, Florian Roth
+author: EagleEye Team, Florian Roth, NVISO
 date: 2020/05/13
-modified: 2020/05/23
+modified: 2020/05/26
 references:
     - https://windows-internals.com/printdemon-cve-2020-1048/
 tags:
@@ -23,10 +23,11 @@ detection:
             - SetValue
             - DeleteValue
             - CreateValue
-        TargetObject|contains:
+        Details|contains:
             - '.dll'
             - '.exe'
             - '.bat'
+            - '.com'
             - 'C:'
     condition: selection
 falsepositives:


### PR DESCRIPTION
Added detection of `.com` executables, the second use of TargetObject should have been Details to properly match.