### PR TITLE
Susp file characteristics: Reduce FP of legitime processes

### DIFF
--- a/rules/windows/process_creation/win_susp_file_characteristics.yml
+++ b/rules/windows/process_creation/win_susp_file_characteristics.yml
@@ -1,4 +1,4 @@
-title: Suspicious File Characteristics Due to Missing Fields in Downloads folder
+title: Suspicious File Characteristics Due to Missing Fields
 id: 9637e8a5-7131-4f7f-bdc7-2b05d8670c43
 description: Detects Executables in the Downloads folder without FileVersion,Description,Product,Company likely created with py2exe
 status: experimental

--- a/rules/windows/process_creation/win_susp_file_characteristics.yml
+++ b/rules/windows/process_creation/win_susp_file_characteristics.yml
@@ -1,13 +1,13 @@
-title: Suspicious File Characteristics Due to Missing Fields
+title: Suspicious File Characteristics Due to Missing Fields in Downloads folder
 id: 9637e8a5-7131-4f7f-bdc7-2b05d8670c43
-description: Detects Executables without FileVersion,Description,Product,Company likely created with py2exe
+description: Detects Executables in the Downloads folder without FileVersion,Description,Product,Company likely created with py2exe
 status: experimental
 references:
     - https://securelist.com/muddywater/88059/
     - https://www.virustotal.com/#/file/276a765a10f98cda1a38d3a31e7483585ca3722ecad19d784441293acf1b7beb/detection
-author: Markus Neis
+author: Markus Neis, Sander Wiebing
 date: 2018/11/22
-modified: 2019/11/09
+modified: 2020/05/26
 tags:
     - attack.defense_evasion
     - attack.execution
@@ -25,7 +25,9 @@ detection:
     selection3:
         Description: '\?'
         Company: '\?'
-    condition: 1 of them
+    folder:
+        Image: '*\Downloads\\*'
+    condition: (selection1 or selection2 or selection3) and folder
 fields:
     - CommandLine
     - ParentCommandLine


### PR DESCRIPTION
A lot of Windows apps does not have any file characteristics. Some examples:
- Gamebar: C:\\Program Files\\WindowsApps\\Microsoft.XboxGamingOverlay_3.38.25003.0_x64__8wekyb3d8bbwe\\GameBarFT.exe
- YourPhone: C:\\Program Files\\WindowsApps\\Microsoft.YourPhone_1.20022.82.0_x64__8wekyb3d8bbwe\\YourPhoneServer/YourPhoneServer.exe

And also other images:
- All C:\Windows\System32\OpenSSH (scp, sftp, ssh etc) does not have a description and company.

- Python 2.7, 3.3 and 3.7 does not have any file characteristics.

So I don't think it is possible to whitelist all options, maybe it is worthwhile to check the \Downloads\ folder otherwise it would be better to just delete the rule. All other suspicious folders are covered by /rules/windows/process_creation/win_susp_exec_folder.yml