### PR TITLE
Fixes for rules in new sysmon registry_event category

### DIFF
--- a/rules/windows/registry_event/sysmon_disable_security_events_logging_adding_reg_key_minint.yml
+++ b/rules/windows/registry_event/sysmon_disable_security_events_logging_adding_reg_key_minint.yml
@@ -15,8 +15,7 @@ logsource:
     product: windows
 detection:
     selection:
-      - EventID: 12 # key create
-        # Sysmon gives us HKLM\SYSTEM\CurrentControlSet\.. if ControlSetXX is the selected one
+      - # Sysmon gives us HKLM\SYSTEM\CurrentControlSet\.. if ControlSetXX is the selected one
         TargetObject: 'HKLM\SYSTEM\CurrentControlSet\Control\MiniNt'
         EventType: 'CreateKey'  # we don't want deletekey
       -   # key rename

--- a/rules/windows/registry_event/sysmon_new_dll_added_to_appcertdlls_registry_key.yml
+++ b/rules/windows/registry_event/sysmon_new_dll_added_to_appcertdlls_registry_key.yml
@@ -17,12 +17,9 @@ logsource:
     product: windows
 detection:
     selection:
-      - EventID: 
-            - 12  # key create
-            - 13  # value set
-        # Sysmon gives us HKLM\SYSTEM\CurrentControlSet\.. if ControlSetXX is the selected one
+      - # Sysmon gives us HKLM\SYSTEM\CurrentControlSet\.. if ControlSetXX is the selected one
         TargetObject: 'HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\AppCertDlls'
-      -   # key rename
+      - # key rename
         NewName: 'HKLM\SYSTEM\CurentControlSet\Control\Session Manager\AppCertDlls'
     condition: selection
 fields:


### PR DESCRIPTION
To be consistent with the behaviour of the other rules, the eventID should not
be specified as part of the rule. The category defines the eventID.