### PR TITLE
[OSCD] suspicious clr logs creation

### DIFF
--- a/rules/windows/file_event/sysmon_susp_clr_logs.yml
+++ b/rules/windows/file_event/sysmon_susp_clr_logs.yml
@@ -15,13 +15,13 @@ logsource:
 detection:
     selection:
         EventID: 11
-        TargetFilename|endswith:
+        TargetFilename|contains:
           - '\AppData\Local\Microsoft\CLR*\UsageLogs\mshta*'
           - '\AppData\Local\Microsoft\CLR*\UsageLogs\cscript*'
           - '\AppData\Local\Microsoft\CLR*\UsageLogs\wscript*'
           - '\AppData\Local\Microsoft\CLR*\UsageLogs\regsvr32*'
           - '\AppData\Local\Microsoft\CLR*\UsageLogs\wmic*'
-condition: selection
+    condition: selection
 falsepositives:
   - Unknown
 level: high

--- a/rules/windows/file_event/sysmon_susp_clr_logs.yml
+++ b/rules/windows/file_event/sysmon_susp_clr_logs.yml
@@ -15,11 +15,14 @@ logsource:
 detection:
     selection:
         TargetFilename:
-          - '*\AppData\Local\Microsoft\CLR*\UsageLogs\mshta*'
-          - '*\AppData\Local\Microsoft\CLR*\UsageLogs\cscript*'
-          - '*\AppData\Local\Microsoft\CLR*\UsageLogs\wscript*'
-          - '*\AppData\Local\Microsoft\CLR*\UsageLogs\regsvr32*'
-          - '*\AppData\Local\Microsoft\CLR*\UsageLogs\wmic*'
+          - '\AppData\Local\Microsoft\CLR'
+          - '\UsageLogs\'
+        TargetFilename|contains:
+          - 'mshta'
+          - 'cscript'
+          - 'wscript'
+          - 'regsvr32'
+          - 'wmic'
     condition: selection
 falsepositives:
   - Unknown

--- a/rules/windows/file_event/sysmon_susp_clr_logs.yml
+++ b/rules/windows/file_event/sysmon_susp_clr_logs.yml
@@ -5,8 +5,8 @@ references:
   - https://blog.menasec.net/2019/07/interesting-difr-traces-of-net-clr.html
 date: 2020/10/12
 tags:
-  - attack.execution
-  - attack.t1059.001
+    - attack.execution
+    - attack.t1059.001
 status: experimental
 author: omkar72, oscd.community
 logsource:

--- a/rules/windows/file_event/sysmon_susp_clr_logs.yml
+++ b/rules/windows/file_event/sysmon_susp_clr_logs.yml
@@ -2,7 +2,7 @@ title: Suspcious CLR Logs Creation
 id: e4b63079-6198-405c-abd7-3fe8b0ce3263
 description: Detects suspicious .NET assembly executions 
 references:
-  - https://blog.menasec.net/2019/07/interesting-difr-traces-of-net-clr.html
+    - https://blog.menasec.net/2019/07/interesting-difr-traces-of-net-clr.html
 date: 2020/10/12
 tags:
     - attack.execution

--- a/rules/windows/file_event/sysmon_susp_clr_logs.yml
+++ b/rules/windows/file_event/sysmon_susp_clr_logs.yml
@@ -10,17 +10,16 @@ tags:
 status: experimental
 author: omkar72, oscd.community
 logsource:
+    category: file_event
     product: windows
-    service: sysmon
 detection:
     selection:
-        EventID: 11
-        TargetFilename|contains:
-          - '\AppData\Local\Microsoft\CLR*\UsageLogs\mshta*'
-          - '\AppData\Local\Microsoft\CLR*\UsageLogs\cscript*'
-          - '\AppData\Local\Microsoft\CLR*\UsageLogs\wscript*'
-          - '\AppData\Local\Microsoft\CLR*\UsageLogs\regsvr32*'
-          - '\AppData\Local\Microsoft\CLR*\UsageLogs\wmic*'
+        TargetFilename:
+          - '*\AppData\Local\Microsoft\CLR*\UsageLogs\mshta*'
+          - '*\AppData\Local\Microsoft\CLR*\UsageLogs\cscript*'
+          - '*\AppData\Local\Microsoft\CLR*\UsageLogs\wscript*'
+          - '*\AppData\Local\Microsoft\CLR*\UsageLogs\regsvr32*'
+          - '*\AppData\Local\Microsoft\CLR*\UsageLogs\wmic*'
     condition: selection
 falsepositives:
   - Unknown

--- a/rules/windows/file_event/sysmon_susp_clr_logs.yml
+++ b/rules/windows/file_event/sysmon_susp_clr_logs.yml
@@ -14,7 +14,7 @@ logsource:
     product: windows
 detection:
     selection:
-        TargetFilename:
+        TargetFilename|contains|all:
           - '\AppData\Local\Microsoft\CLR'
           - '\UsageLogs\'
         TargetFilename|contains:

--- a/rules/windows/file_event/sysmon_susp_clr_logs.yml
+++ b/rules/windows/file_event/sysmon_susp_clr_logs.yml
@@ -21,7 +21,7 @@ detection:
           - '\AppData\Local\Microsoft\CLR*\UsageLogs\wscript*'
           - '\AppData\Local\Microsoft\CLR*\UsageLogs\regsvr32*'
           - '\AppData\Local\Microsoft\CLR*\UsageLogs\wmic*'
-  condition: selection
+condition: selection
 falsepositives:
   - Unknown
 level: high

--- a/rules/windows/file_event/sysmon_susp_clr_logs.yml
+++ b/rules/windows/file_event/sysmon_susp_clr_logs.yml
@@ -1,14 +1,14 @@
-title: Susopcious CLR Logs Creation
+title: Suspcious CLR Logs Creation
 id: e4b63079-6198-405c-abd7-3fe8b0ce3263
-status: experimental
 description: Detects suspicious .NET assembly executions 
 references:
   - https://blog.menasec.net/2019/07/interesting-difr-traces-of-net-clr.html
+date: 2020/10/12
 tags:
   - attack.execution
   - attack.t1059.001
+status: experimental
 author: omkar72, oscd.community
-date: 2020/10/12
 logsource:
     product: windows
     service: sysmon

--- a/rules/windows/file_event/sysmon_susp_clr_logs.yml
+++ b/rules/windows/file_event/sysmon_susp_clr_logs.yml
@@ -1,0 +1,27 @@
+title: Susopcious CLR Logs Creation
+id: e4b63079-6198-405c-abd7-3fe8b0ce3263
+status: experimental
+description: Detects suspicious .NET assembly executions 
+references:
+  - https://blog.menasec.net/2019/07/interesting-difr-traces-of-net-clr.html
+tags:
+  - attack.execution
+  - attack.t1059.001
+author: omkar72, oscd.community
+date: 2020/10/12
+logsource:
+    product: windows
+    service: sysmon
+detection:
+    selection:
+        EventID: 11
+        TargetFilename|endswith:
+          - '\AppData\Local\Microsoft\CLR*\UsageLogs\mshta*'
+          - '\AppData\Local\Microsoft\CLR*\UsageLogs\cscript*'
+          - '\AppData\Local\Microsoft\CLR*\UsageLogs\wscript*'
+          - '\AppData\Local\Microsoft\CLR*\UsageLogs\regsvr32*'
+          - '\AppData\Local\Microsoft\CLR*\UsageLogs\wmic*'
+  condition: selection
+falsepositives:
+  - Unknown
+level: high


### PR DESCRIPTION
forensic file traces observed when offensive tools like .Net2js, sharpshooter which internally use .NET for execution. CLR logs are captured in the mentioned folder and can be a trace for such attempts. I did not add svchost might create fp.