### PR TITLE
[OSCD] UAC bypass added

### DIFF
--- a/rules/windows/image_load/sysmon_uac_bypass_via_dism.yml
+++ b/rules/windows/image_load/sysmon_uac_bypass_via_dism.yml
@@ -1,7 +1,7 @@
 title: UAC Bypass With Fake DLL
 id: a5ea83a7-05a5-44c1-be2e-addccbbd8c03
 status: experimental
-description: Attempts to load dismcore.dll after dropping it.
+description: Attempts to load dismcore.dll after dropping it
 references:
     - https://steemit.com/utopian-io/@ah101/uac-bypassing-utility
 tags:

--- a/rules/windows/image_load/sysmon_uac_bypass_via_dism.yml
+++ b/rules/windows/image_load/sysmon_uac_bypass_via_dism.yml
@@ -17,10 +17,13 @@ logsource:
     product: windows     
 detection:
     selection:
-        Image:
+        Image|endswith:
             - '\dism.exe'
-        ImageLoaded:
+        ImageLoaded|endswith:
             - '\dismcore.dll'
+    filter:
+        ImageLoaded:
+            - 'C:\Windows\System32\Dism\dismcore.dll'
     condition: selection
 falsepositives:
     - Pentests

--- a/rules/windows/image_load/sysmon_uac_bypass_via_dism.yml
+++ b/rules/windows/image_load/sysmon_uac_bypass_via_dism.yml
@@ -1,0 +1,28 @@
+title: UAC bypass with fake dll
+id: a5ea83a7-05a5-44c1-be2e-addccbbd8c03
+status: experimental
+description: Attempts to load dismcore.dll after dropping it.
+references:
+    - https://steemit.com/utopian-io/@ah101/uac-bypassing-utility
+tags:
+    - attack.persistence
+    - attack.defense_evasion
+    - attack.privilege_escalation
+    - attack.t1548.002
+    - attack.t1574.002
+author: oscd.community, Dmitry Uchakin
+date: 2020/10/06
+logsource:               
+    category: image_load 
+    product: windows     
+detection:
+    selection:
+        Image:
+            - '\dism.exe'
+        ImageLoaded:
+            - '\dismcore.dll'
+    condition: selection
+falsepositives:
+    - Pentests
+    - Actions of a legitimate telnet client
+level: high

--- a/rules/windows/image_load/sysmon_uac_bypass_via_dism.yml
+++ b/rules/windows/image_load/sysmon_uac_bypass_via_dism.yml
@@ -1,4 +1,4 @@
-title: UAC bypass with fake dll
+title: UAC Bypass With Fake DLL
 id: a5ea83a7-05a5-44c1-be2e-addccbbd8c03
 status: experimental
 description: Attempts to load dismcore.dll after dropping it.

--- a/rules/windows/process_access/sysmon_load_undocumented_autoelevated_com_interface.yml
+++ b/rules/windows/process_access/sysmon_load_undocumented_autoelevated_com_interface.yml
@@ -16,7 +16,7 @@ logsource:
     product: windows        
 detection:
     selection:
-        CallTrace|contains: '*editionupgrademanagerobj.dll*'
+        CallTrace|contains: 'editionupgrademanagerobj.dll'
     condition: selection
 fields:
     - ComputerName

--- a/rules/windows/process_access/sysmon_load_undocumented_autoelevated_com_interface.yml
+++ b/rules/windows/process_access/sysmon_load_undocumented_autoelevated_com_interface.yml
@@ -1,0 +1,29 @@
+title: load undocumented autoelevated com interface
+id: fb3722e4-1a06-46b6-b772-253e2e7db933
+status: experimental
+description: COM interface (EditionUpgradeManager) that is not used by standard executables.
+references:
+    - https://www.snip2code.com/Snippet/4397378/UAC-bypass-using-EditionUpgradeManager-C/ 
+    - https://gist.github.com/hfiref0x/de9c83966623236f5ebf8d9ae2407611
+tags:
+    - attack.defense_evasion
+    - attack.privilege_escalation
+    - attack.t1548.002
+author: oscd.community, Dmitry Uchakin
+date: 2020/10/07
+logsource:                  
+    category: process_access
+    product: windows        
+detection:
+    selection:
+        CallTrace: '*editionupgrademanagerobj.dll*'
+    condition: selection
+fields:
+    - ComputerName
+    - User
+    - SourceImage
+    - TargetImage
+    - CallTrace
+falsepositives:
+    - unknown
+level: high

--- a/rules/windows/process_access/sysmon_load_undocumented_autoelevated_com_interface.yml
+++ b/rules/windows/process_access/sysmon_load_undocumented_autoelevated_com_interface.yml
@@ -1,4 +1,4 @@
-title: load undocumented autoelevated com interface
+title: Load Undocumented Autoelevated COM Interface
 id: fb3722e4-1a06-46b6-b772-253e2e7db933
 status: experimental
 description: COM interface (EditionUpgradeManager) that is not used by standard executables.

--- a/rules/windows/process_access/sysmon_load_undocumented_autoelevated_com_interface.yml
+++ b/rules/windows/process_access/sysmon_load_undocumented_autoelevated_com_interface.yml
@@ -16,7 +16,7 @@ logsource:
     product: windows        
 detection:
     selection:
-        CallTrace: '*editionupgrademanagerobj.dll*'
+        CallTrace|contains: '*editionupgrademanagerobj.dll*'
     condition: selection
 fields:
     - ComputerName

--- a/rules/windows/registry_event/sysmon_bypass_via_wsreset.yml
+++ b/rules/windows/registry_event/sysmon_bypass_via_wsreset.yml
@@ -5,7 +5,6 @@ description: Unfixed method for UAC bypass from windows 10. WSReset.exe file ass
 references:
     - https://www.bleepingcomputer.com/news/security/trickbot-uses-a-new-windows-10-uac-bypass-to-launch-quietly
     - https://lolbas-project.github.io/lolbas/Binaries/Wsreset
-    
 tags:
     - attack.defense_evasion
     - attack.privilege_escalation

--- a/rules/windows/registry_event/sysmon_bypass_via_wsreset.yml
+++ b/rules/windows/registry_event/sysmon_bypass_via_wsreset.yml
@@ -1,4 +1,4 @@
-title: UAC bypass via wsreset
+title: UAC Bypass Via Wsreset
 id: 6ea3bf32-9680-422d-9f50-e90716b12a66
 status: experimental
 description: Unfixed method for UAC bypass from windows 10. WSReset.exe file associated with the Windows Store. It will run a binary file contained in a low-privilege registry.

--- a/rules/windows/registry_event/sysmon_bypass_via_wsreset.yml
+++ b/rules/windows/registry_event/sysmon_bypass_via_wsreset.yml
@@ -1,0 +1,30 @@
+title: UAC bypass via wsreset
+id: 6ea3bf32-9680-422d-9f50-e90716b12a66
+status: experimental
+description: Unfixed method for UAC bypass from windows 10. WSReset.exe file associated with the Windows Store. It will run a binary file contained in a low-privilege registry.
+references:
+    - https://www.bleepingcomputer.com/news/security/trickbot-uses-a-new-windows-10-uac-bypass-to-launch-quietly
+    - https://lolbas-project.github.io/lolbas/Binaries/Wsreset
+    
+tags:
+    - attack.defense_evasion
+    - attack.privilege_escalation
+    - attack.t1548.002
+author: oscd.community, Dmitry Uchakin
+date: 2020/10/07
+logsource:
+    category: registry_event
+    product: windows
+detection:
+    selection:
+        TargetObject|endswith:
+            - '\AppX82a6gwre4fdg3bt635tn5ctqjf8msdd2\Shell\open\command'
+    condition: selection
+fields:
+    - ComputerName
+    - Image
+    - EventType
+    - TargetObject
+falsepositives:
+    - unknown
+level: high


### PR DESCRIPTION
Using UAC bypass is a good way to detect malicious actions. Despite the simplicity of this mechanism, it can be used like an IOC.

3 rules.