### PR TITLE
Fix bug changing the logsource

### DIFF
--- a/rules/windows/process_creation/win_susp_adfind.yml
+++ b/rules/windows/process_creation/win_susp_adfind.yml
@@ -16,7 +16,7 @@ tags:
     #- attack.t1087.002
 logsource:
     product: windows
-    service: process_creation
+    category: process_creation
 detection:
     selection:
         ProcessCommandline|contains: 'objectcategory'


### PR DESCRIPTION
In the rule, the logsource field should be changed from service to category