### PR TITLE
[OSCD] script applications loading .net dll

### DIFF
--- a/rules/windows/image_load/sysmon_susp_script_dotnet_clr_dll_load.yml
+++ b/rules/windows/image_load/sysmon_susp_script_dotnet_clr_dll_load.yml
@@ -1,0 +1,30 @@
+title: CLR DLL Loaded Via Scripting Applications
+id: 4508a70e-97ef-4300-b62b-ff27992990ea
+status: experimental
+description: Detects CLR DLL being loaded by an scripting applications
+references:
+    - https://github.com/tyranid/DotNetToJScript
+    - https://thewover.github.io/Introducing-Donut/
+author: omkar72, oscd.community
+date: 2020/10/10
+tags:
+    - attack.execution
+    - attack.privilege_escalation
+    - attack.t1055
+logsource:
+    category: image_load
+    product: windows
+detection:
+    selection:
+        Image:
+            - '*\wscript.exe'
+            - '*\cscript.exe'
+            - '*\mshta.exe'
+        ImageLoaded:
+            - '*\clr.dll'
+            - '*\mscoree.dll'
+            - '*\mscorlib.dll'
+    condition: selection
+falsepositives:
+    - unknown
+level: high

--- a/rules/windows/image_load/sysmon_susp_script_dotnet_clr_dll_load.yml
+++ b/rules/windows/image_load/sysmon_susp_script_dotnet_clr_dll_load.yml
@@ -7,7 +7,7 @@ references:
     - https://thewover.github.io/Introducing-Donut/
     - https://blog.menasec.net/2019/07/interesting-difr-traces-of-net-clr.html
 author: omkar72, oscd.community
-date: 2020/10/10
+date: 2020/10/14
 tags:
     - attack.execution
     - attack.privilege_escalation

--- a/rules/windows/image_load/sysmon_susp_script_dotnet_clr_dll_load.yml
+++ b/rules/windows/image_load/sysmon_susp_script_dotnet_clr_dll_load.yml
@@ -18,13 +18,13 @@ logsource:
 detection:
     selection:
         Image|endswith:
-            - '\wscript.exe'
-            - '\cscript.exe'
-            - '\mshta.exe'
+            - 'wscript.exe'
+            - 'cscript.exe'
+            - 'mshta.exe'
         ImageLoaded|endswith:
-            - '\clr.dll'
-            - '\mscoree.dll'
-            - '\mscorlib.dll'
+            - 'clr.dll'
+            - 'mscoree.dll'
+            - 'mscorlib.dll'
     condition: selection
 falsepositives:
     - unknown

--- a/rules/windows/image_load/sysmon_susp_script_dotnet_clr_dll_load.yml
+++ b/rules/windows/image_load/sysmon_susp_script_dotnet_clr_dll_load.yml
@@ -5,6 +5,7 @@ description: Detects CLR DLL being loaded by an scripting applications
 references:
     - https://github.com/tyranid/DotNetToJScript
     - https://thewover.github.io/Introducing-Donut/
+    - https://blog.menasec.net/2019/07/interesting-difr-traces-of-net-clr.html
 author: omkar72, oscd.community
 date: 2020/10/10
 tags:
@@ -16,11 +17,11 @@ logsource:
     product: windows
 detection:
     selection:
-        Image:
+        Image|endswith:
             - '*\wscript.exe'
             - '*\cscript.exe'
             - '*\mshta.exe'
-        ImageLoaded:
+        ImageLoaded|endswith:
             - '*\clr.dll'
             - '*\mscoree.dll'
             - '*\mscorlib.dll'

--- a/rules/windows/image_load/sysmon_susp_script_dotnet_clr_dll_load.yml
+++ b/rules/windows/image_load/sysmon_susp_script_dotnet_clr_dll_load.yml
@@ -18,13 +18,13 @@ logsource:
 detection:
     selection:
         Image|endswith:
-            - 'wscript.exe'
-            - 'cscript.exe'
-            - 'mshta.exe'
+            - '\wscript.exe'
+            - '\cscript.exe'
+            - '\mshta.exe'
         ImageLoaded|endswith:
-            - 'clr.dll'
-            - 'mscoree.dll'
-            - 'mscorlib.dll'
+            - '\clr.dll'
+            - '\mscoree.dll'
+            - '\mscorlib.dll'
     condition: selection
 falsepositives:
     - unknown

--- a/rules/windows/image_load/sysmon_susp_script_dotnet_clr_dll_load.yml
+++ b/rules/windows/image_load/sysmon_susp_script_dotnet_clr_dll_load.yml
@@ -18,13 +18,13 @@ logsource:
 detection:
     selection:
         Image|endswith:
-            - '*\wscript.exe'
-            - '*\cscript.exe'
-            - '*\mshta.exe'
+            - '\wscript.exe'
+            - '\cscript.exe'
+            - '\mshta.exe'
         ImageLoaded|endswith:
-            - '*\clr.dll'
-            - '*\mscoree.dll'
-            - '*\mscorlib.dll'
+            - '\clr.dll'
+            - '\mscoree.dll'
+            - '\mscorlib.dll'
     condition: selection
 falsepositives:
     - unknown


### PR DESCRIPTION
frameworks like .net2js produces scripts with .net embedded inside it. rule will help execution of those scripts through these frameworks. This covers hta, js, vbs files for now. this will also help in bring your own assembly attacks.