### PR TITLE
Proposed fix for sysmon_uac_bypass_eventvwr

### DIFF
--- a/rules/windows/registry_event/sysmon_uac_bypass_eventvwr.yml
+++ b/rules/windows/registry_event/sysmon_uac_bypass_eventvwr.yml
@@ -1,3 +1,4 @@
+action: global
 title: UAC Bypass via Event Viewer
 id: 7c81fec3-1c1d-43b0-996a-46753041b1b6
 status: experimental
@@ -7,21 +8,6 @@ references:
     - https://www.hybrid-analysis.com/sample/e122bc8bf291f15cab182a5d2d27b8db1e7019e4e96bb5cdbd1dfe7446f3f51f?environmentId=100
 author: Florian Roth
 date: 2017/03/19
-logsource:
-    product: windows
-    category: registry_event
-detection:
-    methregistry:
-        TargetObject: 'HKU\\*\mscfile\shell\open\command'
-    methprocess:
-        EventID: 1 # Migration to process_creation requires multipart YAML
-        ParentImage: '*\eventvwr.exe'
-    filterprocess:
-        Image: '*\mmc.exe'
-    condition: methregistry or ( methprocess and not filterprocess )
-fields:
-    - CommandLine
-    - ParentCommandLine
 tags:
     - attack.defense_evasion
     - attack.privilege_escalation
@@ -30,3 +16,24 @@ tags:
 falsepositives:
     - unknown
 level: critical
+---
+logsource:
+    product: windows
+    category: registry_event
+detection:
+    methregistry:
+        TargetObject: 'HKU\\*\mscfile\shell\open\command'
+    condition: methregistry
+---
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    methprocess:
+        ParentImage: '*\eventvwr.exe'
+    filterprocess:
+        Image: '*\mmc.exe'
+    condition: methprocess and not filterprocess
+fields:
+    - CommandLine
+    - ParentCommandLine


### PR DESCRIPTION
Issue: https://github.com/Neo23x0/sigma/issues/888

The rules were not merged correctly with the transition to sysmon categories.

Split the rule into separate documents: one for the registry_event and one for
the process_creation