### PR TITLE
Update win_susp_rasdial_activity.yml to use `contains` instead of `equal`

### DIFF
--- a/rules/windows/process_creation/win_susp_rasdial_activity.yml
+++ b/rules/windows/process_creation/win_susp_rasdial_activity.yml
@@ -16,7 +16,7 @@ logsource:
     product: windows
 detection:
     selection:
-        CommandLine:
+        CommandLine|contains:
             - rasdial
     condition: selection
 falsepositives:

--- a/rules/windows/process_creation/win_susp_rasdial_activity.yml
+++ b/rules/windows/process_creation/win_susp_rasdial_activity.yml
@@ -16,8 +16,8 @@ logsource:
     product: windows
 detection:
     selection:
-        CommandLine|contains:
-            - rasdial
+        Image|endswith:
+            - rasdial.exe
     condition: selection
 falsepositives:
     - False positives depend on scripts and administrative tools used in the monitored environment


### PR DESCRIPTION
`rasdial` is an `exe`, and probably appear as `rasdial.exe`
`LIKE` is more fit in this case