### PR TITLE
Change fitler typo from 'Username' to 'User' for Wmiprvse Spawning Process rule

### DIFF
--- a/rules/windows/process_creation/win_wmiprvse_spawning_process.yml
+++ b/rules/windows/process_creation/win_wmiprvse_spawning_process.yml
@@ -18,7 +18,7 @@ detection:
         ParentImage|endswith: '\WmiPrvSe.exe'
     filter:
         - LogonId: '0x3e7'  # LUID 999 for SYSTEM
-        - Username: 'NT AUTHORITY\SYSTEM'  # if we don't have LogonId data, fallback on username detection
+        - User: 'NT AUTHORITY\SYSTEM'  # if we don't have LogonId data, fallback on username detection
     condition: selection and not filter
 falsepositives:
     - Unknown


### PR DESCRIPTION
Rule Title: Wmiprvse Spawning Process
Rule ID: d21374ff-f574-44a7-9998-4a8c8bf33d7d

This rule has a typo under the detection filter. It is filtering by a 'Username' field when it should be 'User'. Resolving that typo here.