### PR TITLE
COM hijack & UAC bypass via Sdclt

### DIFF
--- a/rules/windows/registry_event/sysmon_comhijack_sdclt.yml
+++ b/rules/windows/registry_event/sysmon_comhijack_sdclt.yml
@@ -1,4 +1,4 @@
-title: com hijack & uac bypass via sdclt
+title: COM hijack via Sdclt
 id: 07743f65-7ec9-404a-a519-913db7118a8d
 status: experimental
 description: Detects changes to 'HKCU\Software\Classes\Folder\shell\open\command\DelegateExecute'
@@ -7,8 +7,8 @@ references:
     - https://www.exploit-db.com/exploits/47696
 tags:
     - attack.privilege_escalation
-    - attack.T1546
-    - attack.T1548
+    - attack.t1546
+    - attack.t1548
 author: Omkar Gudhate
 date: 2020/09/27
 logsource:

--- a/rules/windows/registry_event/sysmon_comhijack_uac_bypass.yml
+++ b/rules/windows/registry_event/sysmon_comhijack_uac_bypass.yml
@@ -1,0 +1,25 @@
+title: COM hijack & UAC bypass via Sdclt
+status: experimental
+description: Detects changes to 'HKCU\Software\Classes\Folder\shell\open\command\DelegateExecute'
+references:
+    - http://blog.sevagas.com/?Yet-another-sdclt-UAC-bypass
+    - https://www.exploit-db.com/exploits/47696
+author: Omkar Gudhate
+date: 2020/09/27
+logsource:
+    category: registry_event
+    product: windows
+detection:
+    selection:
+        TargetObject:
+            - 'HKCU\Software\Classes\Folder\shell\open\command\DelegateExecute'
+            - 'HKCU\Software\Classes\Folder\shell\open\command'
+    condition: selection
+tags:
+    - attack.defense_evasion
+    - attack.privilege_escalation
+    - attack.T1546.015
+    - attack.T1548.002
+falsepositives:
+    - unknown
+level: high

--- a/rules/windows/registry_event/sysmon_comhijack_uac_bypass.yml
+++ b/rules/windows/registry_event/sysmon_comhijack_uac_bypass.yml
@@ -1,9 +1,14 @@
-title: COM hijack & UAC bypass via Sdclt
+title: com hijack & uac bypass via sdclt
+id: 07743f65-7ec9-404a-a519-913db7118a8d
 status: experimental
 description: Detects changes to 'HKCU\Software\Classes\Folder\shell\open\command\DelegateExecute'
 references:
     - http://blog.sevagas.com/?Yet-another-sdclt-UAC-bypass
     - https://www.exploit-db.com/exploits/47696
+tags:
+    - attack.privilege_escalation
+    - attack.T1546
+    - attack.T1548
 author: Omkar Gudhate
 date: 2020/09/27
 logsource:
@@ -15,11 +20,6 @@ detection:
             - 'HKCU\Software\Classes\Folder\shell\open\command\DelegateExecute'
             - 'HKCU\Software\Classes\Folder\shell\open\command'
     condition: selection
-tags:
-    - attack.defense_evasion
-    - attack.privilege_escalation
-    - attack.T1546.015
-    - attack.T1548.002
 falsepositives:
     - unknown
 level: high


### PR DESCRIPTION
Adding shell folder registry key with application to execute can bypass UAC and work in high integrity context. Rule will monitor creation of registry key