### PR TITLE
[OSCD] Detects Obfuscated Powershell via use Rundll32 in Scripts #30 (process_creation) 

### DIFF
--- a/rules/windows/process_creation/win_invoke_obfuscation_via_use_rundll32.yml
+++ b/rules/windows/process_creation/win_invoke_obfuscation_via_use_rundll32.yml
@@ -1,0 +1,23 @@
+title: Invoke-Obfuscation Via Use Rundll32
+id: 36c5146c-d127-4f85-8e21-01bf62355d5a
+description: Detects Obfuscated Powershell via use Rundll32 in Scripts
+status: experimental
+author: Nikita Nazarov, oscd.community
+date: 2019/10/08
+references:
+    - https://github.com/Neo23x0/sigma/issues/1009
+tags:
+    - attack.defense_evasion
+    - attack.t1027
+    - attack.execution
+    - attack.t1059.001
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        - CommandLine|re: '(?i).*downloadstring&&.*rundll32.*powershell.*(value|invoke|comspec|iex).*"'
+    condition: selection
+falsepositives:
+    - Unknown
+level: high

--- a/rules/windows/process_creation/win_invoke_obfuscation_via_use_rundll32.yml
+++ b/rules/windows/process_creation/win_invoke_obfuscation_via_use_rundll32.yml
@@ -16,7 +16,7 @@ logsource:
     product: windows
 detection:
     selection:
-        - CommandLine|re: '(?i).*downloadstring&&.*rundll32.*powershell.*(value|invoke|comspec|iex).*"'
+        - CommandLine|re: '(?i).*&&.*rundll32.*shell32\.dll.*shellexec_rundll.*(value|invoke|comspec|iex).*"'
     condition: selection
 falsepositives:
     - Unknown


### PR DESCRIPTION
Made it a single regular expression.
In the first version (?i).?cmd./c\s*"set\s+.*downloadstring&&.rundll32.powershell.(value|invoke|comspec|iex)." , but I changed it because the script can be of this type:
'Invoke-Expression (New-Object Net.WebClient).DownloadString&&RuNdll32 SHELL32.DLL ShellExec_RunDLL "PoWERsheLl" " -noPRoFIL " " ( ^& ( '{1}{2}{3}{0}' -f 'eM','GE','t-child','IT' ) ( '{0}{1}' -f'E','nV:igFm' ) ).'VAlUE' ^| . ( '{1}{0}'-f 'x','ie')"'
And i add in regular 'iex' because 'invoke' could be different.