### PR TITLE
Edit Clear Command History

### DIFF
--- a/rules/linux/lnx_shell_clear_cmd_history.yml
+++ b/rules/linux/lnx_shell_clear_cmd_history.yml
@@ -15,7 +15,7 @@ references:
     - https://www.hackers-arise.com/single-post/2016/06/20/Covering-your-BASH-Shell-Tracks-AntiForensics
 author: Patrick Bareiss
 date: 2019/03/24
-modified : 2020/05/28
+modified: 2020/05/28
 logsource:
     product: linux
 detection:

--- a/rules/linux/lnx_shell_clear_cmd_history.yml
+++ b/rules/linux/lnx_shell_clear_cmd_history.yml
@@ -2,12 +2,20 @@ title: Clear Command History
 id: fdc88d25-96fb-4b7c-9633-c0e417fdbd4e
 status: experimental
 description: Clear command history in linux which is used for defense evasion.
+    # Example config for this one (place it in .bash_profile):
+    # (is_empty=false; inotifywait -m .bash_history | while read file; do if [ $(wc -l <.bash_history) -lt 1  ]; then if  [ "$is_empty" = false ]; then logger -i -p local5.info -t empty_bash_history "$USER : ~/.bash_history is empty "; is_empty=true; fi; else is_empty=false;  fi;  done ) &
+    # It monitors the size of .bash_history and log the words "empty_bash_history" whenever a previously not empty bash_history becomes empty
+    # We define an empty file as a document with 0 or 1 lines (it can be a line with only one space character for example)
+    # It has two advantages over the version suggested by Patrick Bareiss  :
+    #   - it is not relative to the exact command used to clear .bash_history : for instance Caldera uses "> .bash_history" to clear the history and this is not one the commands listed here. We can't be exhaustive for all the possibilities ! 
+    #   - the method suggested by Patrick Bareiss logs all the commands entered directly in a bash shell. therefore it may miss some events (for instance it doesn't log the commands launched from a Caldera agent). Here if .bash_history is cleared, it will always be detected 
 references:
     - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1146/T1146.yaml
     - https://attack.mitre.org/techniques/T1146/
     - https://www.hackers-arise.com/single-post/2016/06/20/Covering-your-BASH-Shell-Tracks-AntiForensics
 author: Patrick Bareiss
 date: 2019/03/24
+modified : 2020/05/28
 logsource:
     product: linux
 detection:
@@ -22,6 +30,7 @@ detection:
         - 'history -c'
         - 'history -w'
         - 'shred *bash_history'
+        - 'empty_bash_history'
     condition: keywords
 falsepositives:
     - Unknown


### PR DESCRIPTION
I suggest a new point of view to detect that bash_history has been cleared : Instead of trying to detect all the commands that can do that, we could monitor the size of the file and log whenever it has less than 1 line.