### PR TITLE
Backend: FireEye Helix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ test-sigmac:
 	$(COVERAGE) run -a --include=$(COVSCOPE) tools/sigmac -rvdI -t sqlite -c sysmon rules/ > /dev/null
 	$(COVERAGE) run -a --include=$(COVSCOPE) tools/sigmac -rvdI -t csharp -c sysmon rules/ > /dev/null
 	$(COVERAGE) run -a --include=$(COVSCOPE) tools/sigmac -rvdI -t logiq -c sysmon rules/ > /dev/null
+	$(COVERAGE) run -a --include=$(COVSCOPE) tools/sigmac -rvdI -t fireeye-helix -c tools/config/fireeye-helix.yml rules/ > /dev/null
 	$(COVERAGE) run -a --include=$(COVSCOPE) tools/sigmac -rvdI -t sysmon -c sysmon -rvd rules/windows/driver_load rules/windows/file_event rules/windows/image_load rules/windows/network_connection rules/windows/process_access rules/windows/process_creation rules/windows/registry_event rules/windows/sysmon > /dev/null
 	$(COVERAGE) run -a --include=$(COVSCOPE) tools/sigmac -rvdI -t splunk -c tools/config/splunk-windows-index.yml -f 'level>=high,level<=critical,status=stable,logsource=windows,tag=attack.execution' rules/ > /dev/null
 	! $(COVERAGE) run -a --include=$(COVSCOPE) tools/sigmac -rvdI -t splunk -c tools/config/splunk-windows-index.yml -f 'level>=high,level<=critical,status=xstable,logsource=windows' rules/ > /dev/null

--- a/tools/config/fireeye-helix.yml
+++ b/tools/config/fireeye-helix.yml
@@ -1,0 +1,169 @@
+title: FireEye Helix
+order: 20
+backends:
+    - fireeye-helix
+logsources:
+    windows:
+        product: windows
+        index: windows
+    windows-application:
+        product: windows
+        index: windows
+        service: application
+        conditions:
+            channel: Application
+    windows-security:
+        product: windows
+        index: windows
+        service: security
+        conditions:
+            channel: Security
+    windows-sysmon:
+        product: windows
+        index: windows
+        service: sysmon
+        conditions:
+            channel: Microsoft-Windows-Sysmon
+    windows-dns-server:
+        product: windows
+        index: windows
+        service: dns-server
+        conditions:
+            channel: 'DNS Server'
+    windows-driver-framework:
+        product: windows
+        index: windows
+        service: driver-framework
+        conditions:
+            channel: 'Microsoft-Windows-DriverFrameworks-UserMode/Operational'
+    windows-dhcp:
+        product: windows
+        index: windows
+        service: dhcp
+        conditions:
+            channel: 'Microsoft-Windows-DHCP-Server/Operational'
+    windows-defender:
+        product: windows
+        index: windows
+        service: windefend
+        conditions:
+            channel: 'Microsoft-Windows-Windows Defender/Operational'
+    windows-ntlm:
+        product: windows
+        index: windows
+        service: ntlm
+        conditions:
+            channel: 'Microsoft-Windows-NTLM/Operational'
+    windows-applocker:
+        product: windows
+        index: windows
+        service: applocker
+        conditions:
+            channel:
+            - 'Microsoft-Windows-AppLocker/MSI and Script'
+            - 'Microsoft-Windows-AppLocker/EXE and DLL'
+            - 'Microsoft-Windows-AppLocker/Packaged app-Deployment'
+            - 'Microsoft-Windows-AppLocker/Packaged app-Execution'
+    windows-powershell:
+        product: windows
+        index: windows
+        service: powershell
+        conditions:
+            channel: 'Microsoft-Windows-Powershell'
+    linux:
+        product: linux
+        index: posix
+    unix:
+        product: unix
+        index: posix
+    dns:
+        category: dns
+        index: dns
+    firewall:
+        category: firewall
+        index: firewall
+    connection:
+        category: netflow
+        index: connection
+    proxy:
+        category: proxy
+        index: http_proxy
+    antivirus:
+        product: antivirus
+        index: antivirus
+    webserver:
+        category: webserver
+        index: http_server
+fieldmappings:
+    AccessMask: accessmask
+    AccountName: username
+    cs-host: domain
+    cs-method: method
+    c-uri: url
+    c-uri-extension: uri
+    c-uri-path: uri
+    c-uri-query: uri
+    c-uri-stem: url
+    c-useragent: useragent
+    ClientAddress: ~srcipv4
+    ClientIPAddress: ~srcipv4
+    ClientIP: ~srcipv4
+    CommandLine: args
+    ComputerName: username
+    CurrentDirectory: cwd
+    DestAddress: ~dstipv4
+    DestinationHostname: dsthost
+    DestinationIp: ~dstipv4
+    DestinationPort: dstport
+    destination.port: dstport
+    dst: ~dstipv4
+    dst_ip: ~dstipv4
+    dst_port: dstport
+    EventID: eventid
+    EventType: eventtype
+    file_hash: ~hash
+    FileName: filename
+    FileVersion: version
+    HostVersion: version
+    Image: process
+    Imphash: imphash
+    ipAddress: ~dstipv4
+    IpAddress: ~srcipv4
+    IPString: ~srcipv4
+    LogonType: logontype
+    NewProcessName: process
+    ObjectName: object
+    ObjectType: object_type
+    ParentImage: pprocess
+    ParentProcessName: pprocess
+    Path: filepath
+    ProcessName: process
+    ProcessCommandLine: args
+    Product: product
+    r-dns: domain
+    sc-status: status
+    ServiceFileName: filepath
+    ShareName: filename
+    SourceAddress: ~srcipv4
+    SourceHostname: srchost
+    SourceImage: process
+    SourceIp: ~srcipv4
+    SourcePort: srcport
+    src: ~srcipv4
+    src_ip: ~srcipv4
+    src_port: srcport
+    Status: status
+    SubjectUserName: username
+    TargetServer: ~dstipv4
+    TaskName: task
+    TargetFilename: filepath
+    TargetImage: filepath
+    TargetObject: object
+    USER: username
+    User: accountname
+    UserAgent: useragent
+    UserName: username
+    username: username
+    Version: version
+    Workstation: srchost
+    WorkstationName: srchost

--- a/tools/sigma/backends/fireeye-helix.py
+++ b/tools/sigma/backends/fireeye-helix.py
@@ -1,0 +1,166 @@
+# Output backends for sigmac
+# Copyright 2020 FireEye, Inc.
+# Author: Alek Rollyson <alek.rollyson@fireeye.com>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from sigma.backends.base import SingleTextQueryBackend
+
+from sigma.parser.modifiers.base import SigmaTypeModifier
+from sigma.parser.modifiers.transform import (
+    SigmaContainsModifier,
+    SigmaStartswithModifier,
+    SigmaEndswithModifier,
+)
+from sigma.parser.modifiers.type import SigmaRegularExpressionModifier
+
+
+class FireEyeHelixBackend(SingleTextQueryBackend):
+    """Converts Sigma rule into FireEye Helix Query Language."""
+
+    identifier = "fireeye-helix"
+    active = True
+    index_field = "metaclass"
+    nonTaxonomyField = "rawmsg"
+
+    andToken = " "
+    orToken = " OR "
+    notToken = "NOT "
+    subExpression = "(%s)"
+    listExpression = "[%s]"
+    listAndExpression = "&[%s]"
+    listSeparator = ","
+    valueExpression = "`%s`"
+    nullExpression = "missing(%s)"
+    notNullExpression = "has(%s)"
+    mapExpression = "%s=%s"
+    mapContainsExpression = "%s:%s"
+    typedValueExpression = {
+        SigmaRegularExpressionModifier: "/%s/",
+        SigmaContainsModifier: "%s",
+        SigmaStartswithModifier: "%s",
+        SigmaEndswithModifier: "%s",
+    }
+    containsMatchFields = [index_field, nonTaxonomyField]
+    exactMatchFields = ["eventid", "srcport", "dstport", "channel"]
+
+    def __init__(self, *args, **kwargs):
+        """Initialize field mappings"""
+        super().__init__(*args, **kwargs)
+        # Retrieve a list of fields explicity mapped in the config so we can use "rawmsg" for unmapped fields
+        fl = ["metaclass", "channel"]
+        for item in self.sigmaconfig.fieldmappings.values():
+            if item.target_type == list:
+                fl.extend(item.target)
+            else:
+                fl.append(item.target)
+        self.allowedFieldsList = list(set(fl))
+
+    def generateMapItemNode(self, node):
+        key, value = node
+        # Default our expression to a contains match
+        divinedExpression = self.mapContainsExpression
+        # If a field defines what the expression would be, use this to lock it in despite what the value determines
+        fieldForcedExpression = False
+        # Special field handling
+        if key not in self.allowedFieldsList:
+            key = self.nonTaxonomyField
+        if key in self.containsMatchFields:
+            divinedExpression = self.mapContainsExpression
+            fieldForcedExpression = True
+        elif key in self.exactMatchFields:
+            divinedExpression = self.mapExpression
+            fieldForcedExpression = True
+
+        # Always exact match integers
+        if isinstance(value, int):
+            if not fieldForcedExpression:
+                divinedExpression = self.mapExpression
+            return divinedExpression % (key, self.generateNode(value))
+        elif isinstance(value, str):
+            value, divinedExpression = self.parseStringValue(
+                key, value, divinedExpression, fieldForcedExpression, False
+            )
+            return divinedExpression % (key, self.generateNode(value))
+        elif isinstance(value, list):
+            newList = []
+            # Iterate over our list values to deal with wildcards in strings
+            for _value in value:
+                if isinstance(_value, str):
+                    _value, divinedExpression = self.parseStringValue(
+                        key, _value, divinedExpression, fieldForcedExpression, True
+                    )
+                    newList.append(_value)
+                else:
+                    newList.append(_value)
+            return divinedExpression % (key, self.generateNode(newList))
+        elif isinstance(value, SigmaTypeModifier):
+            if isinstance(value, (SigmaStartswithModifier, SigmaEndswithModifier)):
+                divinedExpression = self.mapContainsExpression
+                # Strip prefix/suffix matching wildcards on rawmsg field searches
+                if key == self.nonTaxonomyField and isinstance(value, str):
+                    value.strip("*")
+            elif isinstance(value, SigmaContainsModifier):
+                divinedExpression = self.mapContainsExpression
+            elif isinstance(value, SigmaRegularExpressionModifier):
+                divinedExpression = self.mapContainsExpression
+            return divinedExpression % (key, self.generateTypedValueNode(value))
+        elif value is None:
+            return self.nullExpression % (key,)
+        else:
+            raise TypeError(
+                "Backend does not support map values of type " + str(type(value))
+            )
+
+    def generateNULLValueNode(self, node):
+        # Don't generate null value nodes for fields we don't map
+        if node.item is "rawmsg":
+            return None
+        else:
+            return self.notNullExpression % (node.item)
+
+    def generateNotNULLValueNode(self, node):
+        # Don't generate not null value nodes for fields we don't map
+        if node.item is "rawmsg":
+            return None
+        else:
+            return self.nullExpression % (node.item)
+
+    def parseStringValue(
+        self, key, value, divinedExpression, fieldForcedExpression, isList
+    ):
+        # Raise a NotImplementedError if the query contains mid value wildcards for now
+        # TODO figure out how to best handle this
+        if "*" in value[1:-1]:
+            raise NotImplementedError(
+                "Backend does not support queries containing mid value wildcards."
+            )
+        # Strip balanced wildcards
+        if value.startswith("*") and value.endswith("*"):
+            value = value[1:-1]
+            if not fieldForcedExpression:
+                divinedExpression = self.mapContainsExpression
+        # Prefix/suffix matches are "contains" operators
+        elif value.startswith("*") or value.endswith("*"):
+            # Strip wildcards from rawmsg matching because we don't know where in the log we're matching from
+            if key == self.nonTaxonomyField:
+                value = value.strip("*")
+            if not fieldForcedExpression:
+                divinedExpression = self.mapContainsExpression
+        # If we have no indicators of this being a "contains" match for a string, use an exact match
+        else:
+            if not fieldForcedExpression and not isList:
+                divinedExpression = self.mapExpression
+
+        return value, divinedExpression


### PR DESCRIPTION
Adds a backend for conversion to Helix MQL queries.

A couple of relevant questions I encountered while writing this:

* Would it make sense to provide an easier way to override the mixin that's adding wildcards around contains statements? Right now it seems like everyone that doesn't need balanced wildcards for contains statements is rewriting strings after the fact, which isn't very efficient
* Along the same lines, there isn't a great way of handling mid string wildcards right now. Talking about examples like: `*SYSTEM\\*ControlSet*\Control\Lsa*\NtlmMinClientSec`, `\AppData\Roaming\Oracle*\java*.exe`, or `*/E:vbscript * C:\Users\\*.txt" /F`. None of these are going to be well supported or performant in very many systems and the ways backends seem to be handling them right now are kinda hacky i.e. converting to regex, stripping the wildcards, or just leaving them be even though the query won't work. Might be more of a style guide type or problem where encouraging a regex or breaking the string up into a multi contains statement makes more sense than trying to handle every edge case here.