### PR TITLE
[OSCD] Detects Obfuscated Powershell via use Rundll32 in Scripts #30 (4104, 4103)

### DIFF
--- a/rules/windows/powershell/powershell_invoke_obfuscation_via_use_rundll32.yml
+++ b/rules/windows/powershell/powershell_invoke_obfuscation_via_use_rundll32.yml
@@ -1,0 +1,28 @@
+title: Invoke-Obfuscation Via Use Rundll32
+id: a5a30a6e-75ca-4233-8b8c-42e0f2037d3b
+description: Detects Obfuscated Powershell via use Rundll32 in Scripts
+status: experimental
+author: Nikita Nazarov, oscd.community
+date: 2019/10/08
+references: https://github.com/Neo23x0/sigma/issues/1009
+tags:
+    - attack.defense_evasion
+    - attack.t1027
+    - attack.execution
+    - attack.t1059.001
+logsource:
+    product: windows
+    service: powershell
+detection:
+    selection_1:
+        EventID: 4104
+    selection_2:
+        - ScriptBlockText|re: '(?i).*downloadstring&&.*rundll32.*powershell.*(value|invoke|comspec|iex).*"'
+    selection_3:
+        EventID: 4103
+    selection_4:
+        - Payload|re: '(?i).*downloadstring&&.*rundll32.*powershell.*(value|invoke|comspec|iex).*"'
+    condition: ( selection_1 and selection_2 ) or ( selection_3 and selection_4 )
+falsepositives:
+    - Unknown
+level: high

--- a/rules/windows/powershell/powershell_invoke_obfuscation_via_use_rundll32.yml
+++ b/rules/windows/powershell/powershell_invoke_obfuscation_via_use_rundll32.yml
@@ -4,7 +4,7 @@ description: Detects Obfuscated Powershell via use Rundll32 in Scripts
 status: experimental
 author: Nikita Nazarov, oscd.community
 date: 2019/10/08
-references: -https://github.com/Neo23x0/sigma/issues/1009
+references: - https://github.com/Neo23x0/sigma/issues/1009
 tags:
     - attack.defense_evasion
     - attack.t1027

--- a/rules/windows/powershell/powershell_invoke_obfuscation_via_use_rundll32.yml
+++ b/rules/windows/powershell/powershell_invoke_obfuscation_via_use_rundll32.yml
@@ -4,7 +4,8 @@ description: Detects Obfuscated Powershell via use Rundll32 in Scripts
 status: experimental
 author: Nikita Nazarov, oscd.community
 date: 2019/10/08
-references: - https://github.com/Neo23x0/sigma/issues/1009
+references: 
+    - https://github.com/Neo23x0/sigma/issues/1009
 tags:
     - attack.defense_evasion
     - attack.t1027

--- a/rules/windows/powershell/powershell_invoke_obfuscation_via_use_rundll32.yml
+++ b/rules/windows/powershell/powershell_invoke_obfuscation_via_use_rundll32.yml
@@ -18,11 +18,11 @@ detection:
     selection_1:
         EventID: 4104
     selection_2:
-        - ScriptBlockText|re: '(?i).*downloadstring&&.*rundll32.*powershell.*(value|invoke|comspec|iex).*"'
+        - ScriptBlockText|re: '(?i).*&&.*rundll32.*shell32\.dll.*shellexec_rundll.*(value|invoke|comspec|iex).*"'
     selection_3:
         EventID: 4103
     selection_4:
-        - Payload|re: '(?i).*downloadstring&&.*rundll32.*powershell.*(value|invoke|comspec|iex).*"'
+        - Payload|re: '(?i).*&&.*rundll32.*shell32\.dll.*shellexec_rundll.*(value|invoke|comspec|iex).*"'
     condition: ( selection_1 and selection_2 ) or ( selection_3 and selection_4 )
 falsepositives:
     - Unknown

--- a/rules/windows/powershell/powershell_invoke_obfuscation_via_use_rundll32.yml
+++ b/rules/windows/powershell/powershell_invoke_obfuscation_via_use_rundll32.yml
@@ -4,7 +4,7 @@ description: Detects Obfuscated Powershell via use Rundll32 in Scripts
 status: experimental
 author: Nikita Nazarov, oscd.community
 date: 2019/10/08
-references: https://github.com/Neo23x0/sigma/issues/1009
+references: -https://github.com/Neo23x0/sigma/issues/1009
 tags:
     - attack.defense_evasion
     - attack.t1027


### PR DESCRIPTION
Made it a single regular expression. 
In the first version (?i).*?cmd.*\/c\s*"set\s+.*downloadstring&&.*rundll32.*powershell.*(value|invoke|comspec|iex).*" , but I changed it because the script can be of this type: 
'Invoke-Expression (New-Object Net.WebClient).DownloadString&&RuNdll32 SHELL32.DLL ShellExec_RunDLL "PoWERsheLl" " -noPRoFIL " " ( ^& ( '{1}{2}{3}{0}' -f 'eM','GE','t-child','IT' ) ( '{0}{1}' -f'E','nV:igFm' ) ).'VAlUE' ^| . ( '{1}{0}'-f 'x','ie')"'
And i add in regular 'iex' because 'invoke' could be different.