### PR TITLE
Custom STIX object "x-sigma" for fields that missing mapping [stix backend]

### DIFF
--- a/tools/sigma/backends/stix.py
+++ b/tools/sigma/backends/stix.py
@@ -15,6 +15,7 @@ class STIXBackend(SingleTextQueryBackend):
     valueExpression = "\'%s\'"
     mapExpression = "%s = %s"
     mapListsSpecialHandling = True
+    sigmaSTIXObjectName = "x-sigma"
 
     def cleanKey(self, key):
         if key is None:
@@ -50,7 +51,7 @@ class STIXBackend(SingleTextQueryBackend):
     def generateMapItemNode(self, node):
         key, value = node
         if ":" not in key:
-            raise TypeError("Backend does not support mapping for key " + str(key))
+            key = "%s:%s" % (self.sigmaSTIXObjectName, str(key).lower())
         if self.mapListsSpecialHandling == False and type(value) in (str, int, list) or self.mapListsSpecialHandling == True and type(value) in (str, int):
             if type(value) == str and "*" in value:
                 value = value.replace("*", "%")


### PR DESCRIPTION
Custom STIX object "x-sigma" for fields that missing mapping, so the pattern is STIX valid if mapping is missing.
for example `RelativeTargetName` mapping is missing and translated to `x-sigma:relativetargetname`: 
```
[((x-event:id = '5145' OR x-event:code = '5145') AND x-windows:sharename LIKE '\\\\%\\SYSVOL' AND x-sigma:relativetargetname LIKE '%ScheduledTasks.xml' AND x-windows:accesses LIKE '%WriteData%')]
```