### PR TITLE
fix: case in level

### DIFF
--- a/rules/cloud/aws_update_login_profile.yml
+++ b/rules/cloud/aws_update_login_profile.yml
@@ -23,7 +23,7 @@ fields:
     - errorMessage
 falsepositives:
     - Legit User Account Administration 
-level: High
+level: high
 tags:
     - attack.persistence
     - attack.t1098


### PR DESCRIPTION
Otherwise es-rule ends up with a null risk_score and invalid severity.