### PR TITLE
Undefined name: from .exceptions import SigmaCollectionParseError

### DIFF
--- a/tools/sigma/parser/collection.py
+++ b/tools/sigma/parser/collection.py
@@ -14,8 +14,6 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-tools/sigma/parser/exceptions.py
-
 import yaml
 from .exceptions import SigmaCollectionParseError
 from .rule import SigmaParser

--- a/tools/sigma/parser/collection.py
+++ b/tools/sigma/parser/collection.py
@@ -14,7 +14,10 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+tools/sigma/parser/exceptions.py
+
 import yaml
+from .exceptions import SigmaCollectionParseError
 from .rule import SigmaParser
 
 class SigmaCollectionParser:


### PR DESCRIPTION
Discovered in #378.  `SigmaCollectionParseError()` is called on line 55 but it is never defined or imported which means that NameError will be raised instead of SigmaCollectionParseError.