### PR TITLE
[OSCD] Added a rule to detect possible Zerologon exploitation

### DIFF
--- a/rules/windows/builtin/win_privesc_cve_2020_1472.yml
+++ b/rules/windows/builtin/win_privesc_cve_2020_1472.yml
@@ -1,0 +1,28 @@
+title: 'Possible Zerologon (CVE-2020-1472) exploitation'
+id: dd7876d8-0f09-11eb-adc1-0242ac120002
+status: experimental
+description: Detects Netlogon Elevation of Privilege Vulnerability aka Zerologon (CVE-2020-1472)
+references:
+    - https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2020-1472
+    - https://www.logpoint.com/en/blog/detecting-zerologon-vulnerability-in-logpoint/
+author: 'Aleksandr Akhremchik, @aleqs4ndr, ocsd.community'
+date: 2020/10/15
+tags:
+    - attack.t1068
+    - attack.privilege_escalation
+logsource:
+    product: windows
+    service: security
+detection:
+    selection:
+        EventID: 4742
+        SourceUserName: 'ANONYMOUS LOGON'
+        TargetUserName: '%DC-MACHINE-NAME$%' # DC machine account name that ends with '$'
+    filter:
+        ChangedAttributes|contains:
+            - 'Password Last Set:	-'
+    condition: selection and not filter
+falsepositives:
+    - automatic DC computer account password change
+    - legitimate DC computer account password change
+level: high

--- a/rules/windows/builtin/win_privesc_cve_2020_1472.yml
+++ b/rules/windows/builtin/win_privesc_cve_2020_1472.yml
@@ -1,4 +1,4 @@
-title: 'Possible Zerologon (CVE-2020-1472) exploitation'
+title: 'Possible Zerologon (CVE-2020-1472) Exploitation'
 id: dd7876d8-0f09-11eb-adc1-0242ac120002
 status: experimental
 description: Detects Netlogon Elevation of Privilege Vulnerability aka Zerologon (CVE-2020-1472)

--- a/rules/windows/builtin/win_privesc_cve_2020_1472.yml
+++ b/rules/windows/builtin/win_privesc_cve_2020_1472.yml
@@ -17,7 +17,7 @@ detection:
     selection:
         EventID: 4742
         SourceUserName: 'ANONYMOUS LOGON'
-        TargetUserName: '%DC-MACHINE-NAME$%' # DC machine account name that ends with '$'
+        TargetUserName: '%DC-MACHINE-NAME%' # DC machine account name that ends with '$'
     filter:
         ChangedAttributes|contains:
             - 'Password Last Set:	-'


### PR DESCRIPTION
For this issue [#574](https://github.com/Neo23x0/sigma/issues/574)