### PR TITLE
Undefined name: parser_print_help() --> parser.print_help()

### DIFF
--- a/contrib/sigma2sumologic.py
+++ b/contrib/sigma2sumologic.py
@@ -124,7 +124,7 @@ def get_rule_as_sumologic(file):
     return "".join(output)
 
 if args.help:
-    parser_print_help()
+    parser.print_help()
 
 if args.conf:
     with open(args.conf, 'r') as ymlfile:


### PR DESCRIPTION
Discovered in #378 
https://docs.python.org/3.8/library/argparse.html#argparse.ArgumentParser.print_help