### PR TITLE
[OSCD] MacOS Network Sniffing

### DIFF
--- a/rules/linux/macos_network_sniffing.yml
+++ b/rules/linux/macos_network_sniffing.yml
@@ -10,13 +10,11 @@ logsource:
   category: process_creation
   product: macos
 detection:
-  selection_1:
-    ProcessName|endswith:
+  selection:
+    ProcessName|endswith: 
       - '/tcpdump'
-  selection_2:
-    ProcessName|endswith:
       - '/tshark'
-  condition: 1 of them
+  condition: selection
 falsepositives:
   - Legitimate administration activities
 level: medium

--- a/rules/linux/macos_network_sniffing.yml
+++ b/rules/linux/macos_network_sniffing.yml
@@ -1,0 +1,26 @@
+title: Network Sniffing
+id: adc9bcc4-c39c-4f6b-a711-1884017bf043
+status: experimental
+description: Detects the usage of tooling to sniff network traffic. An adversary may place a network interface into promiscuous mode to passively access data in transit over the network, or use span ports to capture a larger amount of data.
+author: Alejandro Ortuno, oscd.community
+date: 2020/10/14
+references:
+  - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1040/T1040.md
+logsource:
+  category: process_creation
+  product: macos
+detection:
+  selection_1:
+    ProcessName|endswith:
+      - '/tcpdump'
+  selection_2:
+    ProcessName|endswith:
+      - '/tshark'
+  condition: 1 of them
+falsepositives:
+  - Legitimate administration activities
+level: medium
+tags:
+  - attack.discovery
+  - attack.credential_access
+  - attack.t1040


### PR DESCRIPTION
Covering:

Macos task 11 T1040: Network Sniffing #1012

Regarding the outcome of #1048 we can consider renaming the file name prefix and also move it into the right folder.