### PR TITLE
Fixes for rules in the sysmon file_event category

### DIFF
--- a/rules/windows/file_event/sysmon_hack_dumpert.yml
+++ b/rules/windows/file_event/sysmon_hack_dumpert.yml
@@ -10,9 +10,6 @@ date: 2020/02/04
 tags:
     - attack.credential_access
     - attack.t1003
-logsource:
-    category: file_event
-    product: windows
 falsepositives:
     - Very unlikely
 level: critical
@@ -26,8 +23,8 @@ detection:
     condition: selection
 ---
 logsource:
+    category: file_event
     product: windows
-    service: sysmon
 detection:
     selection: 
         TargetFilename: C:\Windows\Temp\dumpert.dmp

--- a/rules/windows/file_event/sysmon_tsclient_filewrite_startup.yml
+++ b/rules/windows/file_event/sysmon_tsclient_filewrite_startup.yml
@@ -10,7 +10,7 @@ logsource:
 detection:
     selection:
         Image: '*\mstsc.exe'
-        TargetFileName: '*\Microsoft\Windows\Start Menu\Programs\Startup\\*'
+        TargetFilename: '*\Microsoft\Windows\Start Menu\Programs\Startup\\*'
     condition: selection
 falsepositives:
     - unknown

--- a/rules/windows/file_event/sysmon_wmi_persistence_script_event_consumer_write.yml
+++ b/rules/windows/file_event/sysmon_wmi_persistence_script_event_consumer_write.yml
@@ -11,7 +11,7 @@ tags:
     - attack.persistence
 logsource:
     product: windows
-    category: file_created
+    category: file_event
 detection:
     selection:
         Image: 'C:\WINDOWS\system32\wbem\scrcons.exe'


### PR DESCRIPTION
Fix a couple of typos

For sysmon_hack_dumpert:
Make sure the logsource is category file_event and not sysmon. Don't set
the category at the global level. Instead set in the individual document.