### PR TITLE
Updated winlogbeat.yml config to include OriginalFileName

### DIFF
--- a/tools/config/winlogbeat.yml
+++ b/tools/config/winlogbeat.yml
@@ -112,6 +112,7 @@ fieldmappings:
   ObjectName: winlog.event_data.ObjectName
   ObjectType: winlog.event_data.ObjectType
   ObjectValueName: winlog.event_data.ObjectValueName
+  OriginalFileName: winlog.event_data.OriginalFileName
   ParentCommandLine: winlog.event_data.ParentCommandLine
   ParentProcessName: winlog.event_data.ParentProcessName
   ParentImage: winlog.event_data.ParentImage


### PR DESCRIPTION
Noticed process_creation/win_renamed_binary.yml wasn't generating hits where I thought it should because OriginalFileName was missing from the winlogbeat.yml config.

Let me know if there's a different branching/PR process you would prefer I follow.