### PR TITLE
[OSCD] Create win_susp_mounted_share_deletion.yml

### DIFF
--- a/rules/windows/process_creation/win_susp_mounted_share_deletion.yml
+++ b/rules/windows/process_creation/win_susp_mounted_share_deletion.yml
@@ -1,0 +1,25 @@
+title: Mounted Share was Deleted
+id: cb7c4a03-2871-43c0-9bbb-18bbdb079896
+status: experimental
+description: Detects when when a mounted share is removed. Adversaries may remove share connections that are no longer useful in order to clean up traces of their operation
+references:
+    - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1070.005/T1070.005.md
+author: 'oscd.community, @redcanary, Zach Stanford @svch0st'
+date: 2020/10/08
+tags:
+    - attack.defense_evasion
+    - attack.t1070.005
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        Image|endswith:
+            - '\net.exe'
+            - '\net1.exe'
+        CommandLine|contains:
+            - '/delete'
+    condition: selection
+falsepositives:
+    - Administrators or Power users may remove their shares via cmd line
+level: medium

--- a/rules/windows/process_creation/win_susp_mounted_share_deletion.yml
+++ b/rules/windows/process_creation/win_susp_mounted_share_deletion.yml
@@ -1,4 +1,4 @@
-title: Mounted Share was Deleted
+title: Mounted Share Deleted
 id: cb7c4a03-2871-43c0-9bbb-18bbdb079896
 status: experimental
 description: Detects when when a mounted share is removed. Adversaries may remove share connections that are no longer useful in order to clean up traces of their operation

--- a/rules/windows/process_creation/win_susp_mounted_share_deletion.yml
+++ b/rules/windows/process_creation/win_susp_mounted_share_deletion.yml
@@ -16,7 +16,8 @@ detection:
     selection:
         ParentImage|endswith: '\net.exe'
         Image|endswith: '\net1.exe'
-        CommandLine|contains:
+        CommandLine|contains|all:
+            - 'share'
             - '/delete'
     condition: selection
 falsepositives:

--- a/rules/windows/process_creation/win_susp_mounted_share_deletion.yml
+++ b/rules/windows/process_creation/win_susp_mounted_share_deletion.yml
@@ -14,9 +14,8 @@ logsource:
     product: windows
 detection:
     selection:
-        Image|endswith:
-            - '\net.exe'
-            - '\net1.exe'
+        ParentImage|endswith: '\net.exe'
+        Image|endswith: '\net1.exe'
         CommandLine|contains:
             - '/delete'
     condition: selection


### PR DESCRIPTION
OSCD Sprint 2 Atomic Red Team Windows - #1013 item 6 - T1070.005: Network Share Connection Removal (one process_creation rule and one PowerShell rule)

Sigmac Test:
`❯ python .\sigmac -t splunk -c .\config\splunk-windows.yml ..\rules\windows\process_creation\win_susp_mounted_share_deletion.yml
((Image="*\\net.exe" OR Image="*\\net1.exe") (CommandLine="*/delete*"))`