### PR TITLE
 [OSCD] Always Install Elevated Alternative

### DIFF
--- a/rules/windows/process_creation/sysmon_always_install_elevated_windows_installer.yml
+++ b/rules/windows/process_creation/sysmon_always_install_elevated_windows_installer.yml
@@ -1,0 +1,37 @@
+title: Always Install Elevated Windows Installer 
+id: cd951fdc-4b2f-47f5-ba99-a33bf61e3770
+description: This rule will looks for Windows Installer service (msiexec.exe) when it tries to install MSI packages with SYSTEM privilege 
+status: experimental
+author: Teymur Kheirkhabarov (idea), Mangatas Tondang (rule), oscd.community
+date: 2020/10/13
+references: 
+    - https://image.slidesharecdn.com/kheirkhabarovoffzonefinal-181117201458/95/hunting-for-privilege-escalation-in-windows-environment-48-638.jpg
+tags:
+    - attack.privilege_escalation
+    - attack.t1548.002
+logsource:
+    product: windows
+    category: process_creation
+detection:
+    integrity_level:
+        IntegrityLevel: 'System'
+    user:
+        User: 'NT AUTHORITY\SYSTEM'
+    image_1:
+        Image|contains|all: 
+            - '\Windows\Installer\'
+            - 'msi'
+        Image|endswith: 
+            - 'tmp'
+    image_2:
+        Image|endswith:
+            - '\msiexec.exe'
+    condition: (image_1 and user) or (image_2 and user and integrity_level)
+fields:
+    - IntegrityLevel
+    - User
+    - Image
+falsepositives:
+    - System administrator Usage
+    - Penetration test 
+level: high


### PR DESCRIPTION
Page [48](https://image.slidesharecdn.com/kheirkhabarovoffzonefinal-181117201458/95/hunting-for-privilege-escalation-in-windows-environment-48-638.jpg) from #574 

Alternative to #1195  because the rule is on the unsupported folder. Following suggestion from @yugoslavskiy - https://github.com/Neo23x0/sigma/issues/574#issuecomment-710690252 