### PR TITLE
[OSCD] Create win_susp_logon_explicit_credentials.yml

### DIFF
--- a/rules/windows/builtin/win_susp_logon_explicit_credentials.yml
+++ b/rules/windows/builtin/win_susp_logon_explicit_credentials.yml
@@ -23,7 +23,6 @@ detection:
             - '\net.exe'
             - '\net1.exe'
             - '\reg.exe'
-            - '\winrs.exe'
     filter:
         Target_Server_Name: 'localhost'
     condition: selection and not filter

--- a/rules/windows/builtin/win_susp_logon_explicit_credentials.yml
+++ b/rules/windows/builtin/win_susp_logon_explicit_credentials.yml
@@ -1,0 +1,31 @@
+title: Suspicous Logon with Explicit Credentials
+id: 941e5c45-cda7-4864-8cea-bbb7458d194a
+status: experimental
+description: Detects the attack technique pass the hash which is used to move laterally inside the network
+references:
+    - https://drive.google.com/file/d/1lKya3_mLnR3UQuCoiYruO3qgu052_iS_/view
+author: Teymur Kheirkhabarov '@HeirhabarovT', Zach '@svch0st'
+date: 2020/10/05
+tags:
+logsource:
+    product: windows
+    service: security
+    definition: 
+detection:
+    selection:
+        EventID: 4648
+        Image|endswith:
+            - '\cmd.exe'
+            - '\powershell.exe'
+            - '\pwsh.exe'
+            - '\winrs.exe'
+            - '\wmic.exe'
+            - '\net.exe'
+            - '\net1.exe'
+            - '\reg.exe'
+            - '\winrs.exe'
+    filter:
+        Target_Server_Name: 'localhost'
+    condition: selection and not filter
+falsepositives:
+level: medium

--- a/rules/windows/builtin/win_susp_logon_explicit_credentials.yml
+++ b/rules/windows/builtin/win_susp_logon_explicit_credentials.yml
@@ -4,7 +4,7 @@ status: experimental
 description: Detects suspicious processes logging on with explicit credentials
 references:
     - https://drive.google.com/file/d/1lKya3_mLnR3UQuCoiYruO3qgu052_iS_/view
-author: Teymur Kheirkhabarov '@HeirhabarovT', Zach Stanford '@svch0st'
+author: 'oscd.community, Teymur Kheirkhabarov @HeirhabarovT, Zach Stanford @svch0st'
 date: 2020/10/05
 tags:
 logsource:

--- a/rules/windows/builtin/win_susp_logon_explicit_credentials.yml
+++ b/rules/windows/builtin/win_susp_logon_explicit_credentials.yml
@@ -1,10 +1,10 @@
-title: Suspicous Logon with Explicit Credentials
+title: Suspicous Remote Logon with Explicit Credentials
 id: 941e5c45-cda7-4864-8cea-bbb7458d194a
 status: experimental
-description: Detects the attack technique pass the hash which is used to move laterally inside the network
+description: Detects suspicious processes logging on with explicit credentials
 references:
     - https://drive.google.com/file/d/1lKya3_mLnR3UQuCoiYruO3qgu052_iS_/view
-author: Teymur Kheirkhabarov '@HeirhabarovT', Zach '@svch0st'
+author: Teymur Kheirkhabarov '@HeirhabarovT', Zach Stanford '@svch0st'
 date: 2020/10/05
 tags:
 logsource:
@@ -28,4 +28,5 @@ detection:
         Target_Server_Name: 'localhost'
     condition: selection and not filter
 falsepositives:
+    - Administrators that use the RunAS command or scheduled tasks
 level: medium


### PR DESCRIPTION
Part of oscd sprint 2 - https://github.com/Neo23x0/sigma/issues/576

Sigmac Testing:
`❯ python .\sigmac -t splunk -c .\config\splunk-windows.yml ..\rules\windows\builtin\win_susp_logon_explicit_credentials.yml
(source="WinEventLog:Security" (EventCode="4648" (Image="*\\cmd.exe" OR Image="*\\powershell.exe" OR Image="*\\pwsh.exe" OR Image="*\\winrs.exe" OR Image="*\\wmic.exe" OR Image="*\\net.exe" OR Image="*\\net1.exe" OR Image="*\\reg.exe" OR Image="*\\winrs.exe")) NOT (Target_Server_Name="localhost"))`