### PR TITLE
added role name field to ecs-cloudtrail.

### DIFF
--- a/tools/config/ecs-cloudtrail.yml
+++ b/tools/config/ecs-cloudtrail.yml
@@ -40,6 +40,7 @@ fieldmappings:
   userIdentity.principalId: user.id
   userIdentity.sessionContext.attributes.creationDate: aws.cloudtrail.user_identity.session_context.creation_date
   userIdentity.sessionContext.attributes.mfaAuthenticated: aws.cloudtrail.user_identity.session_context.mfa_authenticated
+  userIdentity.sessionContext.sessionIssuer.userName: role.name
   userIdentity.type: aws.cloudtrail.user_identity.type
   userIdentity.userName: user.name
   vpcEndpointId: aws.cloudtrail.vpc_endpoint_id 


### PR DESCRIPTION
There was previously no mapping for the role name field in the ecs-cloudtrail.yml.

This field can actually help trace the effective role that is making the API calls.