### PR TITLE
[OSCD] Rasautou.exe LOLbin

### DIFF
--- a/rules/windows/process_creation/win_rasautou_dll_execution.yml
+++ b/rules/windows/process_creation/win_rasautou_dll_execution.yml
@@ -27,4 +27,4 @@ detection:
     condition: (use_rasautou or remaned_rasautou) and special_keys
 level: medium
 falsepositives:
-    - Unlikely.
+    - Unlikely

--- a/rules/windows/process_creation/win_rasautou_dll_execution.yml
+++ b/rules/windows/process_creation/win_rasautou_dll_execution.yml
@@ -13,7 +13,7 @@ tags:
 logsource:
     product: windows
     category: process_creation
-    definition: Since options '-d' and '-p' removed in Windows 10 this rule is relevant only for windows before 10. ANd as Windows 7 doesn't log command line in 4688 by default, to detect this attack you need Sysmon 1 configured or KB3004375 installed for command-line auditing (https://support.microsoft.com/en-au/help/3004375/microsoft-security-advisory-update-to-improve-windows-command-line-aud)
+    definition: Since options '-d' and '-p' were removed in Windows 10 this rule is relevant only for Windows before 10. And as Windows 7 doesn't log command line in 4688 by default, to detect this attack you need Sysmon 1 configured or KB3004375 installed for command-line auditing (https://support.microsoft.com/en-au/help/3004375/microsoft-security-advisory-update-to-improve-windows-command-line-aud)
 detection:
     use_rasautou:
         Image|endswith: '\rasautou.exe'

--- a/rules/windows/process_creation/win_rasautou_dll_execution.yml
+++ b/rules/windows/process_creation/win_rasautou_dll_execution.yml
@@ -3,6 +3,7 @@ id: cd3d1298-eb3b-476c-ac67-12847de55813
 description: Detects using Rasautou.exe for loading arbitrary .DLL specified in -d option and executes the export specified in -p. 
 status: experimental
 references:
+    - https://lolbas-project.github.io/lolbas/Binaries/Rasautou/
     - https://github.com/fireeye/DueDLLigence
     - https://www.fireeye.com/blog/threat-research/2019/10/staying-hidden-on-the-endpoint-evading-detection-with-shellcode.html
 author: Julia Fomina, oscd.community

--- a/rules/windows/sysmon/sysmon_rasautou_dll_execution.yml
+++ b/rules/windows/sysmon/sysmon_rasautou_dll_execution.yml
@@ -13,6 +13,7 @@ tags:
 logsource:
     product: windows
     category: process_creation
+    definition: Since options '-d' and '-p' removed in Windows 10 this rule is relevant only for windows before 10. ANd as Windows 7 doesn't log command line in 4688 by default, to detect this attack you need Sysmon 1 configured or KB3004375 installed for command-line auditing (https://support.microsoft.com/en-au/help/3004375/microsoft-security-advisory-update-to-improve-windows-command-line-aud)
 detection:
     use_rasautou:
         Image|endswith: '\rasautou.exe'
@@ -25,4 +26,4 @@ detection:
     condition: (use_rasautou or remaned_rasautou) and special_keys
 level: medium
 falsepositives:
-    - Unlikely. Options '-d' and '-p' removed in Windows 10.
+    - Unlikely.

--- a/rules/windows/sysmon/sysmon_rasautou_dll_execution.yml
+++ b/rules/windows/sysmon/sysmon_rasautou_dll_execution.yml
@@ -12,7 +12,6 @@ tags:
     - attack.t1218
 logsource:
     product: windows
-    service: sysmon
     category: process_creation
 detection:
     use_rasautou:

--- a/rules/windows/sysmon/sysmon_rasautou_dll_execution.yml
+++ b/rules/windows/sysmon/sysmon_rasautou_dll_execution.yml
@@ -1,0 +1,31 @@
+title: DLL Execution via Rasautou.exe
+id: cd3d1298-eb3b-476c-ac67-12847de55813
+description: Detects using Rasautou.exe for loading arbitrary .DLL specified in -d option and executes the export specified in -p. 
+status: experimental
+references:
+    - https://github.com/fireeye/DueDLLigence
+    - https://www.fireeye.com/blog/threat-research/2019/10/staying-hidden-on-the-endpoint-evading-detection-with-shellcode.html
+author: Julia Fomina, oscd.community
+date: 2020/10/09
+tags:
+    - attack.defense_evasion
+    - attack.t1218
+logsource:
+    product: windows
+    service: sysmon
+detection:
+    start_process:
+        EventID: 1
+    use_rasautou:
+        Image|endswith: '\rasautou.exe'
+    remaned_rasautou:
+        OriginalFileName: 'rasdlui.exe'
+    special_keys:
+        CommandLine|contains|all: 
+            - '-d'
+            - '-p'
+    condition: start_process and (use_rasautou or remaned_rasautou) and special_keys
+level: medium
+falsepositives:
+    - Unlikely. Options '-d' and '-p' removed in Windows 10.
+    

--- a/rules/windows/sysmon/sysmon_rasautou_dll_execution.yml
+++ b/rules/windows/sysmon/sysmon_rasautou_dll_execution.yml
@@ -13,9 +13,8 @@ tags:
 logsource:
     product: windows
     service: sysmon
+    category: process_creation
 detection:
-    start_process:
-        EventID: 1
     use_rasautou:
         Image|endswith: '\rasautou.exe'
     remaned_rasautou:
@@ -24,8 +23,7 @@ detection:
         CommandLine|contains|all: 
             - '-d'
             - '-p'
-    condition: start_process and (use_rasautou or remaned_rasautou) and special_keys
+    condition: (use_rasautou or remaned_rasautou) and special_keys
 level: medium
 falsepositives:
     - Unlikely. Options '-d' and '-p' removed in Windows 10.
-    


### PR DESCRIPTION
task 69, #1014 
Attack doesn't work in Windows 10 as options '-d' and '-p' were removed in Windows 10.
Standart 4688 in WIn7 doesn't log command line, that is why only Sysymon1 is required
Do i have some way to include only Sysmon1 and not 4688?