### PR TITLE
[OSCD] Local System Groups Discovery

### DIFF
--- a/rules/linux/lnx_local_groups.yml
+++ b/rules/linux/lnx_local_groups.yml
@@ -2,7 +2,7 @@ title: Local Groups Discovery
 id: 676381a6-15ca-4d73-a9c8-6a22e970b90d
 status: experimental
 description: Detects enumeration of local system groups
-author: Alejandro Ortuno, oscd.community
+author: Ömer Günal, Alejandro Ortuno, oscd.community
 date: 2020/10/11
 references:
   - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1069.001/T1069.001.md

--- a/rules/linux/lnx_local_groups.yml
+++ b/rules/linux/lnx_local_groups.yml
@@ -12,10 +12,10 @@ logsource:
 detection:
   selection_1:
     ProcessName|endswith:
-      - '*/groups'
+      - '/groups'
   selection_2:
     ProcessName|endswith:
-      - '*/cat'
+      - '/cat'
     CommandLine|contains:
       - '/etc/group'
   condition: 1 of them

--- a/rules/linux/lnx_local_groups.yml
+++ b/rules/linux/lnx_local_groups.yml
@@ -1,0 +1,27 @@
+title: Local Groups Discovery
+id: 676381a6-15ca-4d73-a9c8-6a22e970b90d
+status: experimental
+description: Detects enumeration of local system groups
+author: Alejandro Ortuno, oscd.community
+date: 2020/10/11
+references:
+  - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1069.001/T1069.001.md
+logsource:
+  category: process_creation
+  product: linux
+detection:
+  selection_1:
+    ProcessName|endswith:
+      - '*/groups'
+  selection_2:
+    ProcessName|endswith:
+      - '*/cat'
+    CommandLine|contains:
+      - '/etc/group'
+  condition: 1 of them
+falsepositives:
+  - Legitimate administration activities
+level: low
+tags:
+  - attack.discovery
+  - attack.t1069.001

--- a/rules/linux/macos_local_groups.yml
+++ b/rules/linux/macos_local_groups.yml
@@ -2,7 +2,7 @@ title: Local Groups Discovery
 id: 89bb1f97-c7b9-40e8-b52b-7d6afbd67276
 status: experimental
 description: Detects enumeration of local system groups
-author: Alejandro Ortuno, oscd.community
+author: Ömer Günal, Alejandro Ortuno, oscd.community
 date: 2020/10/11
 references:
   - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1069.001/T1069.001.md

--- a/rules/linux/macos_local_groups.yml
+++ b/rules/linux/macos_local_groups.yml
@@ -1,0 +1,34 @@
+title: Local Groups Discovery
+id: 89bb1f97-c7b9-40e8-b52b-7d6afbd67276
+status: experimental
+description: Detects enumeration of local system groups
+author: Alejandro Ortuno, oscd.community
+date: 2020/10/11
+references:
+  - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1069.001/T1069.001.md
+logsource:
+  category: process_creation
+  product: macos
+detection:
+  selection_1:
+    ProcessName|endswith:
+      - '*/dscacheutil'
+    CommandLine|contains:
+      - '-q group'
+  selection_2:
+    ProcessName|endswith:
+      - '*/cat'
+    CommandLine|contains:
+      - '/etc/group'
+  selection_3:
+    ProcessName|endswith:
+      - '*/dscl'
+    CommandLine|contains:
+      - '. -list /groups'
+  condition: 1 of them
+falsepositives:
+  - Legitimate administration activities
+level: low
+tags:
+  - attack.discovery
+  - attack.t1069.001

--- a/rules/linux/macos_local_groups.yml
+++ b/rules/linux/macos_local_groups.yml
@@ -12,19 +12,21 @@ logsource:
 detection:
   selection_1:
     ProcessName|endswith:
-      - '*/dscacheutil'
-    CommandLine|contains:
-      - '-q group'
+      - '/dscacheutil'
+    CommandLine|contains|all:
+      - '-q'
+      - 'group'
   selection_2:
     ProcessName|endswith:
-      - '*/cat'
+      - '/cat'
     CommandLine|contains:
       - '/etc/group'
   selection_3:
     ProcessName|endswith:
-      - '*/dscl'
-    CommandLine|contains:
-      - '. -list /groups'
+      - '/dscl'
+    CommandLine|contains|all:
+      - '-list'
+      - '/groups'
   condition: 1 of them
 falsepositives:
   - Legitimate administration activities


### PR DESCRIPTION
Covering:

Linux task 12 T1069.001: Local Groups #1011
MacOs task 21 T1069.001: Local Groups #1012

Regarding the outcome of #1048 we can consider renaming the file name prefix and also move it into the right folder.