### PR TITLE
Fix logsource field name from service->category

### DIFF
--- a/rules/windows/process_creation/win_invoke_obfuscation_obfuscated_iex_commandline.yml
+++ b/rules/windows/process_creation/win_invoke_obfuscation_obfuscated_iex_commandline.yml
@@ -8,8 +8,8 @@ tags:
     - attack.defense_evasion
     - attack.t1027
 logsource:
+    category: process_creation
     product: windows
-    service: process_creation
 detection:
     selection:
         - CommandLine|re: '\$PSHome\[\s*\d{1,3}\s*\]\s*\+\s*\$PSHome\['


### PR DESCRIPTION
The rule win_invoke_obfuscation_obfuscated_iex_commandline has the
wrong field name for the "process_creation" tag. Rename from "service"
to "category"