### PR TITLE
fix "references" field + add test for references in plural form

### DIFF
--- a/rules/web/win_webshell_regeorg.yml
+++ b/rules/web/win_webshell_regeorg.yml
@@ -5,7 +5,7 @@ description: Certain strings in the uri_query field when combined with null refe
 author: Cian Heasley
 date: 2020/08/04
 modified: 2020/09/03
-reference:
+references:
     - https://community.rsa.com/community/products/netwitness/blog/2019/02/19/web-shells-and-netwitness-part-3
     - https://github.com/sensepost/reGeorg
 logsource:

--- a/rules/windows/other/win_defender_history_delete.yml
+++ b/rules/windows/other/win_defender_history_delete.yml
@@ -3,7 +3,7 @@ id: 2afe6582-e149-11ea-87d0-0242ac130003
 status: experimental
 description: Windows Defender logs when the history of detected infections is deleted. Log file will contain the message "Windows Defender Antivirus has removed history of malware and other potentially unwanted software".
 author: Cian Heasley
-reference:
+references:
     - https://docs.microsoft.com/en-us/windows/security/threat-protection/microsoft-defender-antivirus/troubleshoot-microsoft-defender-antivirus
 date: 2020/08/13
 tags:

--- a/rules/windows/process_creation/win_control_panel_item.yml
+++ b/rules/windows/process_creation/win_control_panel_item.yml
@@ -2,7 +2,7 @@ title: Control Panel Items
 id: 0ba863e6-def5-4e50-9cea-4dd8c7dc46a4
 status: experimental
 description: Detects the malicious use of a control panel item
-reference:
+references:
     - https://attack.mitre.org/techniques/T1196/
     - https://ired.team/offensive-security/code-execution/code-execution-through-control-panel-add-ins
 tags:

--- a/rules/windows/process_creation/win_dnscat2_powershell_implementation.yml
+++ b/rules/windows/process_creation/win_dnscat2_powershell_implementation.yml
@@ -3,7 +3,7 @@ id: b11d75d6-d7c1-11ea-87d0-0242ac130003
 status: experimental
 description: The PowerShell implementation of DNSCat2 calls nslookup to craft queries. Counting nslookup processes spawned by PowerShell will show hundreds or thousands of instances if PS DNSCat2 is active locally.
 author: Cian Heasley
-reference:
+references:
     - https://github.com/lukebaggett/dnscat2-powershell
     - https://blu3-team.blogspot.com/2019/08/powershell-dns-c2-notes.html
     - https://ragged-lab.blogspot.com/2020/06/it-is-always-dns-powershell-edition.html

--- a/rules/windows/process_creation/win_mouse_lock.yml
+++ b/rules/windows/process_creation/win_mouse_lock.yml
@@ -3,7 +3,7 @@ id: c9192ad9-75e5-43eb-8647-82a0a5b493e3
 status: experimental
 description: In Kaspersky's 2020 Incident Response Analyst Report they listed legitimate tool "Mouse Lock" as being used for both credential access and collection in security incidents.
 author: Cian Heasley
-reference:
+references:
     - https://github.com/klsecservices/Publications/blob/master/Incident-Response-Analyst-Report-2020.pdf
     - https://sourceforge.net/projects/mouselock/
 date: 2020/08/13

--- a/rules/windows/process_creation/win_webshell_detection.yml
+++ b/rules/windows/process_creation/win_webshell_detection.yml
@@ -2,7 +2,7 @@ title: Webshell Detection With Command Line Keywords
 id: bed2a484-9348-4143-8a8a-b801c979301c
 description: Detects certain command line parameters often used during reconnaissance activity via web shells
 author: Florian Roth
-reference:
+references:
     - https://www.fireeye.com/blog/threat-research/2013/08/breaking-down-the-china-chopper-web-shell-part-ii.html
 date: 2017/01/01
 modified: 2019/10/26

--- a/rules/windows/process_creation/win_webshell_recon_detection.yml
+++ b/rules/windows/process_creation/win_webshell_recon_detection.yml
@@ -3,7 +3,7 @@ id: f64e5c19-879c-4bae-b471-6d84c8339677
 status: experimental
 description: Looking for processes spawned by web server components that indicate reconnaissance by popular public domain webshells for whether perl, python or wget are installed.
 author: Cian Heasley
-reference:
+references:
     - https://ragged-lab.blogspot.com/2020/07/webshells-automating-reconnaissance.html
 date: 2020/07/22
 tags:

--- a/rules/windows/registry_event/sysmon_susp_mic_cam_access.yml
+++ b/rules/windows/registry_event/sysmon_susp_mic_cam_access.yml
@@ -3,7 +3,7 @@ id: 62120148-6b7a-42be-8b91-271c04e281a3
 description: Detects Processes accessing the camera and microphone from suspicious folder
 author: Den Iuzvyk
 date: 2020/06/07
-reference:
+references:
     - https://medium.com/@7a616368/can-you-track-processes-accessing-the-camera-and-microphone-7e6885b37072
 tags:
     - attack.collection

--- a/rules/windows/sysmon/sysmon_abusing_azure_browser_sso.yml
+++ b/rules/windows/sysmon/sysmon_abusing_azure_browser_sso.yml
@@ -2,7 +2,7 @@ title: Avusing Azure Browser SSO
 id: 50f852e6-af22-4c78-9ede-42ef36aa3453
 description: Detects abusing  Azure Browser SSO by requesting  OAuth 2.0 refresh tokens for an Azure-AD-authenticated Windows user (i.e. the machine is joined to Azure AD and a user logs in with their Azure AD account) wanting to perform SSO authentication in the browser. An attacker can use this to authenticate to Azure AD in a browser as that user.
 author: Den Iuzvyk
-reference:
+references:
    - https://posts.specterops.io/requesting-azure-ad-request-tokens-on-azure-ad-joined-machines-for-browser-sso-2b0409caad30
 date: 2020/07/15
 modified: 2020/08/26

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -249,7 +249,6 @@ class TestRules(unittest.TestCase):
         self.assertEqual(faulty_rules, [], Fore.RED + 
                          "There are rules using sysmon events but with no EventID specified")
 
-
     def test_missing_date(self):
         faulty_rules = []
         for file in self.yield_next_rule_file_path(self.path_to_rules):
@@ -261,25 +260,36 @@ class TestRules(unittest.TestCase):
                 print(Fore.YELLOW + "Rule {} has a malformed 'date' (not 10 chars, should be YYYY/MM/DD).".format(file))
                 faulty_rules.append(file)                
 
-        self.assertEqual(faulty_rules, [], Fore.RED + 
+        self.assertEqual(faulty_rules, [], Fore.RED +
                          "There are rules with missing or malformed 'date' fields. (create one, e.g. date: 2019/01/14)")
 
     def test_references(self):
         faulty_rules = []
         for file in self.yield_next_rule_file_path(self.path_to_rules):
             references = self.get_rule_part(file_path=file, part_name="references")
-            # Reference field doesn't exist      
-            #if not references:
-                #print(Fore.YELLOW + "Rule {} has no field 'references'.".format(file))
-                #faulty_rules.append(file)
+            # Reference field doesn't exist
+            # if not references:
+                # print(Fore.YELLOW + "Rule {} has no field 'references'.".format(file))
+                # faulty_rules.append(file)
             if references:
                 # it exists but isn't a list
                 if not isinstance(references, list):
                     print(Fore.YELLOW + "Rule {} has a references field that isn't a list.".format(file))
-                    faulty_rules.append(file)     
+                    faulty_rules.append(file)
 
         self.assertEqual(faulty_rules, [], Fore.RED + 
                          "There are rules with malformed 'references' fields. (has to be a list of values even if it contains only a single value)")
+
+    def test_references_plural(self):
+        faulty_rules = []
+        for file in self.yield_next_rule_file_path(self.path_to_rules):
+            reference = self.get_rule_part(file_path=file, part_name="reference")
+            if reference:
+                # it exists but in singular form
+                faulty_rules.append(file)
+
+        self.assertEqual(faulty_rules, [], Fore.RED +
+                         "There are rules with malformed 'references' fields. (has to be 'references' in plural form, not singular)")
 
     def test_file_names(self):
         faulty_rules = []


### PR DESCRIPTION
- Fix discrepancies between "reference" and "references" in rules
- Add a test to test_rules.py for this

Wiki about specs should be patched to reflect that the correct field name is "references" and not "reference" : https://github.com/Neo23x0/sigma/wiki/Specification#references-optional