### PR TITLE
TA410 FlowCloud malware detection

### DIFF
--- a/rules/windows/malware/win_mal_flowcloud.yml
+++ b/rules/windows/malware/win_mal_flowcloud.yml
@@ -1,0 +1,28 @@
+title: FlowCloud Malware
+id: 5118765f-6657-4ddb-a487-d7bd673abbf1
+status: experimental
+description: Detects FlowCloud malware from threat group TA410.
+references:
+  - https://www.proofpoint.com/us/blog/threat-insight/ta410-group-behind-lookback-attacks-against-us-utilities-sector-returns-new
+author: NVISO
+tags:
+  - attack.persistence
+  - attack.t1112
+date: 2020/06/09
+logsource:
+  product: windows
+  service: sysmon
+detection:
+  selection:
+    EventID:
+      - 12 # key create
+      - 13 # value set
+    TargetObject:
+      - 'HKLM\HARDWARE\{804423C2-F490-4ac3-BFA5-13DEDE63A71A}'
+      - 'HKLM\HARDWARE\{A5124AF5-DF23-49bf-B0ED-A18ED3DEA027}'
+      - 'HKLM\HARDWARE\{2DB80286-1784-48b5-A751-B6ED1F490303}'
+      - 'HKLM\SYSTEM\Setup\PrintResponsor\*'
+  condition: selection
+falsepositives:
+  - Unknown
+level: critical


### PR DESCRIPTION
Rule to detect FlowCloud malware used by TA410, as reported by [Proofpoint](https://www.proofpoint.com/us/blog/threat-insight/ta410-group-behind-lookback-attacks-against-us-utilities-sector-returns-new).