### PR TITLE
Add sigmac flag to delimit results by NUL instead of \n

### DIFF
--- a/tools/sigma/sigmac.py
+++ b/tools/sigma/sigmac.py
@@ -103,7 +103,7 @@ def set_argparser():
     argparser.add_argument("--lists", "-l", action="store_true", help="List available output target formats and configurations")
     argparser.add_argument("--config", "-c", action="append", help="Configurations with field name and index mapping for target environment. Multiple configurations are merged into one. Last config is authorative in case of conflicts.")
     argparser.add_argument("--output", "-o", default=None, help="Output file or filename prefix if multiple files are generated")
-    argparser.add_argument("--print0", action="store_true", help="Delimit output by NUL-character")
+    argparser.add_argument("--print0", action="store_true", help="Delimit results by NUL-character")
     argparser.add_argument("--backend-option", "-O", action="append", help="Options and switches that are passed to the backend")
     argparser.add_argument("--backend-config", "-C", help="Configuration file (YAML format) containing options to pass to the backend")
     argparser.add_argument("--backend-help", action=ActionBackendHelp, help="Print backend options")

--- a/tools/sigma/sigmac.py
+++ b/tools/sigma/sigmac.py
@@ -236,7 +236,7 @@ def main():
             parser = SigmaCollectionParser(f, sigmaconfigs, rulefilter)
             results = parser.generate(backend)
 
-            newline_separator = '\0' if cmdargs.print0 else None
+            newline_separator = '\0' if cmdargs.print0 else '\n'
             for result in results:
                 print(result, file=out, end=newline_separator)
         except OSError as e:

--- a/tools/sigma/sigmac.py
+++ b/tools/sigma/sigmac.py
@@ -103,6 +103,7 @@ def set_argparser():
     argparser.add_argument("--lists", "-l", action="store_true", help="List available output target formats and configurations")
     argparser.add_argument("--config", "-c", action="append", help="Configurations with field name and index mapping for target environment. Multiple configurations are merged into one. Last config is authorative in case of conflicts.")
     argparser.add_argument("--output", "-o", default=None, help="Output file or filename prefix if multiple files are generated")
+    argparser.add_argument("--print0", action="store_true", help="Delimit output by NUL-character")
     argparser.add_argument("--backend-option", "-O", action="append", help="Options and switches that are passed to the backend")
     argparser.add_argument("--backend-config", "-C", help="Configuration file (YAML format) containing options to pass to the backend")
     argparser.add_argument("--backend-help", action=ActionBackendHelp, help="Print backend options")
@@ -234,8 +235,10 @@ def main():
                 f = sigmafile.open(encoding='utf-8')
             parser = SigmaCollectionParser(f, sigmaconfigs, rulefilter)
             results = parser.generate(backend)
+
+            newline_separator = '\0' if cmdargs.print0 else None
             for result in results:
-                print(result, file=out)
+                print(result, file=out, end=newline_separator)
         except OSError as e:
             print("Failed to open Sigma file %s: %s" % (sigmafile, str(e)), file=sys.stderr)
             error = ERR_OPEN_SIGMA_RULE


### PR DESCRIPTION
Hi,

I have added a flag called `--print0` to sigmac which changes the delimiter of the results from newline to the NUL-character.  
The use case for that is being able to deal with multiline results. The NUL-byte as record separator is widely supported by Unix tools such as `xargs -0` or `parallel -0`. The name for the flag was inspired by `-print0` from the `find` utility.