### PR TITLE
[OSCD] Added a rule to detect potential persistence using registry keys

### DIFF
--- a/rules/proxy/proxy_ua_apt.yml
+++ b/rules/proxy/proxy_ua_apt.yml
@@ -48,6 +48,7 @@ detection:
         - 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT)'  # https://blog.telsy.com/meeting-powerband-the-apt33-net-powerton-variant/
         - 'Mozilla/5.0 (Windows NT 6.1; WOW64) Chrome/28.0.1500.95 Safari/537.36'  # Hidden Cobra malware
         - 'Mozilla/5.0 (Windows NT 6.2; Win32; rv:47.0)'  # Strong Pity loader https://twitter.com/VK_Intel/status/1264185981118406657
+        - 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1;SV1;'  # Mustang Panda https://insights.oem.avira.com/new-wave-of-plugx-targets-hong-kong/
     condition: selection
 fields:
     - ClientIP

--- a/rules/proxy/proxy_ua_suspicious.yml
+++ b/rules/proxy/proxy_ua_suspicious.yml
@@ -10,18 +10,22 @@ references:
 logsource:
     category: proxy
 detection:
-    selection:
-      c-useragent:
-        # Badly scripted UA
+    selection1:
+      c-useragent|startswith:
         - 'user-agent'  # User-Agent: User-Agent:
-        - '* (compatible;MSIE *'  # typical typo - missing space
-        - '*.0;Windows NT *'  # typical typo - missing space
-        - 'Mozilla/3.0 *'
-        - 'Mozilla/2.0 *'
-        - 'Mozilla/1.0 *'
-        - 'Mozilla *'  # missing slash
-        - ' Mozilla/*'  # leading space
-        - 'Mozila/*'  # single 'l'
+        - 'Mozilla/3.0 '
+        - 'Mozilla/2.0 '
+        - 'Mozilla/1.0 '
+        - 'Mozilla '  # missing slash
+        - ' Mozilla/'  # leading space
+        - 'Mozila/'  # single 'l'
+        - 'Mozilla/4.0 (compatible; MSIE 6.0; MS Web Services Client Protocol'  # https://twitter.com/NtSetDefault/status/1303643299509567488
+    selection2:
+      c-useragent|contains:
+        - ' (compatible;MSIE '  # typical typo - missing space
+        - '.0;Windows NT '  # typical typo - missing space
+    selection3:
+      c-useragent:
         - '_'
         - 'CertUtil URL Agent'  # https://twitter.com/stvemillertime/status/985150675527974912
         - 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:60.0)'  # CobaltStrike Beacon https://unit42.paloaltonetworks.com/tracking-oceanlotus-new-downloader-kerrdown/
@@ -30,7 +34,7 @@ detection:
     falsepositives:
         c-useragent:
             - 'Mozilla/3.0 * Acrobat *'  # Acrobat with linked content
-    condition: selection and not falsepositives
+    condition: ( selection1 or selection2 or selection3 ) and not falsepositives
 fields:
     - ClientIP
     - c-uri

--- a/rules/windows/process_creation/win_crime_snatch_ransomware.yml
+++ b/rules/windows/process_creation/win_crime_snatch_ransomware.yml
@@ -1,7 +1,7 @@
 title: Snatch Ransomware
 id: 5325945e-f1f0-406e-97b8-65104d393fff
 status: experimental
-description: Detects specific process characteristics of Maze ransomware word document droppers
+description: Detects specific process characteristics of Snatch ransomware word document droppers
 references:
     - https://news.sophos.com/en-us/2019/12/09/snatch-ransomware-reboots-pcs-into-safe-mode-to-bypass-protection/
 author: Florian Roth

--- a/rules/windows/process_creation/win_susp_mpcmdrun_download.yml
+++ b/rules/windows/process_creation/win_susp_mpcmdrun_download.yml
@@ -10,6 +10,8 @@ references:
 tags:
     - attack.defense_evasion
     - attack.t1218.010
+    - attack.command_and_control
+    - attack.t1105
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_susp_ping_hex_ip.yml
+++ b/rules/windows/process_creation/win_susp_ping_hex_ip.yml
@@ -6,6 +6,7 @@ references:
     - https://twitter.com/vysecurity/status/977198418354491392
 author: Florian Roth
 date: 2018/03/23
+modified: 2020/10/16
 tags:
     - attack.defense_evasion
     - attack.t1140
@@ -15,9 +16,11 @@ logsource:
     product: windows
 detection:
     selection:
-        CommandLine:
-            - '*\ping.exe 0x*'
-            - '*\ping 0x*'
+        CommandLine|contains:
+            - '\ping.exe 0x'
+            - '\ping 0x'
+        Image|contains:
+            - 'ping.exe'
     condition: selection
 fields:
     - ParentCommandLine

--- a/rules/windows/process_creation/win_susp_wmi_execution.yml
+++ b/rules/windows/process_creation/win_susp_wmi_execution.yml
@@ -29,6 +29,5 @@ tags:
     - attack.t1047
     - car.2016-03-002
 falsepositives:
-    - Will need to be tuned
-    - If using Splunk, I recommend | stats count by Computer,CommandLine following for easy hunting by Computer/CommandLine.
+    - If using Splunk, we recommend | stats count by Computer,CommandLine following for easy hunting by Computer/CommandLine
 level: medium

--- a/rules/windows/process_creation/win_susp_wmic_proc_create_rundll32.yml
+++ b/rules/windows/process_creation/win_susp_wmic_proc_create_rundll32.yml
@@ -1,0 +1,26 @@
+title: Suspicious WMI Execution Using Rundll32
+id: 3c89a1e8-0fba-449e-8f1b-8409d6267ec8
+status: experimental
+description: Detects WMI executing rundll32
+references:
+    - https://thedfirreport.com/2020/10/08/ryuks-return/
+author: Florian Roth
+date: 2020/10/12
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        CommandLine|contains|all:
+            - 'process call create'
+            - 'rundll32'
+    condition: selection
+fields:
+    - CommandLine
+    - ParentCommandLine
+tags:
+    - attack.execution
+    - attack.t1047
+falsepositives:
+    - Unknown
+level: high

--- a/rules/windows/registry_event/sysmon_runonce_persistence.yml
+++ b/rules/windows/registry_event/sysmon_runonce_persistence.yml
@@ -15,8 +15,8 @@ logsource:
     category: registry_event
 detection:
     selection:
-      TargetObject|startswith: 'HKLM\SOFTWARE\Microsoft\Active Setup\Installed Components'
       EventType: 'SetValue'
+      TargetObject|startswith: 'HKLM\SOFTWARE\Microsoft\Active Setup\Installed Components'
       TargetObject|endswith: '\StubPath'
     condition: selection
 falsepositives:

--- a/rules/windows/registry_event/sysmon_runonce_persistence.yml
+++ b/rules/windows/registry_event/sysmon_runonce_persistence.yml
@@ -1,0 +1,25 @@
+title: Run Once Task Configuration in Registry
+id: c74d7efc-8826-45d9-b8bb-f04fac9e4eff
+description: Rule to detect the configuration of Run Once registry key. Configured payload can be run by runonce.exe /AlternateShellStartup
+author: 'Avneet Singh @v3t0_, oscd.community'
+status: experimental
+date: 2020/10/18
+references:
+    - https://twitter.com/pabraeken/status/990717080805789697
+    - https://github.com/LOLBAS-Project/LOLBAS/blob/master/yml/OSBinaries/Runonce.yml
+tags:
+    - attack.defense_evasion
+    - attack.t1112
+logsource:
+    product: windows
+    category: registry_event
+detection:
+    selection:
+      EventID: 13
+      TargetObject|startswith: 'HKLM\SOFTWARE\Microsoft\Active Setup\Installed Components'
+      EventType: 'SetValue'
+      TargetObject|endswith: '\StubPath'
+    condition: selection
+falsepositives:
+    - Legitimate modification of the registry key by legitimate program
+level: medium

--- a/rules/windows/registry_event/sysmon_runonce_persistence.yml
+++ b/rules/windows/registry_event/sysmon_runonce_persistence.yml
@@ -15,7 +15,6 @@ logsource:
     category: registry_event
 detection:
     selection:
-      EventID: 13
       TargetObject|startswith: 'HKLM\SOFTWARE\Microsoft\Active Setup\Installed Components'
       EventType: 'SetValue'
       TargetObject|endswith: '\StubPath'

--- a/tools/sigma/parser/condition.py
+++ b/tools/sigma/parser/condition.py
@@ -506,12 +506,39 @@ class SigmaConditionParser:
         """
         Iterative parsing of search expression.
         """
+        def find_close_token_index_in_pairs(tokens, start_index, open_token, close_token):
+            """
+                the function try to find close_token index for open_token in pairs
+                e.g
+                    open_token was '(' and
+                    tokens were ['(', '...', '(', '...', ')', ')']
+                    the first '(' should pair with the last ')' instead of the first ')'
+                
+                Parameters:
+                    tokens: the list of tokens
+                    start_index: the start index (included) of the input tokens for finding the close_token
+                    open_token: the token that considered as opening token
+                    close_token: the token that considered as closing token
+                Returns:
+                    the index of the close_token in pair with the open_token
+                    raise ValueError when there is no close_token in pairs
+            """
+            open_token_count = 0
+            for i in range(start_index, len(tokens)):
+                if tokens[i] == open_token:
+                    open_token_count += 1
+                elif tokens[i] == close_token:
+                    if open_token_count == 0:
+                        return i
+                    else:
+                        open_token_count -= 1
+            raise ValueError(f"matched close_token {close_token} is not found in tokens")
         # 1. Identify subexpressions with parentheses around them and parse them like a separate search expression
         while SigmaConditionToken.TOKEN_LPAR in tokens:
             lPos = tokens.index(SigmaConditionToken.TOKEN_LPAR)
             lTok = tokens[lPos]
             try:
-                rPos = tokens.index(SigmaConditionToken.TOKEN_RPAR)
+                rPos = find_close_token_index_in_pairs(tokens, lPos+1, SigmaConditionToken.TOKEN_LPAR, SigmaConditionToken.TOKEN_RPAR)
                 rTok = tokens[rPos]
             except ValueError as e:
                 raise SigmaParseError("Missing matching closing parentheses") from e

--- a/tools/sigma/sigma2misp.py
+++ b/tools/sigma/sigma2misp.py
@@ -5,13 +5,13 @@ import argparse
 import pathlib
 import urllib3
 urllib3.disable_warnings()
-from pymisp import PyMISP
+from pymisp import PyMISP, MISPEvent
 
 def create_new_event(args, misp):
     if hasattr(misp, "new_event"):
         return misp.new_event(info=args.info)["Event"]["id"]
     
-    event = misp.MISPEvent()
+    event = MISPEvent()
     event.info = args.info
     return misp.add_event(event)["Event"]["id"]
 


### PR DESCRIPTION
Added a rule to detect potential persistence by using the registry key: HKLM\SOFTWARE\Microsoft\Active Setup\Installed Components. An attacker can add payload in StubPath value and execute it via runonce.exe