### PR TITLE
Re-fix sysmon rules that lost changes with category refactoring.

### DIFF
--- a/rules/windows/file_event/sysmon_creation_system_file.yml
+++ b/rules/windows/file_event/sysmon_creation_system_file.yml
@@ -14,7 +14,7 @@ logsource:
     product: windows
 detection:
     selection:      
-        Image:
+        TargetFilename:
             - '*\svchost.exe'
             - '*\rundll32.exe'
             - '*\services.exe'
@@ -40,7 +40,7 @@ detection:
             - '*\audiodg.exe'
             - '*\wlanext.exe'
     filter:
-        Image:
+        TargetFilename:
             - 'C:\Windows\System32\\*'
             - 'C:\Windows\system32\\*'
             - 'C:\Windows\SysWow64\\*'

--- a/rules/windows/file_event/sysmon_susp_adsi_cache_usage.yml
+++ b/rules/windows/file_event/sysmon_susp_adsi_cache_usage.yml
@@ -16,7 +16,7 @@ logsource:
     category: file_event
 detection:
     selection_1:
-        TargetFilename: '*\Local\Microsoft\Windows\SchCache\*.sch'
+        TargetFilename: '*\Local\Microsoft\Windows\SchCache\\*.sch'
     selection_2:
         Image|contains:
             - 'C:\windows\system32\svchost.exe'

--- a/rules/windows/file_event/sysmon_susp_procexplorer_driver_created_in_tmp_folder.yml
+++ b/rules/windows/file_event/sysmon_susp_procexplorer_driver_created_in_tmp_folder.yml
@@ -14,7 +14,7 @@ logsource:
     category: file_event
 detection:
     selection_1:
-        TargetFilename: '*\AppData\Local\Temp\*\PROCEXP152.sys'
+        TargetFilename: '*\AppData\Local\Temp\\*\PROCEXP152.sys'
     selection_2:
         Image|contains:
             - '*\procexp64.exe'

--- a/rules/windows/image_load/sysmon_susp_office_dotnet_assembly_dll_load.yml
+++ b/rules/windows/image_load/sysmon_susp_office_dotnet_assembly_dll_load.yml
@@ -20,7 +20,7 @@ detection:
             - '*\excel.exe'
             - '*\outlook.exe'
         ImageLoaded:
-            - 'C:\Windows\assembly\*'
+            - 'C:\Windows\assembly\\*'
     condition: selection
 falsepositives:
     - Alerts on legitimate macro usage as well, will need to filter as appropriate

--- a/rules/windows/image_load/sysmon_svchost_dll_search_order_hijack.yml
+++ b/rules/windows/image_load/sysmon_svchost_dll_search_order_hijack.yml
@@ -27,7 +27,7 @@ detection:
             - '*\wlbsctrl.dll'
     filter:
         ImageLoaded:
-            - 'C:\Windows\WinSxS\*'        
+            - 'C:\Windows\WinSxS\\*'        
     condition: selection and not filter
 falsepositives:
     - Pentest

--- a/rules/windows/image_load/sysmon_wmi_persistence_commandline_event_consumer.yml
+++ b/rules/windows/image_load/sysmon_wmi_persistence_commandline_event_consumer.yml
@@ -15,7 +15,7 @@ logsource:
 detection:
     selection:
         Image: 'C:\Windows\System32\wbem\WmiPrvSE.exe'
-        ImageLoaded: 'wbemcons.dll'
+        ImageLoaded|endswith: '\wbemcons.dll'
     condition: selection
 falsepositives: 
     - Unknown (data set is too small; further testing needed)

--- a/rules/windows/registry_event/sysmon_suspicious_keyboard_layout_load.yml
+++ b/rules/windows/registry_event/sysmon_suspicious_keyboard_layout_load.yml
@@ -15,8 +15,8 @@ logsource:
 detection:
     selection_registry:
         TargetObject: 
-            - '*\Keyboard Layout\Preload\*'
-            - '*\Keyboard Layout\Substitutes\*'
+            - '*\Keyboard Layout\Preload\\*'
+            - '*\Keyboard Layout\Substitutes\\*'
         Details|contains:
             - 00000429  # Persian (Iran)
             - 00050429  # Persian (Iran)


### PR DESCRIPTION
Several fixes for sysmon rules got lost when the rules were refactored to use
categories.

Re-add the fixes.

https://github.com/Neo23x0/sigma/commit/38afd8b5def24191616ff0f0c0324cfbb7f0d6d0

https://github.com/Neo23x0/sigma/commit/422b2bffd77b217e6cec9a67c496b0aa44711ece

https://github.com/Neo23x0/sigma/commit/dfae2a6df6f5bbc90a7b476c22fc9c8fedab47e9