### PR TITLE
Fix unicode error in sigma2attack

### DIFF
--- a/tools/sigma/sigma2attack.py
+++ b/tools/sigma/sigma2attack.py
@@ -21,7 +21,7 @@ def main():
     num_rules_used = 0
     for rule_file in rule_files:
         try:
-            rule = yaml.safe_load(open(rule_file).read())
+            rule = yaml.safe_load(open(rule_file, encoding="utf-8").read())
         except yaml.YAMLError:
             sys.stderr.write("Ignoring rule " + rule_file + " (parsing failed)\n")
             continue


### PR DESCRIPTION
using sigma2attack on the repository database fails on a recent python3 installation (python 3.9 tested on windows) because of bad usage of `open` and unicode caracters in [win_defender_disabled.yml](/rules/windows/other/win_defender_disabled.yml).

