### PR TITLE
[OSCD] Too Long Powershell CommandLine Rule added

### DIFF
--- a/rules/windows/process_creation/sysmon_long_powershell_commandline.yml
+++ b/rules/windows/process_creation/sysmon_long_powershell_commandline.yml
@@ -1,0 +1,28 @@
+title: Too Long PowerShell Commandlines
+id: 3f07b9d1-2082-4c56-9277-613a621983cc
+description: Detects Too long PowerShell command lines
+references:
+    - https://speakerdeck.com/heirhabarov/hunting-for-powershell-abuse
+tags:
+    - attack.execution
+    - attack.t1059.001
+status: experimental
+author: oscd.community, Natalia Shornikova
+date: 2020/10/06
+logsource:
+    product: windows
+    service: sysmon
+detection:
+    selection:
+      EventID: 1
+    Powershell_selection:
+      - CommandLine: 
+        - '*powershell*'
+        - '*pwsh*'
+      - Description: 'Windows Powershell'
+      - Product: 'PowerShell Core 6'
+    Length_selection|re:
+      CommandLine: '(.){1000,}'
+    condition: all of them
+falsepositives: Unknown
+level: medium

--- a/rules/windows/process_creation/sysmon_long_powershell_commandline.yml
+++ b/rules/windows/process_creation/sysmon_long_powershell_commandline.yml
@@ -10,8 +10,8 @@ status: experimental
 author: oscd.community, Natalia Shornikova
 date: 2020/10/06
 logsource:
-    product: windows 
     category: process_creation
+    product: windows
 detection:
     selection:
       EventID: 1

--- a/rules/windows/process_creation/sysmon_long_powershell_commandline.yml
+++ b/rules/windows/process_creation/sysmon_long_powershell_commandline.yml
@@ -1,5 +1,5 @@
 title: Too Long PowerShell Commandlines
-id: 3f07b9d1-2082-4c56-9277-613a621983cc
+id: d0d28567-4b9a-45e2-8bbc-fb1b66a1f7f6
 description: Detects Too long PowerShell command lines
 references:
     - https://speakerdeck.com/heirhabarov/hunting-for-powershell-abuse
@@ -14,13 +14,13 @@ logsource:
     product: windows
 detection:
     Powershell_selection:
-      - CommandLine: 
-        - '*powershell*'
-        - '*pwsh*'
+      - CommandLine|contains: 
+        - 'powershell'
+        - 'pwsh'
       - Description: 'Windows Powershell'
       - Product: 'PowerShell Core 6'
-    Length_selection|re:
-      CommandLine: '(.){1000,}'
+    Length_selection:
+      CommandLine|re: '(.){1000,}'
     condition: all of them
 falsepositives: Unknown
 level: medium

--- a/rules/windows/process_creation/sysmon_long_powershell_commandline.yml
+++ b/rules/windows/process_creation/sysmon_long_powershell_commandline.yml
@@ -13,8 +13,6 @@ logsource:
     category: process_creation
     product: windows
 detection:
-    selection:
-      EventID: 1
     Powershell_selection:
       - CommandLine: 
         - '*powershell*'

--- a/rules/windows/process_creation/sysmon_long_powershell_commandline.yml
+++ b/rules/windows/process_creation/sysmon_long_powershell_commandline.yml
@@ -10,8 +10,8 @@ status: experimental
 author: oscd.community, Natalia Shornikova
 date: 2020/10/06
 logsource:
-    product: windows
-    service: sysmon
+    product: windows 
+    category: process_creation
 detection:
     selection:
       EventID: 1


### PR DESCRIPTION
[OSCD Initiative] Develop Sigma rules for PowerShell Abuse #575: Task #67 (Too long PowerShell command lines).