### PR TITLE
[OSCD] Add Files Dropped to Program Files by Non-Priviledged Process Rule

### DIFF
--- a/.github/workflows/sigma-test.yml
+++ b/.github/workflows/sigma-test.yml
@@ -23,18 +23,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r tools/requirements.txt -r tools/requirements-devel.txt
-        wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add -
-        sudo apt install -y apt-transport-https
-        echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic.list
-        sudo apt update
-        sudo apt install -y elasticsearch
-        sudo systemctl start elasticsearch
     - name: Test Sigma Tools and Rules
       run: |
         make test
-    - name: Test Generated Elasticsearch Query Strings
-      run: |
-        make test-backend-es-qs
     - name: Test SQL(ite) Backend
       run: |
         make test-backend-sql

--- a/rules/windows/file_event/sysmon_non_priv_program_files_move.yml
+++ b/rules/windows/file_event/sysmon_non_priv_program_files_move.yml
@@ -21,10 +21,11 @@ detection:
         - TargetFilename|contains:
             - '\Program Files\'
             - '\Program Files (x86)\'
-        - TargetFilename|startswith: '\Windows\'
+    windows:
+        TargetFilename|startswith: '\Windows\'
     temp:
         TargetFilename|contains: 'temp'
-    condition: integrity and (program_files or temp)
+    condition: integrity and (program_files or windows and not temp)
 falsepositives:
     - Unknown
 level: medium

--- a/rules/windows/file_event/sysmon_non_priv_program_files_move.yml
+++ b/rules/windows/file_event/sysmon_non_priv_program_files_move.yml
@@ -1,0 +1,30 @@
+title: Files Dropped to Program Files by Non-Priviledged Process
+id: d6d9f4fb-4c1c-4f53-b306-62a22c7c61e1
+description: Search for dropping of files to Windows/Program Files fodlers by non-priviledged processes
+status: experimental
+author: Teymur Kheirkhabarov (idea), Ryan Plas (rule), oscd.community
+date: 2020/10/17
+references:
+    - https://image.slidesharecdn.com/kheirkhabarovoffzonefinal-181117201458/95/hunting-for-privilege-escalation-in-windows-environment-37-638.jpg
+tags:
+    - attack.persistence
+    - attack.defense_evasion
+    - attack.t1574
+    - attack.t1574.010
+logsource:
+    category: file_event
+    product: windows
+detection:
+    integrity:
+        IntegrityLevel: 'Medium'
+    program_files:
+        - TargetFilename|contains:
+            - '\Program Files\'
+            - '\Program Files (x86)\'
+        - TargetFilename|startswith: '\Windows\'
+    temp:
+        TargetFilename|contains: 'temp'
+    condition: integrity and (program_files or temp)
+falsepositives:
+    - Unknown
+level: medium


### PR DESCRIPTION
Page 37 from #574 

![](https://image.slidesharecdn.com/kheirkhabarovoffzonefinal-181117201458/95/hunting-for-privilege-escalation-in-windows-environment-37-638.jpg)

I took some liberties in changing the detection a bit to make more sense to me, but let me know if it's now incorrect. I put wildcards around  `\Program Files\` and `\Program Files (x86)\` and made `*temp*` be linked with an OR instead of an AND

```
>tools/sigmac -c sysmon -c helk --target es-qs rules/windows/file_event/sysmon_non_priv_program_files_move.yml

(event_id:"11" AND IntegrityLevel:"Medium" AND (file_name.keyword:(*\\Program\ Files\\* OR *\\Program\ Files\ \(x86\)\\*) OR file_name.keyword:\\Windows\\* OR file_name.keyword:*temp*))
```