### PR TITLE
Fix multiple references to default field mapping in same rule

### DIFF
--- a/tools/sigma/config/mapping.py
+++ b/tools/sigma/config/mapping.py
@@ -125,9 +125,9 @@ class ConditionalFieldMapping(SimpleFieldMapping):
 
         if len(targets) == 1:     # result set contains only one target, return mapped item (like SimpleFieldMapping)
             if value is None:
-                return ConditionNULLValue(val=targets.pop())
+                return ConditionNULLValue(val=targets[0])
             else:
-                return (targets.pop(), value)
+                return (targets[0], value)
         elif len(targets) > 1:        # result set contains multiple targets, return all linked as OR condition (like MultiFieldMapping)
             cond = ConditionOR()
             for target in targets:


### PR DESCRIPTION
If there is a default mapping specified for a fieldmapping and that field is
referenced multiple times in the rule, the default mapping will be "pop"ped
and return the unmapped key on subsequent uses.

Don't pop the value. Just return the first entry.