### PR TITLE
Typo on field name

### DIFF
--- a/rules/windows/process_creation/win_susp_adfind.yml
+++ b/rules/windows/process_creation/win_susp_adfind.yml
@@ -3,8 +3,8 @@ id: 75df3b17-8bcc-4565-b89b-c9898acef911
 status: experimental
 description: Detects the execution of a AdFind for Active Directory enumeration 
 references:
-    - https://social.technet.microsoft.com/wiki/contents/articles/7535.adfind-command-examples.aspx
-    - https://github.com/center-for-threat-informed-defense/adversary_emulation_library/blob/master/fin6/Emulation_Plan/Phase1.md
+    - 
+    - 
 author: FPT.EagleEye Team
 date: 2020/09/26
 tags:
@@ -19,7 +19,7 @@ logsource:
     service: process_creation
 detection:
     selection:
-        ProcessCommandline|contains: 'objectcategory'
+        ProcessCommandLine|contains: 'objectcategory'
         Image: 
             - '*\adfind.exe'
     condition: selection

--- a/rules/windows/process_creation/win_susp_adfind.yml
+++ b/rules/windows/process_creation/win_susp_adfind.yml
@@ -3,8 +3,8 @@ id: 75df3b17-8bcc-4565-b89b-c9898acef911
 status: experimental
 description: Detects the execution of a AdFind for Active Directory enumeration 
 references:
-    - 
-    - 
+    - https://social.technet.microsoft.com/wiki/contents/articles/7535.adfind-command-examples.aspx
+    - https://github.com/center-for-threat-informed-defense/adversary_emulation_library/blob/master/fin6/Emulation_Plan/Phase1.md
 author: FPT.EagleEye Team
 date: 2020/09/26
 tags:


### PR DESCRIPTION
Original field on event log is Process Command Line so translated field name will be ProcessCommandLine