### PR TITLE
Remove --- from a rule

### DIFF
--- a/rules/network/net_high_dns_requests_rate.yml
+++ b/rules/network/net_high_dns_requests_rate.yml
@@ -16,7 +16,6 @@ tags:
     - attack.command_and_control
     - attack.t1071 # an old one
     - attack.t1071.004
----
 logsource:
     category: dns
 detection:
@@ -24,7 +23,6 @@ detection:
         query: '*'
     timeframe: 1m
     condition: selection | count() by src_ip > 1000
----
 logsource:
     category: firewall
 detection:


### PR DESCRIPTION
If you try to parse the file with a yaml parser it fails with:

```
  in "<unicode string>", line 1, column 1:
    action: global
    ^
but found another document
  in "<unicode string>", line 19, column 1:
    ---
```