### PR TITLE
Fix rules with incorrect escaping of wildcars

### DIFF
--- a/rules/windows/malware/win_mal_flowcloud.yml
+++ b/rules/windows/malware/win_mal_flowcloud.yml
@@ -21,7 +21,7 @@ detection:
       - 'HKLM\HARDWARE\{804423C2-F490-4ac3-BFA5-13DEDE63A71A}'
       - 'HKLM\HARDWARE\{A5124AF5-DF23-49bf-B0ED-A18ED3DEA027}'
       - 'HKLM\HARDWARE\{2DB80286-1784-48b5-A751-B6ED1F490303}'
-      - 'HKLM\SYSTEM\Setup\PrintResponsor\*'
+      - 'HKLM\SYSTEM\Setup\PrintResponsor\\*'
   condition: selection
 falsepositives:
   - Unknown

--- a/rules/windows/process_creation/win_apt_mustangpanda.yml
+++ b/rules/windows/process_creation/win_apt_mustangpanda.yml
@@ -16,7 +16,7 @@ detection:
         CommandLine: 
             - '*Temp\wtask.exe /create*'
             - '*%windir:~-3,1%%PUBLIC:~-9,1%*'
-            - '*/E:vbscript * C:\Users\*.txt" /F'
+            - '*/E:vbscript * C:\Users\\*.txt" /F'
             - '*/tn "Security Script *'
             - '*%windir:~-1,1%*'
     selection2:

--- a/rules/windows/process_creation/win_apt_wocao.yml
+++ b/rules/windows/process_creation/win_apt_wocao.yml
@@ -37,5 +37,5 @@ detection:
             - ' -exec bypass -enc JgAg'
             - 'type *keepass\KeePass.config.xml'
             - 'iie.exe iie.txt'
-            - 'reg query HKEY_CURRENT_USER\Software\*\PuTTY\Sessions\'
+            - 'reg query HKEY_CURRENT_USER\Software\\*\PuTTY\Sessions\'
     condition: selection

--- a/rules/windows/sysmon/sysmon_susp_adsi_cache_usage.yml
+++ b/rules/windows/sysmon/sysmon_susp_adsi_cache_usage.yml
@@ -17,7 +17,7 @@ logsource:
 detection:
     selection_1:
         EventID: 11
-        TargetFilename: '*\Local\Microsoft\Windows\SchCache\*.sch'
+        TargetFilename: '*\Local\Microsoft\Windows\SchCache\\*.sch'
     selection_2:
         Image|contains:
             - 'C:\windows\system32\svchost.exe'

--- a/rules/windows/sysmon/sysmon_susp_office_dotnet_assembly_dll_load.yml
+++ b/rules/windows/sysmon/sysmon_susp_office_dotnet_assembly_dll_load.yml
@@ -21,7 +21,7 @@ detection:
             - '*\excel.exe'
             - '*\outlook.exe'
         ImageLoaded:
-            - 'C:\Windows\assembly\*'
+            - 'C:\Windows\assembly\\*'
     condition: selection
 falsepositives:
     - Alerts on legitimate macro usage as well, will need to filter as appropriate

--- a/rules/windows/sysmon/sysmon_susp_procexplorer_driver_created_in_tmp_folder.yml
+++ b/rules/windows/sysmon/sysmon_susp_procexplorer_driver_created_in_tmp_folder.yml
@@ -15,7 +15,7 @@ logsource:
 detection:
     selection_1:
         EventID: 11
-        TargetFilename: '*\AppData\Local\Temp\*\PROCEXP152.sys'
+        TargetFilename: '*\AppData\Local\Temp\\*\PROCEXP152.sys'
     selection_2:
         Image|contains:
             - '*\procexp64.exe'

--- a/rules/windows/sysmon/sysmon_suspicious_keyboard_layout_load.yml
+++ b/rules/windows/sysmon/sysmon_suspicious_keyboard_layout_load.yml
@@ -16,8 +16,8 @@ detection:
     selection_registry:
         EventID: 13
         TargetObject: 
-            - '*\Keyboard Layout\Preload\*'
-            - '*\Keyboard Layout\Substitutes\*'
+            - '*\Keyboard Layout\Preload\\*'
+            - '*\Keyboard Layout\Substitutes\\*'
         Details|contains:
             - 00000429  # Persian (Iran)
             - 00050429  # Persian (Iran)

--- a/rules/windows/sysmon/sysmon_svchost_dll_search_order_hijack.yml
+++ b/rules/windows/sysmon/sysmon_svchost_dll_search_order_hijack.yml
@@ -28,7 +28,7 @@ detection:
             - '*\wlbsctrl.dll'
     filter:
         ImageLoaded:
-            - 'C:\Windows\WinSxS\*'        
+            - 'C:\Windows\WinSxS\\*'        
     condition: selection and not filter
 falsepositives:
     - Pentest


### PR DESCRIPTION
A backslash before a wildcard needs to be escaped with another backslash.