### PR TITLE
Fix undefined names in sigma2misp.py

### DIFF
--- a/tools/sigma/sigma2misp.py
+++ b/tools/sigma/sigma2misp.py
@@ -7,7 +7,7 @@ import urllib3
 urllib3.disable_warnings()
 from pymisp import PyMISP
 
-def create_new_event():
+def create_new_event(args, misp):
     if hasattr(misp, "new_event"):
         return misp.new_event(info=args.info)["Event"]["id"]
     
@@ -55,7 +55,7 @@ def main():
 
     for sigma in paths:
         if not args.event and (first or not args.same_event):
-            eventid = create_new_event()
+            eventid = create_new_event(args, misp)
         print("Importing Sigma rule {} into MISP event {}...".format(sigma, eventid, end=""))
         f = sigma.open("rt")
 


### PR DESCRIPTION
create_new_event() -> create_new_event(args, misp) to fix:

flake8 testing of https://github.com/Neo23x0/sigma on Python 3.8.3

% _flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics_
```
./tools/sigma/sigma2misp.py:11:16: F821 undefined name 'misp'
    if hasattr(misp, "new_event"):
               ^
./tools/sigma/sigma2misp.py:12:16: F821 undefined name 'misp'
        return misp.new_event(info=args.info)["Event"]["id"]
               ^
./tools/sigma/sigma2misp.py:12:36: F821 undefined name 'args'
        return misp.new_event(info=args.info)["Event"]["id"]
                                   ^
./tools/sigma/sigma2misp.py:14:13: F821 undefined name 'misp'
    event = misp.MISPEvent()
            ^
./tools/sigma/sigma2misp.py:15:18: F821 undefined name 'args'
    event.info = args.info
                 ^
./tools/sigma/sigma2misp.py:16:12: F821 undefined name 'misp'
    return misp.add_event(event)["Event"]["id"]
           ^
6     F821 undefined name 'misp'
6
```