### PR TITLE
Fix match for double-backslash

### DIFF
--- a/rules/windows/process_creation/win_net_enum.yml
+++ b/rules/windows/process_creation/win_net_enum.yml
@@ -21,7 +21,7 @@ detection:
             - '\net1.exe'
         CommandLine|contains: 'view'
     filter:
-        CommandLine|contains: '\\'
+        CommandLine|contains: \\\
     condition: selection and not filter
 fields:
     - ComputerName


### PR DESCRIPTION
To match a double-backslash you actually need three backslashes, since two
backslashes gets reduced to one.