### PR TITLE
Octopus Scanner malware rule

### DIFF
--- a/rules/windows/malware/win_mal_octopus_scanner.yml
+++ b/rules/windows/malware/win_mal_octopus_scanner.yml
@@ -1,0 +1,24 @@
+title: Octopus Scanner Malware
+id: 805c55d9-31e6-4846-9878-c34c75054fe9
+status: experimental
+description: Detects Octopus Scanner Malware.
+references:
+  - https://securitylab.github.com/research/octopus-scanner-malware-open-source-supply-chain
+tags:
+  - attack.t1195
+author: NVISO
+date: 2020/06/09
+logsource:
+  product: windows
+  service: sysmon
+detection:
+  filecreate:
+    EventID: 11
+  selection:
+    TargetFilename|endswith:
+      - '\AppData\Local\Microsoft\Cache134.dat'
+      - '\AppData\Local\Microsoft\ExplorerSync.db'
+condition: filecreate and selection
+falsepositives:
+  - Unknown
+level: high

--- a/rules/windows/malware/win_mal_octopus_scanner.yml
+++ b/rules/windows/malware/win_mal_octopus_scanner.yml
@@ -18,7 +18,7 @@ detection:
     TargetFilename|endswith:
       - '\AppData\Local\Microsoft\Cache134.dat'
       - '\AppData\Local\Microsoft\ExplorerSync.db'
-condition: filecreate and selection
+  condition: filecreate and selection
 falsepositives:
   - Unknown
 level: high


### PR DESCRIPTION
Rule to detect the Octopus Scanner malware that affected several GitHub repositories:
https://securitylab.github.com/research/octopus-scanner-malware-open-source-supply-chain