### PR TITLE
STIX backend added including mapping configurations for windows logs and QRadar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ test-sigmac:
 	$(COVERAGE) run -a --include=$(COVSCOPE) tools/sigmac -rvdI -t arcsight -c tools/config/arcsight.yml rules/ > /dev/null
 	$(COVERAGE) run -a --include=$(COVSCOPE) tools/sigmac -rvdI -t arcsight-esm -c tools/config/arcsight.yml rules/ > /dev/null
 	$(COVERAGE) run -a --include=$(COVSCOPE) tools/sigmac -rvdI -t qradar -c tools/config/qradar.yml rules/ > /dev/null
+	$(COVERAGE) run -a --include=$(COVSCOPE) tools/sigmac -rvdI -t stix -c tools/config/stix.yml -c tools/config/stix-qradar.yml -c tools/config/stix-windows.yml rules/ > /dev/null
 	$(COVERAGE) run -a --include=$(COVSCOPE) tools/sigmac -rvdI -t limacharlie -c tools/config/limacharlie.yml rules/ > /dev/null
 	$(COVERAGE) run -a --include=$(COVSCOPE) tools/sigmac -rvdI -t carbonblack -c tools/config/carbon-black.yml rules/ > /dev/null
 	$(COVERAGE) run -a --include=$(COVSCOPE) tools/sigmac -rvdI -t qualys -c tools/config/qualys.yml rules/ > /dev/null

--- a/tools/config/stix-qradar.yml
+++ b/tools/config/stix-qradar.yml
@@ -1,0 +1,51 @@
+title: STIX for QRadar
+backends:
+  - stix
+order: 30
+fieldmappings:
+  categoryid:
+    - x-ibm-ariel:category_id
+  categoryname:
+    - x-ibm-ariel:category_name
+  credescription:
+    - x-ibm-finding:description
+  Description:
+    - x-ibm-finding:description
+  credibility:
+    - x-ibm-ariel:credibility
+  crename:
+    - x-ibm-finding:name
+  devicetype:
+    - x-ibm-ariel:device_type
+  Device:
+    - x-ibm-ariel:device_type
+  direction:
+    - x-ibm-ariel:direction
+  domainid:
+    - x-ibm-ariel:domain_id
+  geographic:
+    - x-ibm-ariel:geographic
+  high_level_category_id:
+    - x-ibm-ariel:high_level_category_id
+  high_level_category_name:
+    - x-ibm-ariel:high_level_category_name
+  identityhostname:
+    - x-ibm-ariel:identity_host_name
+  logsourceid:
+    - x-ibm-ariel:log_source_id
+  logsourcename:
+    - x-ibm-ariel:log_source_name
+  logsourcetypename:
+    - x-ibm-ariel:log_source_type_name
+  magnitude:
+    - x-ibm-ariel:magnitude
+  qid:
+    - x-ibm-ariel:qid
+  qidname:
+    - x-ibm-ariel:event_name
+  relevance:
+    - x-ibm-ariel:relevance
+  rulenames:
+    - x-ibm-ariel:rule_names[*]
+  severity:
+    - x-ibm-ariel:severity

--- a/tools/config/stix-windows.yml
+++ b/tools/config/stix-windows.yml
@@ -1,0 +1,286 @@
+title: STIX for Windows Logs
+backends:
+  - stix
+order: 40
+logsources:
+  windows:
+    product: windows
+fieldmappings:
+  AccessMask:
+    - x-windows:accessmask
+  Accesses:
+    - x-windows:accesses
+  AccountDomain:
+    - user-account:x_domain
+  AccountID:
+    - user-account:user_id
+  AccountName:
+    - user-account:account_login
+    - user-account:display_name
+  AccountSecurityID:
+    - user-account:x_security_id
+  CallTrace:
+    - x-windows:calltrace
+  ChangedAttributes:
+    - x-windows:changedattributes
+  ClientIP:
+    - ipv4-addr:value
+    - ipv6-addr:value
+    - network-traffic:src_ref.value
+  ComputerName:
+    - x-host:name
+  Description:
+    - x-event:action
+  DestinationIsIpv6:
+    - x-windows:destisipv6
+  DestinationHostname:
+    - network-traffic:dst_ref.value
+  Device:
+    - file:name
+  ErrorCode:
+    - x-error:code
+  Event-ID:
+    - x-event:id
+    - x-event:code
+  EventID:
+    - x-event:id
+    - x-event:code
+  Event_ID:
+    - x-event:id
+    - x-event:code
+  EventType:
+    - x-event:action
+  ExtendedErrorCode:
+    - x-error:code
+    - x-error:id
+  FileDirectory:
+    - directory:path
+  FileExtension:
+    - file:x_extension
+  FileHash:
+    - file:hashes.SHA-256
+    - file:hashes.MD5
+    - file:hashes.SHA-1
+  FilePath:
+    - file:name
+  Filename:
+    - file:name
+  GrantedAccess:
+    - x-windows:grantedaccess
+  GroupDomain:
+    - x-group:domain
+  GroupID:
+    - x-group:id
+  GroupName:
+    - x-group:name
+  GroupSecurityID:
+    - x-group:security_id
+  HomeDirectory:
+    - directory:path
+  IMPHash:
+    - x-windows:imphash
+  Imphash:
+    - x-windows:imphash
+  Image:
+    - process:image_ref.name
+  ImageLoadedTempPath:
+    - process:image_ref.x_temp_path
+  ImageName:
+    - process:image_ref.name
+  ImagePath:
+    - process:image_ref.name
+  ImageTempPath:
+    - process:image_ref.x_temp_path
+  InitiatedConnection:
+    - x-windows:initiatedconnection
+  Initiated:
+    - x-windows:initiatedconnection
+  InitiatorUserName:
+    - user-account:user_id
+    - user-account:account_login
+  IntegrityLevel:
+    - x-windows:integrityname
+  LoadedImage:
+    - process:image_ref.name
+  LoadedImageName:
+    - process:image_ref.name
+  LogonType:
+    - x-windows:logontype
+  MD5Hash:
+    - file:hashes.MD5
+  Message:
+    - x-event:original
+  NewName:
+    - windows-registry-key:key
+  ObjectName:
+    - x-windows:objectname
+  ObjectType:
+    - x-windows:objecttype
+  PSEncodedCommand:
+    - x-windows:psencodedcommand
+  ParentCommandLine:
+    - process:parent_ref.command_line
+  ParentImage:
+    - process:parent_ref.image_ref.name
+  ParentImageName:
+    - process:parent_ref.image_ref.name
+  ParentProcessGuid:
+    - process:parent_ref.x_guid
+  ParentProcessName:
+    - process:parent_ref.image_ref.name
+  ParentProcessPath:
+    - process:parent_ref.image_ref.name
+  PipeName:
+    - x-windows:pipename
+  ProcessCommandLine:
+    - process:command_line
+  Command:
+    - process:command_line
+  CommandLine:
+    - process:command_line
+  ProcessGuid:
+    - process:x_guid
+  ProcessId:
+    - process:pid
+  ProcessName:
+    - process:image_ref.name
+  ProcessPath:
+    - process:image_ref.name
+  QueryName:
+    - x-windows:queryname
+  QueryResults:
+    - x-windows:queryresults
+  QueryStatus:
+    - - x-windows:querystatus
+  Realm:
+    - x-windows:realm
+  RecordNumber:
+    - x-windows:recordnumber
+  RegistryKey:
+    - windows-registry-key:key
+  RegistryValueData:
+    - windows-registry-key:values[*].data
+  RegistryValueName:
+    - windows-registry-key:values[*].name
+  RunLevel:
+    - x-windows:runlevel
+  SAMAccountName:
+    - x-windows:samaccountname
+  SHA1Hash:
+    - file:hashes.SHA-1
+  SHA256Hash:
+    - file:hashes.SHA-256
+  Scope:
+    - x-windows:scope
+  ServiceFileName:
+    - process:extensions.windows-service-ext.service_dll_refs[*].name
+  ServiceName:
+    - process:extensions.windows-service-ext.service_name
+  ShareName:
+    - x-windows:sharename
+  SharePath:
+    - x-windows:sharepath
+  Signature:
+    - x-windows:signature
+  SignatureStatus:
+    - x-windows:signaturestatus
+  Signed:
+    - x-windows:signed
+  SourceImage:
+    - x-windows:sourceimage
+  SourceImageTempPath:
+    - x-windows:sourceimagetemppath
+  SourceWorkstation:
+    - x-windows:sourceworkstation
+  StartAddress:
+    - x-windows:startaddress
+  StartFunction:
+    - x-windows:startfunction
+  StartModule:
+    - x-windows:startmodule
+  TargetAccountSecurityID:
+    - x-windows:targetaccountsecurityid
+  TargetComputerDomain:
+    - x-windows:targetcomputerdomain
+  TargetComputerName:
+    - x-windows:targetcomputername
+  TargetDetails:
+    - x-windows:targetdetails
+  Details:
+    - windows-registry-key:values[*].data
+    - x-event:original
+  TargetFilename:
+    - file:name
+  TargetImage:
+    - x-windows:targetimage
+  TargetImageName:
+    - x-windows:targetimagename
+  TargetObject:
+    - windows-registry-key:key
+  TargetProcessGuid:
+    - x-windows:targetprocessguid
+  TargetProcessAddress:
+    - x-windows:targetprocessaddress
+  TargetUserDomain:
+    - x-windows:targetuserdomain
+  TargetUserName:
+    - x-windows:targetusername
+  TaskName:
+    - x-windows:taskname
+  TicketEncryptionType:
+    - x-windows:ticketencryptiontype
+  User:
+    - user-account:user_id
+  UserDomain:
+    - user-account:x_domain
+  UserPrincipalName:
+    - x-windows:userprincipalname
+  UserRight:
+    - x-windows:userright
+  UserWorkstations:
+    - x-windows:userworkstations
+  event-id:
+    - x-event:id
+  eventId:
+    - x-event:id
+  event_data.FileName:
+    - file:name
+  event_data.Image:
+    - process:image_ref.name
+  event_data.ImageLoaded:
+    - process:image_ref.name
+  ImageLoaded:
+    - process:image_ref.name
+  event_data.ImagePath:
+    - process:image_ref.name
+  event_data.ParentCommandLine:
+    - process:parent_ref.command_line
+  event_data.ParentImage:
+    - process:parent_ref.image_ref.name
+  event_data.ParentProcessName:
+    - process:parent_ref.image_ref.name
+  event_data.PipeName:
+    - x-windows:pipename
+  event_data.ServiceFileName:
+    - process:extensions.windows-service-ext.service_dll_refs[*].name
+  event_data.ShareName:
+    - x-windows:sharename
+  event_data.Signature:
+    - x-windows:signature
+  event_data.SourceImage:
+    - x-windows:sourceimage
+  event_data.StartModule:
+    - x-windows:startmodule
+  event_data.SubjectUserName:
+    - user-account:user_id
+    - user-account:account_login
+  event_data.TargetFilename:
+    - file:name
+  event_data.TargetImage:
+    - x-windows:targetimage
+  event_data.User:
+    - user-account:user_id
+  event_id:
+    - x-event:id
+  eventid:
+    - x-event:id

--- a/tools/config/stix.yml
+++ b/tools/config/stix.yml
@@ -1,0 +1,98 @@
+title: Basic STIX
+backends:
+  - stix
+order: 20
+fieldmappings:
+  User:
+    - user-account:user_id
+  c-ip:
+    - ipv4-addr:value
+    - ipv6-addr:value
+    - network-traffic:src_ref.value
+  cs-ip:
+    - ipv4-addr:value
+    - ipv6-addr:value
+    - network-traffic:src_ref.value
+  destinationip:
+    - ipv4-addr:value
+    - ipv6-addr:value
+    - network-traffic:dst_ref.value
+  destinationmac:
+    - mac-addr:value
+    - network-traffic:dst_ref.value
+  destinationport:
+    - network-traffic:dst_port
+  domainname:
+    - domain-name:value
+  dst:
+    - ipv4-addr:value
+    - ipv6-addr:value
+    - network-traffic:dst_ref.value
+  dst_ip:
+    - ipv4-addr:value
+    - ipv6-addr:value
+    - network-traffic:dst_ref.value
+  endtime:
+    - network-traffic:end
+  event_data.DestinationIp:
+    - ipv4-addr:value
+    - ipv6-addr:value
+    - network-traffic:dst_ref.value
+  DestinationIp:
+    - ipv4-addr:value
+    - ipv6-addr:value
+    - network-traffic:dst_ref.value
+  event_data.DestinationPort:
+    - ipv4-addr:value
+    - ipv6-addr:value
+    - network-traffic:dst_ref.value
+  DestinationPort:
+    - ipv4-addr:value
+    - ipv6-addr:value
+    - network-traffic:dst_ref.value
+  event_data.SubjectUserName:
+    - user-account:user_id
+  event_data.User:
+    - user-account:user_id
+  filehash:
+    - file:hashes.SHA-256
+    - file:hashes.MD5
+    - file:hashes.SHA-1
+  filename:
+    - file:name
+  filepath:
+    - file:parent_directory_ref
+    - directory:path
+  identityip:
+    - ipv4-addr:value
+  protocolid:
+    - network-traffic:protocols[*]
+  sourceip:
+    - ipv4-addr:value
+    - ipv6-addr:value
+    - network-traffic:src_ref.value
+  sourcemac:
+    - mac-addr:value
+    - network-traffic:src_ref.value
+  sourceport:
+    - network-traffic:src_port
+  SourcePort:
+    - network-traffic:src_port
+  src:
+    - ipv4-addr:value
+    - ipv6-addr:value
+    - network-traffic:src_ref.value
+  src_ip:
+    - ipv4-addr:value
+    - ipv6-addr:value
+    - network-traffic:src_ref.value
+  starttime:
+    - network-traffic:start
+  url:
+    - url:value
+  user:
+    - user-account:user_id
+  username:
+    - user-account:user_id
+  utf8_payload:
+    - artifact:payload_bin

--- a/tools/sigma/backends/stix.py
+++ b/tools/sigma/backends/stix.py
@@ -1,0 +1,91 @@
+import sigma
+from sigma.parser.modifiers.base import SigmaTypeModifier
+from sigma.parser.modifiers.type import SigmaRegularExpressionModifier
+from .base import SingleTextQueryBackend
+
+
+class STIXBackend(SingleTextQueryBackend):
+    """Converts Sigma rule into STIX pattern."""
+    identifier = "stix"
+    active = True
+    andToken = " AND "
+    orToken = " OR "
+    notToken = "NOT "
+    subExpression = "(%s)"
+    valueExpression = "\'%s\'"
+    mapExpression = "%s = %s"
+    mapListsSpecialHandling = True
+
+    def cleanKey(self, key):
+        if key is None:
+            raise TypeError("Backend does not support empty key " + str(key))
+        else:
+            return key
+
+    def cleanValue(self, value):
+        return value
+
+    def generateMapItemListNode(self, key, value):
+        items_list = list()
+        for item in value:
+            if type(item) == str and "*" in item:
+                item = item.replace("*", "%")
+                items_list.append('%s LIKE %s' % (self.cleanKey(key), self.generateValueNode(item)))
+            else:
+                items_list.append('%s = %s' % (self.cleanKey(key), self.generateValueNode(item)))
+        return '('+" OR ".join(items_list)+')'
+
+    def generateMapItemTypedNode(self, key, value):
+        if type(value) == SigmaRegularExpressionModifier:
+            regex = str(value)
+            # Regular Expressions have to match the full value in QRadar
+            if not (regex.startswith('^') or regex.startswith('.*')):
+                regex = '.*' + regex
+            if not (regex.endswith('$') or regex.endswith('.*')):
+                regex = regex + '.*'
+            return "%s MATCHES %s" % (self.cleanKey(key), self.generateValueNode(regex))
+        else:
+            raise NotImplementedError("Type modifier '{}' is not supported by backend".format(value.identifier))
+
+    def generateMapItemNode(self, node):
+        key, value = node
+        if ":" not in key:
+            raise TypeError("Backend does not support mapping for key " + str(key))
+        if self.mapListsSpecialHandling == False and type(value) in (str, int, list) or self.mapListsSpecialHandling == True and type(value) in (str, int):
+            if type(value) == str and "*" in value:
+                value = value.replace("*", "%")
+                return "%s LIKE %s" % (self.cleanKey(key), self.generateValueNode(value))
+            elif type(value) in (str, int):
+                return self.mapExpression % (self.cleanKey(key), self.generateValueNode(value))
+        elif type(value) == list:
+            return self.generateMapItemListNode(key, value)
+        elif isinstance(value, SigmaTypeModifier):
+            return self.generateMapItemTypedNode(key, value)
+        else:
+            raise TypeError("Backend does not support map values of type " + str(type(value)))
+
+    def generateValueNode(self, node):
+        return self.valueExpression % (self.cleanValue(str(node)))
+
+    def generateNode(self, node):
+        if type(node) == sigma.parser.condition.ConditionAND:
+            return self.generateANDNode(node)
+        elif type(node) == sigma.parser.condition.ConditionOR:
+            return self.generateORNode(node)
+        elif type(node) == sigma.parser.condition.ConditionNOT:
+            return self.generateNOTNode(node)
+        elif type(node) == sigma.parser.condition.NodeSubexpression:
+            return self.generateSubexpressionNode(node)
+        elif type(node) == tuple:
+            return self.generateMapItemNode(node)
+        else:
+            raise TypeError("Node type %s was not expected in Sigma parse tree" % (str(type(node))))
+
+    def generate(self, sigmaparser):
+        for parsed in sigmaparser.condparsed:
+            query = self.generateQuery(parsed, sigmaparser)
+            return "[" + query + "]"
+
+    def generateQuery(self, parsed, sigmaparser):
+        result = self.generateNode(parsed.parsedSearch)
+        return result


### PR DESCRIPTION
Backend for Sigma rules to STIX - Structured Threat Information Expression 2.1 (https://docs.oasis-open.org/cti/stix/v2.1/csprd01/stix-v2.1-csprd01.html)

Including mapping for windows logs fields and QRadar fields

Example sigmac translation:
```
/sigmac -t stix \
> -c stix \
> -c stix-qradar \
> -c stix-windows \
> /rules/windows/sysmon/sysmon_stickykey_like_backdoor.yml
```

```
[((x-event:code = '13' OR x-event:id = '13') AND (windows-registry-key:key LIKE '%\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\sethc.exe\Debugger' OR windows-registry-key:key LIKE '%\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\utilman.exe\Debugger' OR windows-registry-key:key LIKE '%\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\osk.exe\Debugger' OR windows-registry-key:key LIKE '%\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\Magnify.exe\Debugger' OR windows-registry-key:key LIKE '%\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\Narrator.exe\Debugger' OR windows-registry-key:key LIKE '%\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\DisplaySwitch.exe\Debugger') AND x-event:action = 'SetValue')]
[((process:parent_ref.image_ref.name LIKE '%\winlogon.exe') AND (process:command_line LIKE '%cmd.exe sethc.exe %' OR process:command_line LIKE '%cmd.exe utilman.exe %' OR process:command_line LIKE '%cmd.exe osk.exe %' OR process:command_line LIKE '%cmd.exe Magnify.exe %' OR process:command_line LIKE '%cmd.exe Narrator.exe %' OR process:command_line LIKE '%cmd.exe DisplaySwitch.exe %'))]
```
 
