### PR TITLE
Fix typo in win_apt_lazarus_session_hijack.yml

### DIFF
--- a/rules/windows/process_creation/win_apt_lazarus_session_highjack.yml
+++ b/rules/windows/process_creation/win_apt_lazarus_session_highjack.yml
@@ -8,7 +8,7 @@ tags:
     - attack.defense_evasion
     - attack.t1036 # an old one
     - attack.t1036.005
-author: Trent Liffick (@tliffick)
+author: Trent Liffick (@tliffick), Bartlomiej Czyz (@bczyz1)
 date: 2020/06/03
 logsource:
     category: process_creation
@@ -16,7 +16,7 @@ logsource:
 detection:
     selection:
         Image: 
-            - '*\mstdc.exe'
+            - '*\msdtc.exe'
             - '*\gpvc.exe'
     filter:
         Image:


### PR DESCRIPTION
As described in the references, the binary name is MSDTC.exe, not MSTDC.exe.
https://media.kasperskycontenthub.com/wp-content/uploads/sites/43/2018/03/07180244/Lazarus_Under_The_Hood_PDF_final.pdf