### PR TITLE
[OSCD] Bad Opsec Powershell Artifacts

### DIFF
--- a/rules/windows/powershell/powershell_bad_opsec_artifacts.yml
+++ b/rules/windows/powershell/powershell_bad_opsec_artifacts.yml
@@ -21,21 +21,21 @@ detection:
     selection_4104:
         EventID: 4104
         ScriptBlockText|contains:
-                - '$DoIt'
-                - 'harmj0y'
-                - 'mattifestation'
-                - '_RastaMouse'
-                - 'tifkin_'
-                - '0xdeadbeef'
+            - '$DoIt'
+            - 'harmj0y'
+            - 'mattifestation'
+            - '_RastaMouse'
+            - 'tifkin_'
+            - '0xdeadbeef'
     selection_4103:
         EventID: 4103
         Payload|contains:
-                - '$DoIt'
-                - 'harmj0y'
-                - 'mattifestation'
-                - '_RastaMouse'
-                - 'tifkin_'
-                - '0xdeadbeef'
+            - '$DoIt'
+            - 'harmj0y'
+            - 'mattifestation'
+            - '_RastaMouse'
+            - 'tifkin_'
+            - '0xdeadbeef'
     condition: selection_4104 or selection_4103
 falsepositives:
     - 'Moderate-to-low; Despite the shorter length/lower entropy for some of these, because of high specificity, fp appears to be fairly limited in many environments.'

--- a/rules/windows/powershell/powershell_bad_opsec_artifacts.yml
+++ b/rules/windows/powershell/powershell_bad_opsec_artifacts.yml
@@ -1,0 +1,42 @@
+title: Bad Opsec Powershell Code Artifacts
+id: 73e733cc-1ace-3212-a107-ff2523cc9fc3
+description: Focuses on trivial artifacts observed in variants of prevalent offensive ps1 payloads, including Cobalt Strike Beacon, PoshC2, Powerview, Letmein, Empire, Powersploit, and other attack payloads that often undergo minimal changes by attackers due to bad opsec.
+status: experimental
+references:
+    - https://newtonpaul.com/analysing-fileless-malware-cobalt-strike-beacon/
+    - https://labs.sentinelone.com/top-tier-russian-organized-cybercrime-group-unveils-fileless-stealthy-powertrick-backdoor-for-high-value-targets/
+    - https://www.mdeditor.tw/pl/pgRt
+author: 'ok @securonix invrep_de, oscd.community'
+date: 2020/10/09
+modified: 2020/10/09
+tags:
+    - attack.execution
+    - attack.t1059.001
+    - attack.t1086
+logsource:
+    product: windows
+    service: powershell
+    definition: 'Script block logging must be enabled'
+detection:
+    selection1:
+        EventID: 4104
+    selection2:
+        - ScriptBlockText|contains: '$DoIt'
+        - ScriptBlockText|contains: 'harmj0y'
+        - ScriptBlockText|contains: 'mattifestation'
+        - ScriptBlockText|contains: '_RastaMouse'
+        - ScriptBlockText|contains: 'tifkin_'
+        - ScriptBlockText|contains: '0xdeadbeef'
+    selection3:
+        EventID: 4103
+    selection4:
+        - Payload|contains: '$DoIt'
+        - Payload|contains: 'harmj0y'
+        - Payload|contains: 'mattifestation'
+        - Payload|contains: 'obscuresec'
+        - Payload|contains: 'tifkin_'
+        - Payload|contains: '0xdeadbeef'
+    condition: ( selection1 and selection2 ) or ( selection3 and selection4 )
+falsepositives:
+    - 'Moderate-to-low; Despite the shorter length/lower entropy for some of these, because of high specificity, fp appears to be fairly limited in many environments.'
+level: high

--- a/rules/windows/powershell/powershell_bad_opsec_artifacts.yml
+++ b/rules/windows/powershell/powershell_bad_opsec_artifacts.yml
@@ -20,7 +20,7 @@ logsource:
 detection:
     selection_4104:
         EventID: 4104
-	ScriptBlockText|contains:
+        ScriptBlockText|contains:
                 - '$DoIt'
                 - 'harmj0y'
                 - 'mattifestation'

--- a/rules/windows/powershell/powershell_bad_opsec_artifacts.yml
+++ b/rules/windows/powershell/powershell_bad_opsec_artifacts.yml
@@ -18,25 +18,25 @@ logsource:
     service: powershell
     definition: 'Script block logging must be enabled'
 detection:
-    selection1:
+    selection_4104:
         EventID: 4104
-    selection2:
-        - ScriptBlockText|contains: '$DoIt'
-        - ScriptBlockText|contains: 'harmj0y'
-        - ScriptBlockText|contains: 'mattifestation'
-        - ScriptBlockText|contains: '_RastaMouse'
-        - ScriptBlockText|contains: 'tifkin_'
-        - ScriptBlockText|contains: '0xdeadbeef'
-    selection3:
+	    ScriptBlockText|contains:
+		    - '$DoIt'
+		    - 'harmj0y'
+		    - 'mattifestation'
+		    - '_RastaMouse'
+		    - 'tifkin_'
+		    - '0xdeadbeef'
+    selection_4104:
         EventID: 4103
-    selection4:
-        - Payload|contains: '$DoIt'
-        - Payload|contains: 'harmj0y'
-        - Payload|contains: 'mattifestation'
-        - Payload|contains: 'obscuresec'
-        - Payload|contains: 'tifkin_'
-        - Payload|contains: '0xdeadbeef'
-    condition: ( selection1 and selection2 ) or ( selection3 and selection4 )
+        Payload|contains:
+            - '$DoIt'
+            - 'harmj0y'
+            - 'mattifestation'
+            - 'obscuresec'
+            - 'tifkin_'
+            - '0xdeadbeef'
+    condition: selection_4104 or selection_4103
 falsepositives:
     - 'Moderate-to-low; Despite the shorter length/lower entropy for some of these, because of high specificity, fp appears to be fairly limited in many environments.'
 level: high

--- a/rules/windows/powershell/powershell_bad_opsec_artifacts.yml
+++ b/rules/windows/powershell/powershell_bad_opsec_artifacts.yml
@@ -20,22 +20,22 @@ logsource:
 detection:
     selection_4104:
         EventID: 4104
-	    ScriptBlockText|contains:
-		    - '$DoIt'
-		    - 'harmj0y'
-		    - 'mattifestation'
-		    - '_RastaMouse'
-		    - 'tifkin_'
-		    - '0xdeadbeef'
-    selection_4104:
+	ScriptBlockText|contains:
+                - '$DoIt'
+                - 'harmj0y'
+                - 'mattifestation'
+                - '_RastaMouse'
+                - 'tifkin_'
+                - '0xdeadbeef'
+    selection_4103:
         EventID: 4103
         Payload|contains:
-            - '$DoIt'
-            - 'harmj0y'
-            - 'mattifestation'
-            - 'obscuresec'
-            - 'tifkin_'
-            - '0xdeadbeef'
+                - '$DoIt'
+                - 'harmj0y'
+                - 'mattifestation'
+                - '_RastaMouse'
+                - 'tifkin_'
+                - '0xdeadbeef'
     condition: selection_4104 or selection_4103
 falsepositives:
     - 'Moderate-to-low; Despite the shorter length/lower entropy for some of these, because of high specificity, fp appears to be fairly limited in many environments.'


### PR DESCRIPTION
This detects powershell code artifacts left by attackers in community attack tool powershell payloads as part of bad opsec practices leveraging customized variants of Cobaltstrike Powershell Beacon, PoshC2, Powersploit, Empire, etc.

[Resubmitted per feedback from @yugoslavskiy]