### PR TITLE
Fixing Qradar implementation for creating valid AQL queries

### DIFF
--- a/tools/sigma/backends/qradar.py
+++ b/tools/sigma/backends/qradar.py
@@ -215,7 +215,6 @@ class QRadarBackend(SingleTextQueryBackend):
 
         except KeyError:    # no 'fields' attribute
             mapped = None
-            qradarPrefix+="UTF8(payload) as search_payload"
             pass
         qradarPrefix += " from %s where " % (aql_database)
 

--- a/tools/sigma/backends/qradar.py
+++ b/tools/sigma/backends/qradar.py
@@ -103,7 +103,11 @@ class QRadarBackend(SingleTextQueryBackend):
     def generateMapItemListNode(self, key, value):
         itemslist = list()
         for item in value:
-            if type(item) == str and "*" in item:
+            if item is None:
+                itemslist.append(self.nullExpression % (key))
+            elif type(item) == str and "ip" in key and ("/16" in item or "/24" in item):
+                itemslist.append("INCIDR(%s, %s)" % (self.generateValueNode(item, True), self.cleanKey(key)))
+            elif type(item) == str and "*" in item:
                 item = item.replace("*", "%")
                 itemslist.append('%s ilike %s' % (self.cleanKey(key), self.generateValueNode(item, True)))
             else:
@@ -197,14 +201,18 @@ class QRadarBackend(SingleTextQueryBackend):
             aql_database = "flows"
         else:
             aql_database = "events"
-        
-        qradarPrefix="SELECT "
+
+        qradarPrefix="SELECT UTF8(payload) as search_payload"
         try:
             mappedFields = []
             for field in sigmaparser.parsedyaml["fields"]:
                     mapped = sigmaparser.config.get_fieldmapping(field).resolve_fieldname(field, sigmaparser)
                     mappedFields.append(mapped)
-            qradarPrefix += str(mappedFields).strip('[]')
+                    if " " in mapped and not "(" in mapped:
+                        qradarPrefix += ", \"" + mapped + "\""
+                    else:
+                        qradarPrefix +=  ", " + mapped
+
         except KeyError:    # no 'fields' attribute
             mapped = None
             qradarPrefix+="UTF8(payload) as search_payload"


### PR DESCRIPTION
Hi there,

I've extended the Qradar implementation.
Fixes:
- Search queries have to use double quotes instead of single quotes (fixes issue #787). Queries look like the sample below:
```
SELECT UTF8(payload) AS search_payload,
       sourceip,
       EventID,
       "Parent Process Path",
       "Process Name",
       "Process CommandLine",
       "SHA256 Hash",
       username
FROM EVENTS
```
- Null compares are now possible.
```
         username:
            - null
```
will generate to:
```
username IS NULL
```
- The optimized INCIDR() use is now possible for /24 and /16 networks with a selection syntax as follows ('10.141.*' doesn't work):
```
        src_ip:
            - '10.141.0.0/16'
```
will output to:
```
INCIDR('10.141.0.0/16', sourceip))
```

I know that it is far away from being perfect, but the previous version was even more incomplete.