### PR TITLE
Added support for Defender's PSExec and WMI ASR rules.

### DIFF
--- a/rules/windows/other/win_defender_psexec_wmi_asr.yml
+++ b/rules/windows/other/win_defender_psexec_wmi_asr.yml
@@ -1,0 +1,29 @@
+title: Process Creations from PSExec and WMI Detected via Attack Surface Reduction
+id: ffa2790e-21f4-90da-dd33-ed8b77a9bf78
+description: Detects blocking of process creations originating from PSExec and WMI commands
+status: experimental
+references:
+    - https://docs.microsoft.com/en-us/windows/security/threat-protection/microsoft-defender-atp/attack-surface-reduction?WT.mc_id=twitter#block-process-creations-originating-from-psexec-and-wmi-commands
+    - https://twitter.com/duff22b/status/1280166329660497920
+author: Bhabesh Raj
+date: 2020/07/14
+tags:
+    - attack.lateral_movement
+    - attack.execution
+    - attack.t1570
+    - attack.t1047
+    - attack.t1569
+    - attack.t1569.002
+logsource:
+    product: windows_defender
+    definition: 'Requirements:Enabled Block process creations originating from PSExec and WMI commands from Attack Surface Reduction (GUID: d1e49aac-8f56-4280-b9ba-993a6d77406c)'
+detection:
+    selection:
+        EventID: 1121
+        ProcessName|endswith:
+          - '\wmiprvse.exe'
+          - '\psexesvc.exe'
+    condition: selection
+falsepositives:
+    - Unknown
+level: high

--- a/rules/windows/other/win_defender_psexec_wmi_asr.yml
+++ b/rules/windows/other/win_defender_psexec_wmi_asr.yml
@@ -9,6 +9,8 @@ author: Bhabesh Raj
 date: 2020/07/14
 tags:
     - attack.execution
+    - attack.lateral_movement
+    - attack.t1570
     - attack.t1047
     - attack.t1569
     - attack.t1569.002

--- a/rules/windows/other/win_defender_psexec_wmi_asr.yml
+++ b/rules/windows/other/win_defender_psexec_wmi_asr.yml
@@ -1,5 +1,5 @@
-title: Process Creations from PSExec and WMI Detected via Attack Surface Reduction
-id: ffa2790e-21f4-90da-dd33-ed8b77a9bf78
+title: PSExec and WMI Process Creations Block
+id: 97b9ce1e-c5ab-11ea-87d0-0242ac130003
 description: Detects blocking of process creations originating from PSExec and WMI commands
 status: experimental
 references:
@@ -8,9 +8,7 @@ references:
 author: Bhabesh Raj
 date: 2020/07/14
 tags:
-    - attack.lateral_movement
     - attack.execution
-    - attack.t1570
     - attack.t1047
     - attack.t1569
     - attack.t1569.002


### PR DESCRIPTION
## Defender's Attack Surface Reduction Rule Name:
Block process creations originating from PSExec and WMI commands
- This rule blocks processes created through PsExec and WMI from running. 