### PR TITLE
All Rules use 'TargetFilename' instead of 'TargetFileName'.

### DIFF
--- a/other/godmode_sigma_rule.yml
+++ b/other/godmode_sigma_rule.yml
@@ -104,7 +104,7 @@ logsource:
 detection:
     selection_file_creation:
         EventID: 11
-        TargetFileName|contains: 
+        TargetFilename|contains: 
             - '.dmp'  # dump process memory
             - 'Desktop\how'  # Ransomware
             - 'Desktop\decrypt'  # Ransomware

--- a/rules-unsupported/sysmon_process_reimaging.yml
+++ b/rules-unsupported/sysmon_process_reimaging.yml
@@ -5,7 +5,7 @@ description: Detects process reimaging defense evasion technique
 # where
 #             selection1: ImageFileName != selection1: OriginalFileName
 #             selection1: ParentProcessGuid = selection2: ProcessGuid
-#             selection1: Image = selection2: TargetFileName
+#             selection1: Image = selection2: TargetFilename
 # and new field ImageFileName is coming from enrichment
 #             selection1: Image = ^.+\\<ImageFileName>$
 # Rule must trigger if selection1 and selection2 both occurs in timeframe of 120 sec.
@@ -45,4 +45,4 @@ detection:
         EventID: 11
 fields:
     - ProcessGuid
-    - TargetFileName
+    - TargetFilename

--- a/rules/windows/process_creation/win_hktl_createminidump.yml
+++ b/rules/windows/process_creation/win_hktl_createminidump.yml
@@ -29,5 +29,5 @@ logsource:
 detection:
     selection:
         EventID: 11
-        TargetFileName|contains: '*\lsass.dmp'
+        TargetFilename|contains: '*\lsass.dmp'
     condition: 1 of them

--- a/rules/windows/sysmon/sysmon_lsass_memory_dump_file_creation.yml
+++ b/rules/windows/sysmon/sysmon_lsass_memory_dump_file_creation.yml
@@ -20,7 +20,7 @@ detection:
     condition: selection
 fields:
     - ComputerName
-    - TargetFileName
+    - TargetFilename
 falsepositives:
     - Dumping lsass memory for forensic investigation purposes by legitimate incident responder or forensic invetigator
 level: medium

--- a/rules/windows/sysmon/sysmon_tsclient_filewrite_startup.yml
+++ b/rules/windows/sysmon/sysmon_tsclient_filewrite_startup.yml
@@ -11,7 +11,7 @@ detection:
     selection:
         EventID: 11
         Image: '*\mstsc.exe'
-        TargetFileName: '*\Microsoft\Windows\Start Menu\Programs\Startup\\*'
+        TargetFilename: '*\Microsoft\Windows\Start Menu\Programs\Startup\\*'
     condition: selection
 falsepositives:
     - unknown


### PR DESCRIPTION
This commit fixes the incorrect spelling. When dumping the fieldlist it gives `TargetFileName` and `TargetFilename`. However, there are more rules that are using `TargetFilename` than `TargetFileName` so this commit changes the "wrong" ones. Some backends support both, and it should be case-insensitive when using the fields, but having this correct looks way cleaner.

If that's ok; I would continue doing this for `OriginalFileName` and `OriginalFilename`.