### PR TITLE
Update sumologic.yml

### DIFF
--- a/tools/config/sumologic.yml
+++ b/tools/config/sumologic.yml
@@ -2,6 +2,15 @@ title: SumoLogic
 order: 20
 backends:
   - sumologic
+afl_fields:
+  - _index
+  - EventID
+  - CommandLine
+  - NewProcessName
+  - Image
+  - ParentImage
+  - ParentCommandLine
+  - ParentProcessName
 # Sumulogic mapping depends on customer configuration. Adapt to your context!
 # typically rule on _sourceCategory, _index or Field Extraction Rules (FER)
 # supposing existing FER for service, EventChannel, EventID


### PR DESCRIPTION
The commit from vihreb on October 6, 2020 (https://github.com/Neo23x0/sigma/commit/51df5ad8764cd6896a3ef83ad388aebc136d5815) removed some items from the allowed fields list for the sumologic backend (https://github.com/Neo23x0/sigma/blob/51df5ad8764cd6896a3ef83ad388aebc136d5815/tools/sigma/backends/sumologic.py#L161) with the expectation that they are included in the sumologic config, however the default sumologic config does not reflect that change. This breaks the parsing of maps from rules. For example, when trying to run sigmac on a rule with multiple EventID values, the result is an error that states "argument of type 'int' is not iterable."

I suspect that this change in the behavior of the backend was made to accommodate for new sumologic-cse config which may not need the additional allowed fields that the regular sumologic config does. As such, I think it would probably make the most sense to re-add these fields to the sumologic config file rather than directly back into the backend for sumologic.

Note: In the config, I did not include those fields that are presently hard coded in the allowed field list in the sumologic backend (e.g. _sourceCategory and _view were removed). I also removed "sourcename" since from what I can tell, the syntax that vihreb added to the sumologic backend "_sourceName" is actually correct.