### PR TITLE
Rule lists extra Sysmon ID (11). Should just match registry events (1…

### DIFF
--- a/rules/windows/sysmon/sysmon_logon_scripts_userinitmprlogonscript.yml
+++ b/rules/windows/sysmon/sysmon_logon_scripts_userinitmprlogonscript.yml
@@ -44,7 +44,6 @@ logsource:
 detection:
     create_selection_reg:
         EventID:
-            - 11
             - 12
             - 13
             - 14


### PR DESCRIPTION
…2-14)

Remove extraneous event ID 11. It will never match.