### PR TITLE
Windows Defender logsource and rules

### DIFF
--- a/rules/windows/other/win_defender_disabled.yml
+++ b/rules/windows/other/win_defender_disabled.yml
@@ -1,0 +1,26 @@
+title: Windows Defender threat detection disabled
+id: fe34868f-6e0e-4882-81f6-c43aa8f15b62
+description: Detects disabling Windows Defender threat protection
+date: 2020/07/28
+author: Ján Trenčanský
+references:
+    - https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-antivirus/troubleshoot-windows-defender-antivirus
+status: stable
+tags:
+    - attack.defense_evasion
+    - attack.t1089
+    - attack.t1562.001
+logsource:
+    product: windows
+    service: windefend
+detection:
+    selection:
+        EventID:
+            - 5001
+            - 5010
+            - 5012
+            - 5101
+    condition: selection
+falsepositives:
+    - Administrator actions
+level: high

--- a/rules/windows/other/win_defender_disabled.yml
+++ b/rules/windows/other/win_defender_disabled.yml
@@ -1,4 +1,4 @@
-title: Windows Defender threat detection disabled
+title: Windows Defender Threat Detection Disabled
 id: fe34868f-6e0e-4882-81f6-c43aa8f15b62
 description: Detects disabling Windows Defender threat protection
 date: 2020/07/28

--- a/rules/windows/other/win_defender_threat.yml
+++ b/rules/windows/other/win_defender_threat.yml
@@ -1,4 +1,4 @@
-title: Windows Defender threat detected
+title: Windows Defender Threat Detected
 id: 57b649ef-ff42-4fb0-8bf6-62da243a1708
 description: Detects all actions taken by Windows Defender malware detection engines
 date: 2020/07/28

--- a/rules/windows/other/win_defender_threat.yml
+++ b/rules/windows/other/win_defender_threat.yml
@@ -1,0 +1,22 @@
+title: Windows Defender threat detected
+id: 57b649ef-ff42-4fb0-8bf6-62da243a1708
+description: Detects all actions taken by Windows Defender malware detection engines
+date: 2020/07/28
+author: Ján Trenčanský
+references:
+    - https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-antivirus/troubleshoot-windows-defender-antivirus
+status: stable
+logsource:
+    product: windows
+    service: windefend
+detection:
+    selection:
+        EventID:
+            - 1006
+            - 1116
+            - 1015
+            - 1117
+    condition: selection
+falsepositives:
+    - unlikely
+level: high

--- a/tools/config/logstash-windows.yml
+++ b/tools/config/logstash-windows.yml
@@ -43,4 +43,9 @@ logsources:
     service: dhcp
     conditions:
       Channel: 'Microsoft-Windows-DHCP-Server/Operational'
+  windows-defender:
+    product: windows
+    service: windefend
+    conditions:
+      Channel: 'Microsoft-Windows-Windows Defender/Operational'
 defaultindex: logstash-*

--- a/tools/config/powershell.yml
+++ b/tools/config/powershell.yml
@@ -69,3 +69,8 @@ logsources:
     service: dhcp
     conditions:
       LogName: 'Microsoft-Windows-DHCP-Server/Operational'
+  windows-defender:
+    product: windows
+    service: windefend
+    conditions:
+      LogName: 'Microsoft-Windows-Windows Defender/Operational'

--- a/tools/config/winlogbeat-modules-enabled.yml
+++ b/tools/config/winlogbeat-modules-enabled.yml
@@ -44,6 +44,11 @@ logsources:
     service: dhcp
     conditions:
       winlog.provider_name: 'Microsoft-Windows-DHCP-Server/Operational'
+  windows-defender:
+    product: windows
+    service: windefend
+    conditions:
+      winlog.channel: 'Microsoft-Windows-Windows Defender/Operational'
 defaultindex: winlogbeat-*
 # Extract all field names qith yq:
 # yq -r '.detection | del(.condition) | map(keys) | .[][]' $(find sigma/rules/windows -name '*.yml') | sort -u | grep -v ^EventID$ | sed 's/^\(.*\)/    \1: winlog.event_data.\1/g'

--- a/tools/config/winlogbeat-old.yml
+++ b/tools/config/winlogbeat-old.yml
@@ -43,6 +43,11 @@ logsources:
     service: dhcp
     conditions:
       source: 'Microsoft-Windows-DHCP-Server/Operational'
+  windows-defender:
+    product: windows
+    service: windefend
+    conditions:
+      source: 'Microsoft-Windows-Windows Defender/Operational'
 defaultindex: winlogbeat-*
 # Extract all field names qith yq:
 # yq -r '.detection | del(.condition) | map(keys) | .[][]' $(find sigma/rules/windows -name '*.yml') | sort -u | grep -v ^EventID$ | sed 's/^\(.*\)/    \1: event_data.\1/g'

--- a/tools/config/winlogbeat.yml
+++ b/tools/config/winlogbeat.yml
@@ -43,6 +43,11 @@ logsources:
     service: dhcp
     conditions:
       winlog.provider_name: 'Microsoft-Windows-DHCP-Server/Operational'
+  windows-defender:
+    product: windows
+    service: windefend
+    conditions:
+      winlog.channel: 'Microsoft-Windows-Windows Defender/Operational'
 defaultindex: winlogbeat-*
 # Extract all field names qith yq:
 # yq -r '.detection | del(.condition) | map(keys) | .[][]' $(find sigma/rules/windows -name '*.yml') | sort -u | grep -v ^EventID$ | sed 's/^\(.*\)/    \1: winlog.event_data.\1/g'


### PR DESCRIPTION
Hello,

I created two rules for Windows Defender logs based on Microsoft [documentation](https://docs.microsoft.com/en-us/windows/security/threat-protection/microsoft-defender-antivirus/troubleshoot-microsoft-defender-antivirus).

`win_defender_disabled.yml ` rule detects Event IDs that disable Defender or parts of it:

- 5001 - Real-time protection is disabled.
- 5010 - Scanning for malware and other potentially unwanted software is disabled.
- 5012 - Scanning for viruses is disabled.
- 5101 - The antimalware platform is expired.

`win_defender_threat.yml` rule detects actions taken by Defender components to detect/stop threat:

- 1006 - The antimalware engine found malware or other potentially unwanted software.
- 1116 - The antimalware platform detected malware or other potentially unwanted software.
- 1015 - The antimalware platform detected suspicious behavior.
- 1117 - The antimalware platform performed an action to protect your system from malware or other potentially unwanted software.

Single malware execution may trigger multiple of these events, for some edge cases it's better to include all of them. Microsoft documentation doesn't really explain in-depth when they get triggered.

I gave rules status `stable` since I've had them deployed for a couple of months without any problems or false positives and the logic is pretty straight-forward, but change them to `experimental` if necessary.

Also since these rules require ingest of `Microsoft-Windows-Windows Defender/Operational` I added the `windefend` service as a logsource to backend configs I use, others may be needed, but I can't test those.