### PR TITLE
+ Adding exclusion for Azure AD Sync (MSOL_xxxxxxxx)

### DIFF
--- a/rules/windows/builtin/win_dcsync.yml
+++ b/rules/windows/builtin/win_dcsync.yml
@@ -3,8 +3,8 @@ id: 611eab06-a145-4dfa-a295-3ccc5c20f59a
 description: Detects Mimikatz DC sync security events
 status: experimental
 date: 2018/06/03
-modified: 2019/10/08
-author: Benjamin Delpy, Florian Roth
+modified: 2020/09/11
+author: Benjamin Delpy, Florian Roth, Scott Dermott
 references:
     - https://twitter.com/gentilkiwi/status/1003236624925413376
     - https://gist.github.com/gentilkiwi/dcc132457408cf11ad2061340dcb53c2
@@ -28,6 +28,7 @@ detection:
         SubjectUserName:
             - 'NT AUTHORITY*'
             - '*$'
+            - 'MSOL_*'
     condition: selection and not filter1 and not filter2
 falsepositives:
     - Valid DC Sync that is not covered by the filters; please report


### PR DESCRIPTION
AD Connect on premise AD accounts to Azure AD.  The replication process is completed under the context of the 'MSOL_xxxxxxxx' user account.  The AD Connect application is installed on a member server (i.e. not on a DC).  
https://techcommunity.microsoft.com/t5/azure-advanced-threat-protection/ad-connect-msol-user-suspected-dcsync-attack/m-p/788028
# Further Reading
https://blog.xpnsec.com/azuread-connect-for-redteam/