### PR TITLE
Fix field mapping for DestinationHostname

### DIFF
--- a/tools/config/carbon-black.yml
+++ b/tools/config/carbon-black.yml
@@ -9,7 +9,7 @@ fieldmappings:
   ComputerName: hostname
   CurrentDirectory: path
   Description: product_name
-  DestinationHostname: winlog.event_data.DestinationHostname
+  DestinationHostname: domain
   DestinationIp: ipaddr
   DestinationIsIpv6: ipaddr
   DestinationPort: ipport


### PR DESCRIPTION
DestinationHostname is mapped to wrong fieldname in Carbon Black, should be mapped to <domain>