### PR TITLE
[OSCD] Added a rule to detect execution of tracker.exe with suspicious parameters

### DIFF
--- a/rules/windows/process_creation/win_susp_runonce_execution.yml
+++ b/rules/windows/process_creation/win_susp_runonce_execution.yml
@@ -1,0 +1,29 @@
+title: Run Once task execution as configured in registry
+id: 198effb6-6c98-4d0c-9ea3-451fa143c45c
+description: This rule detects the execution of Run Once task as configured in the registry
+author: Avneet Singh '@v3t0_'
+status: experimental
+date: 2020/10/15
+references:
+    - https://twitter.com/pabraeken/status/990717080805789697
+    - https://github.com/LOLBAS-Project/LOLBAS/blob/master/yml/OSBinaries/Runonce.yml
+tags:
+    - attack.defense_evasion
+    - attack.t1112
+logsource:
+    product: windows
+    category: process_creation
+detection:
+    process_name:
+        Image|endswith:
+            - '\runonce.exe'
+    process_description:
+        Description:
+            - 'Run Once Wrapper'
+    command_line:
+        CommandLine|contains:
+            - ' /AlternateShellStartup'
+    condition: (process_name or process_description) and command_line
+falsepositives:
+    - Unknown
+level: medium

--- a/rules/windows/process_creation/win_susp_tracker_execution.yml
+++ b/rules/windows/process_creation/win_susp_tracker_execution.yml
@@ -1,0 +1,31 @@
+title: DLL code injection and execution via Tracker.exe 
+id: 148431ce-4b70-403d-8525-fcc2993f29ea
+description: This rule detects DLL injection and execution via LOLBAS - Tracker.exe
+author: Avneet Singh '@v3t0_'
+status: experimental
+date: 2020/10/15
+references:
+    - https://github.com/LOLBAS-Project/LOLBAS/blob/master/yml/OtherMSBinaries/Tracker.yml
+tags:
+    - attack.defense_evasion
+    - attack.t1055.001
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    process_name:
+        Image|endswith:
+            - '\tracker.exe'
+    process_description:
+        Description:
+            - 'Tracker'
+    commandline_param1:
+        CommandLine|contains:
+            - ' /d '
+    commandline_param2:
+        CommandLine|contains:
+            - ' /c '
+    condition: (process_name or process_description) and commandline_param1 and commandline_param2
+falsepositives:
+    - Unknown
+level: medium

--- a/rules/windows/registry_event/sysmon_runonce_persistence.yml
+++ b/rules/windows/registry_event/sysmon_runonce_persistence.yml
@@ -1,0 +1,25 @@
+title: Run Once task configuration in the registry
+id: c74d7efc-8826-45d9-b8bb-f04fac9e4eff
+description: Rule to detect the configuration of Run Once registry key. Configured payload can be run by runonce.exe /AlternateShellStartup
+author: Avneet Singh '@v3t0_'
+status: experimental
+date: 2020/10/15
+references:
+    - https://twitter.com/pabraeken/status/990717080805789697
+    - https://github.com/LOLBAS-Project/LOLBAS/blob/master/yml/OSBinaries/Runonce.yml
+tags:
+    - attack.defense_evasion
+    - attack.t1112
+logsource:
+    product: windows
+    service: sysmon
+detection:
+    selection:
+      EventID: 13
+      TargetObject|startswith: 'HKLM\SOFTWARE\Microsoft\Active Setup\Installed Components'
+      EventType: 'SetValue'
+      TargetObject|endswith: '\StubPath'
+    condition: selection
+falsepositives:
+    - Legitimate modification of the registry key by legitimate program
+level: medium


### PR DESCRIPTION
Added a rule to detect the execution of tracker.exe. If it's been executed with -d and -c param, a dll can be injected into the target executable.