### PR TITLE
Identifiers shared between global document and rule gets overwritten

### DIFF
--- a/rules/windows/builtin/win_invoke_obfuscation_obfuscated_iex_services.yml
+++ b/rules/windows/builtin/win_invoke_obfuscation_obfuscated_iex_services.yml
@@ -12,7 +12,7 @@ falsepositives:
     - Unknown
 level: high
 detection:
-    selection:
+    selection_1:
         - ImagePath|re: '\$PSHome\[\s*\d{1,3}\s*\]\s*\+\s*\$PSHome\['
         - ImagePath|re: '\$ShellId\[\s*\d{1,3}\s*\]\s*\+\s*\$ShellId\['
         - ImagePath|re: '\$env:Public\[\s*\d{1,3}\s*\]\s*\+\s*\$env:Public\['
@@ -20,7 +20,7 @@ detection:
         - ImagePath|re: '\*mdr\*\W\s*\)\.Name'
         - ImagePath|re: '\$VerbosePreference\.ToString\('
         - ImagePath|re: '\String\]\s*\$VerbosePreference'
-    condition: selection
+    condition: selection and selection_1
 ---
 logsource:
     product: windows

--- a/rules/windows/builtin/win_meterpreter_or_cobaltstrike_getsystem_service_installation.yml
+++ b/rules/windows/builtin/win_meterpreter_or_cobaltstrike_getsystem_service_installation.yml
@@ -12,7 +12,7 @@ tags:
     - attack.privilege_escalation
     - attack.t1134
 detection:
-    selection:
+    selection_1:
         # meterpreter getsystem technique 1: cmd.exe /c echo 559891bb017 > \\.\pipe\5e120a
         - ServiceFileName|contains|all:
             - 'cmd'
@@ -30,7 +30,7 @@ detection:
             - 'rundll32'
             - '.dll,a'
             - '/p:'
-    condition: selection
+    condition: selection and selection_1
 fields:
     - ComputerName
     - SubjectDomainName

--- a/rules/windows/builtin/win_tap_driver_installation.yml
+++ b/rules/windows/builtin/win_tap_driver_installation.yml
@@ -12,9 +12,9 @@ falsepositives:
     - Legitimate OpenVPN TAP insntallation
 level: medium
 detection:
-    selection:
+    selection_1:
         ImagePath|contains: 'tap0901'
-    condition: selection
+    condition: selection and selection_1
 ---
 logsource:
     product: windows


### PR DESCRIPTION
The global document defines a "selection" identifier which is also defined the
individual rules. The rule identifier is getting overwritten by the global identifier.
Fix by giving unique names to the global identifier.