### PR TITLE
added troubleshooting links to root README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ Florian wrote a short [rule creation tutorial](https://www.nextron-systems.com/2
 5. Convert a whole rule directory with `python sigmac -t splunk -r ../rules/proxy/`
 6. Check the `./tools/config` folder and the [wiki](https://github.com/Neo23x0/sigma/wiki/Converter-Tool-Sigmac) if you need custom field or log source mappings in your environment
 
+## Troubles / Troubleshooting / Help
+
+If you need help for a specific supported backend you can use e.g. `sigmac --backend-help elastalert-dsl`. More details on the usage of `sigmac` can be found in the dedicated [README.md](https://github.com/Neo23x0/sigma/blob/master/tools/README.md).
+
+Be sure to checkout the [guidance on backend specific settings](https://github.com/Neo23x0/sigma/blob/master/tools/README.md#choosing-the-right-sigmac) for `sigmac`.
+
 # Examples
 
 Windows 'Security' Eventlog: Access to LSASS Process with Certain Access Mask / Object Type (experimental)


### PR DESCRIPTION
I suspect this [pull request](https://github.com/Neo23x0/sigma/pull/659) mentioned in [this issue](https://github.com/Neo23x0/sigma/issues/194) actually fixes elasticsearch the field problems. I got my problems solved by following the configuration suggestions in the conversation https://github.com/Neo23x0/sigma/pull/659#issue-386776046. 

Furthermore I just found out, that there is an option for showing the available backend options (`--backend-help`). I did not know this was there.

Additionally there exists a [README.md](https://github.com/Neo23x0/sigma/blob/master/tools/README.md) in the `tools/` folder that also describes specific settings for ECS and Elastic beats. Sadly I did not find any of this until now, because I just used `sigmac` via `pip`.

So I created this pull requests to document / link some relevant information points in the root README.md under the section _Getting Started_.