### PR TITLE
Add parentheses around field list groups in CB

### DIFF
--- a/tools/sigma/backends/carbonblack.py
+++ b/tools/sigma/backends/carbonblack.py
@@ -54,7 +54,7 @@ class CarbonBlackQueryBackend(CarbonBlackWildcardHandlingMixin, SingleTextQueryB
     orToken = " OR "
     notToken = " -"
     subExpression = "(%s)"
-    listExpression = "%s"
+    listExpression = "(%s)"
     listSeparator = " OR "
     valueExpression = '%s'
     typedValueExpression = {


### PR DESCRIPTION
This should address the grouping issue from #660.

The grouping issue was solved by just slamming some parentheses around the fields in the listExpression field.

-----

```yaml
detection:
    selection:
        SomeField:
            - 'foo'
            - 'bar'
        AnotherField: 'baz'
    condition: selection
```

```
$ sigmac -t carbonblack -c carbon-black.yml test-rule.yaml
((SomeField:foo OR SomeField:bar) AND AnotherField:baz)
```