### PR TITLE
Fix missing product mouse lock

### DIFF
--- a/rules/windows/process_creation/win_mouse_lock.yml
+++ b/rules/windows/process_creation/win_mouse_lock.yml
@@ -12,6 +12,7 @@ tags:
     - attack.collection
     - attack.t1056.002
 logsource:
+    product: windows
     category: process_creation
 detection:
     selection:

--- a/rules/windows/process_creation/win_susp_adfind.yml
+++ b/rules/windows/process_creation/win_susp_adfind.yml
@@ -16,7 +16,7 @@ tags:
     #- attack.t1087.002
 logsource:
     product: windows
-    category: process_creation
+    service: process_creation
 detection:
     selection:
         ProcessCommandline|contains: 'objectcategory'

--- a/rules/windows/process_creation/win_susp_adfind.yml
+++ b/rules/windows/process_creation/win_susp_adfind.yml
@@ -16,7 +16,7 @@ tags:
     #- attack.t1087.002
 logsource:
     product: windows
-    service: process_creation
+    category: process_creation
 detection:
     selection:
         ProcessCommandline|contains: 'objectcategory'


### PR DESCRIPTION
For the "mouse lock" rule, the logsource product field was missing.