### PR TITLE
fix service from system to security for rule win_pcap_drivers.yml

### DIFF
--- a/rules/windows/other/win_pcap_drivers.yml
+++ b/rules/windows/other/win_pcap_drivers.yml
@@ -12,7 +12,7 @@ tags:
     - attack.t1040
 logsource:
     product: windows
-    service: system
+    service: security
 detection:
     selection:
         EventID: 4697


### PR DESCRIPTION
There is no event id 4697 in channel "system" (at least in my logs), but in "security". The blog post from the references is working with channel "security" too.