### PR TITLE
Fix quoting for AD Object WriteDAC Access

### DIFF
--- a/rules/windows/builtin/win_ad_object_writedac_access.yml
+++ b/rules/windows/builtin/win_ad_object_writedac_access.yml
@@ -16,7 +16,7 @@ detection:
     selection: 
         EventID: 4662
         ObjectServer: 'DS'
-        AccessMask: 0x40000
+        AccessMask: '0x40000'
         ObjectType:
             - '19195a5b-6da0-11d0-afd3-00c04fd930c9'
             - 'domainDNS'


### PR DESCRIPTION
The AccessMask field needs to be quoted so that it is compared correctly.