### PR TITLE
SIGMA ASEP: remove some false positives

### DIFF
--- a/rules/windows/registry_event/sysmon_asep_reg_keys_modification.yml
+++ b/rules/windows/registry_event/sysmon_asep_reg_keys_modification.yml
@@ -8,7 +8,7 @@ tags:
     - attack.persistence
     - attack.t1060
 date: 2019/10/21
-modified: 2019/11/10
+modified: 2020/08/18
 author: Victor Sergeev, Daniil Yugoslavskiy, oscd.community
 logsource:
     category: registry_event
@@ -23,7 +23,12 @@ detection:
             - '\software\Microsoft\Windows\CurrentVersion\RunServicesOnce'
             - '\software\Microsoft\Windows NT\CurrentVersion\Winlogon\Userinit'
             - '\software\Microsoft\Windows NT\CurrentVersion\Winlogon\Shell'
-            - '\software\Microsoft\Windows NT\CurrentVersion\Windows'
+            - '\software\Microsoft\Windows NT\CurrentVersion\Windows\AppInit_DLLs'  # Appinit DLL
+            - '\software\Wow6432Node\Microsoft\Windows NT\CurrentVersion\Windows\AppInit_DLLs'  # Appinit DLL
+            - '\software\Microsoft\Windows NT\CurrentVersion\Windows\Load'  # WindowsShellLoadAndRun in HKCU
+            - '\software\Wow6432Node\Microsoft\Windows NT\CurrentVersion\Windows\Load'  # WindowsShellLoadAndRun in HKCU
+            - '\software\Microsoft\Windows NT\CurrentVersion\Windows\Run'  # WindowsShellLoadAndRun in HKCU
+            - '\software\Wow6432Node\Microsoft\Windows NT\CurrentVersion\Windows\Run'  # WindowsShellLoadAndRun in HKCU
             - '\software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders'
     condition: selection
 falsepositives:


### PR DESCRIPTION
remove false positives in Windows being too broad and add specific keys looked at + add keys from wow64

Encountered some false positives with keys being "\software\Microsoft\Windows NT\CurrentVersion\Windows XX\YY\ZZ" but can't recall the exact details, so only look for persistence methods in Windows being appinit DLL + WindowsShellLoadAndRun