### PR TITLE
[OSCD] Create win_root_certificate_installed.yml

### DIFF
--- a/rules/windows/builtin/win_root_certificate_installed.yml
+++ b/rules/windows/builtin/win_root_certificate_installed.yml
@@ -17,17 +17,6 @@ detection:
     condition: 1 of them
 ---
 logsource:
-    category: process_creation
-    product: windows
-detection:
-    selection1:
-        Image|endswith: '\certutil.exe'     # Example: certutil -addstore -f -user ROOT CertificateFileName.der
-        CommandLine|contains: '-addstore * root'
-    selection2:
-        Image|endswith: '\CertMgr.exe'      # Example: CertMgr.exe /add CertificateFileName.cer /s /r localMachine root /all
-        CommandLine|contains: '/add * root'
----
-logsource:
     product: windows
     service: powershell
 detection:
@@ -35,4 +24,30 @@ detection:
         EventID: 4104
         ScriptBlockText|contains:
           - 'Import-Certificate * Cert:\LocalMachine\Root'
-          - 'Move-Item * Cert:\LocalMachine\Root'
+          - 'Move-Item * Cert:\LocalMachine\Root'    
+---
+logsource:
+    category: process_creation
+    product: windows
+    service: sysmon
+detection:
+    selection1:
+        EventID: 1
+        Image|endswith: '\certutil.exe'     # Example: certutil -addstore -f -user ROOT CertificateFileName.der
+        CommandLine|contains: '-addstore * root'
+    selection2:
+        EventID: 1
+        Image|endswith: '\CertMgr.exe'      # Example: CertMgr.exe /add CertificateFileName.cer /s /r localMachine root /all
+        CommandLine|contains: '/add * root'
+---
+action: repeat
+logsource:
+    product: windows
+    service: security
+detection:
+    selection1:
+        EventID: 4688
+    selection2:
+        EventID: 4688
+---
+action: reset

--- a/rules/windows/builtin/win_root_certificate_installed.yml
+++ b/rules/windows/builtin/win_root_certificate_installed.yml
@@ -24,31 +24,15 @@ detection:
         EventID: 4104
         ScriptBlockText|contains:
           - 'Import-Certificate * Cert:\LocalMachine\Root'
-          - 'Move-Item * Cert:\LocalMachine\Root'    
+          - 'Move-Item * Cert:\LocalMachine\Root'
 ---
 logsource:
     category: process_creation
     product: windows
-    service: sysmon
 detection:
     selection1:
-        EventID: 1
         Image|endswith: '\certutil.exe'     # Example: certutil -addstore -f -user ROOT CertificateFileName.der
         CommandLine|contains: '-addstore * root'
     selection2:
-        EventID: 1
         Image|endswith: '\CertMgr.exe'      # Example: CertMgr.exe /add CertificateFileName.cer /s /r localMachine root /all
         CommandLine|contains: '/add * root'
----
-action: repeat
-logsource:
-    category: process_creation
-    product: windows
-    service: security
-detection:
-    selection1:
-        EventID: 4688
-    selection2:
-        EventID: 4688
----
-action: reset

--- a/rules/windows/builtin/win_root_certificate_installed.yml
+++ b/rules/windows/builtin/win_root_certificate_installed.yml
@@ -20,11 +20,16 @@ logsource:
     product: windows
     service: powershell
 detection:
-    selection:
+    selection1:
         EventID: 4104
-        ScriptBlockText|contains:
-          - 'Import-Certificate * Cert:\LocalMachine\Root'
-          - 'Move-Item * Cert:\LocalMachine\Root'
+        ScriptBlockText|contains|all:
+          - 'Move-Item'
+          - 'Cert:\LocalMachine\Root'
+    selection2:
+        EventID: 4104
+        ScriptBlockText|contains|all:
+          - 'Import-Certificate'
+          - 'Cert:\LocalMachine\Root'
 ---
 logsource:
     category: process_creation
@@ -32,7 +37,11 @@ logsource:
 detection:
     selection1:
         Image|endswith: '\certutil.exe'     # Example: certutil -addstore -f -user ROOT CertificateFileName.der
-        CommandLine|contains: '-addstore * root'
+        CommandLine|contains|all: 
+            - '-addstore'
+            - 'root'
     selection2:
         Image|endswith: '\CertMgr.exe'      # Example: CertMgr.exe /add CertificateFileName.cer /s /r localMachine root /all
-        CommandLine|contains: '/add * root'
+        CommandLine|contains|all:
+            - '/add'
+            - 'root'

--- a/rules/windows/builtin/win_root_certificate_installed.yml
+++ b/rules/windows/builtin/win_root_certificate_installed.yml
@@ -1,0 +1,38 @@
+action: global
+title: Root Certificate Installed
+id: 42821614-9264-4761-acfc-5772c3286f76
+status: experimental
+description: Adversaries may install a root certificate on a compromised system to avoid warnings when connecting to adversary controlled web servers.
+references:
+    - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1553.004/T1553.004.md
+author: 'oscd.community, @redcanary, Zach Stanford @svch0st'
+date: 2020/10/10
+tags:
+    - attack.defense_evasion
+    - attack.t1553.004
+level: medium
+falsepositives:
+    - Help Desk or IT may need to manually add a corporate Root CA on occasion. Need to test if GPO push doesn't trigger FP
+detection:
+    condition: 1 of them
+---
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection1:
+        Image|endswith: '\certutil.exe'     # Example: certutil -addstore -f -user ROOT CertificateFileName.der
+        CommandLine|contains: '-addstore * root'
+    selection2:
+        Image|endswith: '\CertMgr.exe'      # Example: CertMgr.exe /add CertificateFileName.cer /s /r localMachine root /all
+        CommandLine|contains: '/add * root'
+---
+logsource:
+    product: windows
+    service: powershell
+detection:
+    selection:
+        EventID: 4104
+        ScriptBlockText|contains:
+          - 'Import-Certificate * Cert:\LocalMachine\Root'
+          - 'Move-Item * Cert:\LocalMachine\Root'

--- a/rules/windows/builtin/win_root_certificate_installed.yml
+++ b/rules/windows/builtin/win_root_certificate_installed.yml
@@ -42,6 +42,7 @@ detection:
 ---
 action: repeat
 logsource:
+    category: process_creation
     product: windows
     service: security
 detection:


### PR DESCRIPTION
Ref: https://github.com/Neo23x0/sigma/issues/1013

Sigmac Output
`python .\sigmac -t splunk -c .\config\splunk-windows.yml ..\rules\windows\builtin\win_.yml
(source="WinEventLog:Microsoft-Windows-PowerShell/Operational" EventCode="4104" (ScriptBlockText="*Import-Certificate * Cert:\\LocalMachine\\Root*" OR ScriptBlockText="*Move-Item * Cert:\\LocalMachine\\Root*"))
((Image="*\\certutil.exe" CommandLine="*-addstore * root*") OR (Image="*\\CertMgr.exe" CommandLine="*/add * root*"))`