### PR TITLE
Added rule for Impacket's PsExec execution

### DIFF
--- a/rules/windows/builtin/win_impacket_psexec.yml
+++ b/rules/windows/builtin/win_impacket_psexec.yml
@@ -1,0 +1,26 @@
+title: Impacket PsExec Execution
+id: 32d56ea1-417f-44ff-822b-882873f5f43b
+description: Detects execution of Impacket's psexec.py.
+author: Bhabesh Raj
+date: 2020/12/14
+references:
+    - https://blog.menasec.net/2019/02/threat-hunting-3-detecting-psexec.html
+tags:
+    - attack.lateral_movement
+    - attack.t1021.002
+logsource:
+    product: windows
+    service: security
+    definition: 'The advanced audit policy setting "Object Access > Audit Detailed File Share" must be configured for Success/Failure'
+detection:
+    selection1:
+        EventID: 5145
+        ShareName: \\*\IPC$
+        RelativeTargetName|contains|or:
+            - 'RemCom_stdint'
+            - 'RemCom_stdoutt'
+            - 'RemCom_stderrt'
+    condition: selection1
+falsepositives:
+    - nothing observed so far
+level: high

--- a/rules/windows/builtin/win_impacket_psexec.yml
+++ b/rules/windows/builtin/win_impacket_psexec.yml
@@ -16,7 +16,7 @@ detection:
     selection1:
         EventID: 5145
         ShareName: \\*\IPC$
-        RelativeTargetName|contains|or:
+        RelativeTargetName|contains:
             - 'RemCom_stdint'
             - 'RemCom_stdoutt'
             - 'RemCom_stderrt'


### PR DESCRIPTION
Made changes to support detection of Impacket's PsExec.

Inspired from:
https://github.com/Neo23x0/sigma/blob/master/rules/windows/builtin/win_susp_psexec.yml
