### PR TITLE
Proposed fix for https://github.com/Neo23x0/sigma/issues/889

### DIFF
--- a/rules/windows/network_connection/sysmon_regsvr32_network_activity.yml
+++ b/rules/windows/network_connection/sysmon_regsvr32_network_activity.yml
@@ -1,3 +1,4 @@
+action: global
 title: Regsvr32 Network Activity
 id: c7e91a02-d771-4a6d-a700-42587e0b1095
 description: Detects network connections and DNS queries initiated by Regsvr32.exe
@@ -14,13 +15,10 @@ author: Dmitriy Lifanov, oscd.community
 status: experimental
 date: 2019/10/25
 modified: 2020/07/01
-logsource:
-    category: network_connection
-    product: windows
 detection:
     selection:
         Image|endswith: '\regsvr32.exe'
-    condition: selection
+    condition: all of them
 fields:
     - ComputerName
     - User
@@ -30,3 +28,14 @@ fields:
 falsepositives:
     - unknown
 level: high
+---
+logsource:
+    category: network_connection
+    product: windows
+---
+logsource:
+    product: windows
+    service: sysmon
+detection:
+    selection1:
+        EventID: 22

--- a/tools/config/generic/sysmon.yml
+++ b/tools/config/generic/sysmon.yml
@@ -15,7 +15,6 @@ logsources:
         conditions:
             EventID: 
                 - 3
-                - 22
         rewrite:
             product: windows
             service: sysmon


### PR DESCRIPTION
This change removes dns events from the network connection category. The
one change is that sysmon_regsvr32_network_activity.yml needs to test
the network connection category separately from the DNS event id.