### PR TITLE
Fixed typo in file format

### DIFF
--- a/rules/web/web_solarwinds_cve_2020_10148.yml
+++ b/rules/web/web_solarwinds_cve_2020_10148.yml
@@ -14,8 +14,8 @@ logsource:
 detection:
     selection:
         c-uri|contains:
-            - "WebResource.adx"
-            - "ScriptResource.adx"
+            - "WebResource.axd"
+            - "ScriptResource.axd"
             - "i18n.ashx"
             - "Skipi18n"
     valid_request_1:


### PR DESCRIPTION
There is a typo in file extension in the CERT's Vulnerability Note, as pointed out here: 

https://twitter.com/em1rerdogan/status/1343100528415432705

