### PR TITLE
Added win_vul_cve_2020_1472 rule

### DIFF
--- a/rules/windows/builtin/win_vul_cve_2020_1472.yml
+++ b/rules/windows/builtin/win_vul_cve_2020_1472.yml
@@ -1,0 +1,23 @@
+title: Vulnerable Netlogon Secure Channel Connection Allowed
+id: a0cb7110-edf0-47a4-9177-541a4083128a
+status: experimental
+description: Detects that a vulnerable Netlogon secure channel connection was allowed, which could be an indicator of CVE-2020-1472.
+references:
+    - https://support.microsoft.com/en-us/help/4557222/how-to-manage-the-changes-in-netlogon-secure-channel-connections-assoc
+author: NVISO
+date: 2020/09/15
+tags:
+    - attack.privilege_escalation
+logsource:
+    product: windows
+    service: system
+detection:
+    selection:
+        EventID:
+            - 5829
+    condition: selection
+fields:
+    - SAMAccountName
+falsepositives:
+    - Unknown
+level: high


### PR DESCRIPTION
From Microsoft's own [documentation](https://support.microsoft.com/en-gb/help/4557222/how-to-manage-the-changes-in-netlogon-secure-channel-connections-assoc):
> After the August 11, 2020 updates have been applied to DCs, events can be collected in DC event logs to determine which devices in your environment are using vulnerable Netlogon secure channel connections (referred to as non-compliant devices in this article). Monitor patched DCs for event ID 5829 events.

This rule triggers on the events that are now generated to detect vulnerable devices.